### PR TITLE
fix: graceful terminal process termination on tab close

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,14 @@ Built-in AI assistant panel with:
 - [x] Icon system with currentColor SVGs
 - [x] Status bar (cursor position, language, git branch)
 
+**Terminal Integration**
+- [x] PTY backend — shell sessions with bidirectional I/O and ANSI support
+- [x] xterm.js frontend — themed terminal with Firn Glacier colors
+- [x] Multiple terminal sessions — create, switch, close, rename, drag-to-reorder
+- [x] Graceful process termination — SIGHUP via PTY close with SIGKILL fallback
+
 ### Planned
 
-- [ ] Terminal emulation (xterm.js + PTY)
 - [ ] Workspace management (open folder, persistence, recent projects)
 - [ ] Run profile execution
 - [ ] LSP client integration
@@ -128,6 +133,7 @@ firn-ide/
 ├── app.go                      # Wails bindings
 ├── internal/
 │   ├── filesystem/             # File read/write/watch
+│   ├── terminal/               # PTY session management
 │   ├── watcher/                # FS event watcher
 │   └── process/                # Process management
 ├── frontend/

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,8 +21,8 @@ Firn IDE brings the focused, keyboard-first productivity of JetBrains IDEs to a 
 | Infrastructure | **COMPLETE** | #26-30 |
 | Milestone 1: Core File Operations | **COMPLETE** | #1-7 |
 | UI/UX Polish | **COMPLETE** | #33-34 |
-| **Milestone 2: Terminal Integration** | **NEXT** | #8-10 |
-| Milestone 3: Workspace Management | Not started | #11-13 |
+| **Milestone 2: Terminal Integration** | **COMPLETE** | #8-10 |
+| **Milestone 3: Workspace Management** | **NEXT** | #11-13 |
 | Milestone 4: Run Profiles | Not started | #14-16 |
 | Milestone 5: Language Server Protocol | Not started | #17-20 |
 | Milestone 6: Search | Not started | #21-23 |
@@ -61,21 +61,21 @@ Debounced autosave after ~1.5s idle, save on focus loss, Cmd+S support, error to
 
 ---
 
-## Milestone 2: Terminal Integration (NEXT)
+## Milestone 2: Terminal Integration (COMPLETE)
 
-### Issue #8: Terminal - PTY Backend
-- [ ] Create PTY session with shell (bash/zsh)
-- [ ] Bidirectional communication (stdin/stdout)
-- [ ] Handle terminal resize (SIGWINCH)
-- [ ] Support ANSI escape codes
-- [ ] Clean session termination
+### Issue #8: Terminal - PTY Backend ✅
+- [x] Create PTY session with shell (bash/zsh)
+- [x] Bidirectional communication (stdin/stdout)
+- [x] Handle terminal resize (SIGWINCH)
+- [x] Support ANSI escape codes
+- [x] Clean session termination
 
-### Issue #9: Terminal - xterm.js Integration
-- [ ] Install and configure xterm.js
-- [ ] Connect to backend PTY via Wails bindings
-- [ ] Render terminal output with ANSI colors
-- [ ] Send keyboard input to backend
-- [ ] Handle resize events, match Firn Glacier theme
+### Issue #9: Terminal - xterm.js Integration ✅
+- [x] Install and configure xterm.js
+- [x] Connect to backend PTY via Wails bindings
+- [x] Render terminal output with ANSI colors
+- [x] Send keyboard input to backend
+- [x] Handle resize events, match Firn Glacier theme
 
 ### Issue #10: Terminal - Multiple Sessions & Unified Tab Bar
 - [x] Unified single-row tab bar (Output/Problems/Terminal + session tabs)
@@ -85,7 +85,7 @@ Debounced autosave after ~1.5s idle, save on focus loss, Cmd+S support, error to
 - [x] Right-click context menu (Rename, Close Terminal)
 - [x] Fixed orange accent for bottom panel (`data-accent="orange"`)
 - [x] xterm.js theme: near-black bg, warm foreground, orange cursor
-- [ ] Kill process on tab close (backend: sends SIGHUP on CloseTerminal)
+- [x] Kill process on tab close (graceful SIGHUP via PTY close + SIGKILL fallback)
 
 ---
 

--- a/internal/terminal/session.go
+++ b/internal/terminal/session.go
@@ -1,6 +1,8 @@
 package terminal
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
@@ -51,7 +53,9 @@ func (s *Session) Write(data []byte) (int, error) { return s.pty.Write(data) }
 // causes the kernel to send SIGHUP to the shell process group. We wait
 // briefly for the process to exit, then force-kill as a fallback.
 func (s *Session) Close() error {
-	s.pty.Close()
+	if err := s.pty.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+		return fmt.Errorf("closing pty: %w", err)
+	}
 
 	done := make(chan error, 1)
 	go func() { done <- s.cmd.Wait() }()
@@ -60,7 +64,10 @@ func (s *Session) Close() error {
 	case <-done:
 	case <-time.After(3 * time.Second):
 		_ = s.cmd.Process.Kill()
-		<-done
+		select {
+		case <-done:
+		case <-time.After(1 * time.Second):
+		}
 	}
 
 	s.running = false

--- a/internal/terminal/session.go
+++ b/internal/terminal/session.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"time"
 
 	"github.com/creack/pty"
 )
@@ -46,17 +47,23 @@ func (s *Session) Read(buf []byte) (int, error) {
 // Write sends input to the shell.
 func (s *Session) Write(data []byte) (int, error) { return s.pty.Write(data) }
 
-// Close terminates the PTY and kills the process.
+// Close terminates the PTY session gracefully. Closing the PTY master fd
+// causes the kernel to send SIGHUP to the shell process group. We wait
+// briefly for the process to exit, then force-kill as a fallback.
 func (s *Session) Close() error {
-	err := s.pty.Close()
-	if err != nil {
-		return err
+	s.pty.Close()
+
+	done := make(chan error, 1)
+	go func() { done <- s.cmd.Wait() }()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		_ = s.cmd.Process.Kill()
+		<-done
 	}
 
-	_ = s.cmd.Process.Kill()
-	_ = s.cmd.Wait()
 	s.running = false
-
 	return nil
 }
 

--- a/internal/terminal/session_test.go
+++ b/internal/terminal/session_test.go
@@ -3,6 +3,7 @@ package terminal
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewSession(t *testing.T) {
@@ -41,5 +42,52 @@ func TestSessionWriteRead(t *testing.T) {
 	output := string(buf[:n])
 	if !strings.Contains(output, "hello") {
 		t.Fatalf("expected output to contain 'hello', got: %s", output)
+	}
+}
+
+func TestSessionCloseGraceful(t *testing.T) {
+	session, err := NewSession()
+	if err != nil {
+		t.Fatalf("NewSession() returned error: %v", err)
+	}
+
+	start := time.Now()
+	err = session.Close()
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Close() returned error: %v", err)
+	}
+	if session.running {
+		t.Fatal("expected running to be false after Close()")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("graceful Close() took too long: %v", elapsed)
+	}
+}
+
+func TestSessionCloseTerminatesStubbornProcess(t *testing.T) {
+	session, err := NewSession()
+	if err != nil {
+		t.Fatalf("NewSession() returned error: %v", err)
+	}
+
+	// Launch a process that traps SIGHUP and ignores it.
+	_, err = session.Write([]byte("trap '' HUP; sleep 300 &\n"))
+	if err != nil {
+		t.Fatalf("Write() returned error: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	start := time.Now()
+	err = session.Close()
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Close() returned error: %v", err)
+	}
+	// Should complete within the 3s SIGHUP timeout + 1s kill timeout.
+	if elapsed > 5*time.Second {
+		t.Fatalf("Close() with stubborn process took too long: %v", elapsed)
 	}
 }


### PR DESCRIPTION
## Summary

- Replace immediate `Process.Kill()` (SIGKILL) with graceful PTY close, which triggers the kernel to send SIGHUP to the shell process group
- Wait up to 3 seconds for the process to exit cleanly before falling back to SIGKILL
- Update README to reflect terminal integration as completed, add `internal/terminal/` to project structure
- Mark Milestone 2: Terminal Integration as COMPLETE in the roadmap (Issues #8, #9, #10 all done)

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/terminal/` -- all 9 tests pass
- [ ] Manual: open Firn IDE, create a terminal tab, run a long process, close the tab -- process should terminate gracefully

Generated with [Claude Code](https://claude.com/claude-code)