### PR TITLE
feat: add recent projects to workspace selector and welcome screen

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,12 +12,14 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { Toast } from './components/Toast';
 import { useAutosave } from './hooks/useAutosave';
 import { useWorkspacePersistence } from './hooks/useWorkspacePersistence';
+import { useRecentWorkspaces } from './hooks/useRecentWorkspaces';
 import { useRunProfilesLoader } from './hooks/useRunProfiles';
 import { useWorkspace } from './stores/ideStore';
 
 function App() {
   useAutosave();
   useWorkspacePersistence();
+  useRecentWorkspaces();
   const workspace = useWorkspace();
   useRunProfilesLoader(workspace?.path);
 

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -23,6 +23,7 @@ jest.mock('../../wailsjs/go/main/App', () => ({
   ConfirmBeforeCloseReady: jest.fn(() => Promise.resolve()),
   SaveWorkspaceState: jest.fn(() => Promise.resolve()),
   LoadWorkspaceState: jest.fn(() => Promise.resolve(null)),
+  ListRecentWorkspaces: jest.fn(() => Promise.resolve([])),
 }));
 
 jest.mock('../../wailsjs/runtime/runtime', () => ({

--- a/frontend/src/__tests__/Editor.test.tsx
+++ b/frontend/src/__tests__/Editor.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useIDEStore } from '../stores/ideStore';
+
+jest.mock('../../wailsjs/go/main/App', () => ({
+  OpenFolderDialog: jest.fn(),
+  ListRecentWorkspaces: jest.fn(() => Promise.resolve([])),
+}));
+
+const mockWindowSetTitle = jest.fn();
+jest.mock('../../wailsjs/runtime/runtime', () => ({
+  WindowSetTitle: mockWindowSetTitle,
+}));
+
+import { Editor } from '../components/Editor';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useIDEStore.setState({
+    workspace: null,
+    openFiles: [],
+    activeFileId: null,
+    recentWorkspaces: [],
+  });
+});
+
+describe('Editor Welcome Screen', () => {
+  it('should show keyboard shortcuts when no files are open', () => {
+    render(<Editor />);
+    expect(screen.getByText('Open File')).toBeInTheDocument();
+    expect(screen.getByText('Command Palette')).toBeInTheDocument();
+    expect(screen.getByText('Quick Search')).toBeInTheDocument();
+  });
+
+  it('should show recent projects section when recent workspaces exist', () => {
+    useIDEStore.setState({
+      recentWorkspaces: [
+        { name: 'project-a', path: '/Users/test/project-a', lastOpened: '2026-01-01T00:00:00Z' },
+        { name: 'project-b', path: '/Users/test/project-b', lastOpened: '2025-12-31T00:00:00Z' },
+      ],
+    });
+
+    render(<Editor />);
+    expect(screen.getByText('Recent Projects')).toBeInTheDocument();
+    expect(screen.getByText('project-a')).toBeInTheDocument();
+    expect(screen.getByText('project-b')).toBeInTheDocument();
+  });
+
+  it('should not show recent projects section when list is empty', () => {
+    render(<Editor />);
+    expect(screen.queryByText('Recent Projects')).not.toBeInTheDocument();
+  });
+
+  it('should filter out the current workspace from recent projects', () => {
+    useIDEStore.setState({
+      workspace: { name: 'current', path: '/Users/test/current' },
+      recentWorkspaces: [
+        { name: 'current', path: '/Users/test/current', lastOpened: '2026-01-02T00:00:00Z' },
+        { name: 'other', path: '/Users/test/other', lastOpened: '2026-01-01T00:00:00Z' },
+      ],
+    });
+
+    render(<Editor />);
+    expect(screen.getByText('other')).toBeInTheDocument();
+    // "current" should only appear once (in the store, not in the list)
+    const currentElements = screen.queryAllByText('current');
+    expect(currentElements).toHaveLength(0);
+  });
+
+  it('should open a workspace when a recent project is clicked', () => {
+    useIDEStore.setState({
+      recentWorkspaces: [
+        { name: 'my-project', path: '/Users/test/my-project', lastOpened: '2026-01-01T00:00:00Z' },
+      ],
+    });
+
+    render(<Editor />);
+
+    fireEvent.click(screen.getByText('my-project'));
+
+    const state = useIDEStore.getState();
+    expect(state.workspace).toEqual({
+      name: 'my-project',
+      path: '/Users/test/my-project',
+    });
+    expect(mockWindowSetTitle).toHaveBeenCalledWith('my-project \u2014 Firn');
+  });
+
+  it('should shorten displayed paths with ~ for home directories', () => {
+    useIDEStore.setState({
+      recentWorkspaces: [
+        {
+          name: 'my-project',
+          path: '/Users/testuser/projects/my-project',
+          lastOpened: '2026-01-01T00:00:00Z',
+        },
+      ],
+    });
+
+    render(<Editor />);
+    expect(screen.getByText('~/projects/my-project')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/Header.test.tsx
+++ b/frontend/src/__tests__/Header.test.tsx
@@ -10,6 +10,7 @@ import { useIDEStore } from '../stores/ideStore';
 
 jest.mock('../../wailsjs/go/main/App', () => ({
   OpenFolderDialog: jest.fn(),
+  ListRecentWorkspaces: jest.fn(() => Promise.resolve([])),
 }));
 
 jest.mock('../../wailsjs/runtime/runtime', () => ({
@@ -24,6 +25,7 @@ describe('Header Component', () => {
     jest.clearAllMocks();
     useIDEStore.setState({
       workspace: null,
+      recentWorkspaces: [],
     });
   });
 
@@ -56,13 +58,16 @@ describe('Header Component', () => {
     expect(screen.getByText('my-project')).toBeInTheDocument();
   });
 
-  it('should call OpenFolderDialog when workspace button is clicked', async () => {
+  it('should call OpenFolderDialog when Open Folder menu item is clicked', async () => {
     (OpenFolderDialog as jest.Mock).mockResolvedValue('/Users/test/project');
 
     render(<Header />);
 
-    const workspaceBtn = screen.getByRole('button', { name: /open folder/i });
-    fireEvent.click(workspaceBtn);
+    // Open the workspace dropdown menu
+    fireEvent.click(screen.getByRole('button', { name: /workspace menu/i }));
+
+    // Click "Open Folder..." in the dropdown
+    fireEvent.click(screen.getByText('Open Folder...'));
 
     await waitFor(() => {
       expect(OpenFolderDialog).toHaveBeenCalled();
@@ -74,7 +79,11 @@ describe('Header Component', () => {
 
     render(<Header />);
 
-    fireEvent.click(screen.getByRole('button', { name: /open folder/i }));
+    // Open the workspace dropdown menu
+    fireEvent.click(screen.getByRole('button', { name: /workspace menu/i }));
+
+    // Click "Open Folder..." in the dropdown
+    fireEvent.click(screen.getByText('Open Folder...'));
 
     await waitFor(() => {
       const state = useIDEStore.getState();
@@ -82,7 +91,30 @@ describe('Header Component', () => {
         name: 'my-app',
         path: '/Users/test/my-app',
       });
-      expect(WindowSetTitle).toHaveBeenCalledWith('my-app — Firn');
+      expect(WindowSetTitle).toHaveBeenCalledWith('my-app \u2014 Firn');
     });
+  });
+
+  it('should show recent projects in the dropdown menu', () => {
+    useIDEStore.setState({
+      workspace: { name: 'current', path: '/Users/test/current' },
+      recentWorkspaces: [
+        { name: 'current', path: '/Users/test/current', lastOpened: '2026-01-01T00:00:00Z' },
+        {
+          name: 'other-project',
+          path: '/Users/test/other-project',
+          lastOpened: '2025-12-31T00:00:00Z',
+        },
+      ],
+    });
+
+    render(<Header />);
+
+    // Open the workspace dropdown menu
+    fireEvent.click(screen.getByRole('button', { name: /workspace menu/i }));
+
+    // Current workspace should be filtered out, only "other-project" should appear
+    expect(screen.getByText('other-project')).toBeInTheDocument();
+    expect(screen.getByText('Recent Projects')).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/hooks/useOpenFolder.test.ts
+++ b/frontend/src/__tests__/hooks/useOpenFolder.test.ts
@@ -14,6 +14,7 @@ jest.mock('../../../wailsjs/runtime/runtime', () => ({
 }));
 
 import { useOpenFolder, _resetOpeningLock } from '../../hooks/useOpenFolder';
+import { openWorkspaceByPath } from '../../utils/workspace';
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -24,6 +25,7 @@ beforeEach(() => {
     isLoadingTree: false,
     treeError: null,
     toast: null,
+    recentWorkspaces: [],
   });
 });
 
@@ -153,5 +155,79 @@ describe('useOpenFolder', () => {
       path: 'C:\\Users\\test\\my-project',
     });
     expect(mockWindowSetTitle).toHaveBeenCalledWith('my-project — Firn');
+  });
+});
+
+describe('openWorkspaceByPath', () => {
+  it('should set workspace state and update window title', () => {
+    openWorkspaceByPath('/Users/test/my-app');
+
+    const state = useIDEStore.getState();
+    expect(state.workspace).toEqual({
+      name: 'my-app',
+      path: '/Users/test/my-app',
+    });
+    expect(mockWindowSetTitle).toHaveBeenCalledWith('my-app — Firn');
+  });
+
+  it('should clear stale directory tree and set loading', () => {
+    useIDEStore.setState({
+      directoryTree: [{ name: 'old.ts' }] as unknown as filesystem.FileEntry[],
+      isLoadingTree: false,
+    });
+
+    openWorkspaceByPath('/Users/test/new-project');
+
+    const state = useIDEStore.getState();
+    expect(state.directoryTree).toEqual([]);
+    expect(state.workspace?.name).toBe('new-project');
+  });
+
+  it('should handle Windows paths', () => {
+    openWorkspaceByPath('C:\\Users\\test\\win-project');
+
+    const state = useIDEStore.getState();
+    expect(state.workspace).toEqual({
+      name: 'win-project',
+      path: 'C:\\Users\\test\\win-project',
+    });
+    expect(mockWindowSetTitle).toHaveBeenCalledWith('win-project — Firn');
+  });
+
+  it('should ignore empty paths', () => {
+    openWorkspaceByPath('');
+    expect(useIDEStore.getState().workspace).toBeNull();
+    expect(mockWindowSetTitle).not.toHaveBeenCalled();
+
+    openWorkspaceByPath('   ');
+    expect(useIDEStore.getState().workspace).toBeNull();
+    expect(mockWindowSetTitle).not.toHaveBeenCalled();
+  });
+
+  it('should skip if already on the same workspace', () => {
+    useIDEStore.setState({
+      workspace: { name: 'my-app', path: '/Users/test/my-app' },
+    });
+
+    openWorkspaceByPath('/Users/test/my-app');
+
+    // WindowSetTitle should not be called again
+    expect(mockWindowSetTitle).not.toHaveBeenCalled();
+  });
+
+  it('should optimistically update the recent workspaces list', () => {
+    useIDEStore.setState({
+      recentWorkspaces: [
+        { name: 'old-project', path: '/projects/old', lastOpened: '2025-01-01T00:00:00Z' },
+      ],
+    });
+
+    openWorkspaceByPath('/Users/test/new-project');
+
+    const { recentWorkspaces } = useIDEStore.getState();
+    expect(recentWorkspaces).toHaveLength(2);
+    expect(recentWorkspaces[0].name).toBe('new-project');
+    expect(recentWorkspaces[0].path).toBe('/Users/test/new-project');
+    expect(recentWorkspaces[1].name).toBe('old-project');
   });
 });

--- a/frontend/src/__tests__/hooks/useRecentWorkspaces.test.ts
+++ b/frontend/src/__tests__/hooks/useRecentWorkspaces.test.ts
@@ -73,7 +73,7 @@ describe('useRecentWorkspaces', () => {
     warnSpy.mockRestore();
   });
 
-  it('should refresh when workspace path changes', async () => {
+  it('should NOT refetch when workspace path changes (optimistic updates handle in-session ordering)', async () => {
     mockListRecentWorkspaces.mockResolvedValue([
       { name: 'project-a', path: '/projects/a', lastOpened: '2026-01-01T00:00:00Z' },
     ]);
@@ -84,21 +84,16 @@ describe('useRecentWorkspaces', () => {
       expect(useIDEStore.getState().recentWorkspaces).toHaveLength(1);
     });
 
-    // Change workspace
-    mockListRecentWorkspaces.mockResolvedValue([
-      { name: 'project-a', path: '/projects/a', lastOpened: '2026-01-02T00:00:00Z' },
-      { name: 'project-b', path: '/projects/b', lastOpened: '2026-01-01T00:00:00Z' },
-    ]);
+    // Simulate workspace switch — the hook should NOT refetch because the
+    // backend hasn't persisted the new LastOpened yet. Refetching here would
+    // overwrite the optimistic update from openWorkspaceByPath with stale data.
     useIDEStore.setState({
       workspace: { name: 'project-b', path: '/projects/b' },
     });
 
     rerender();
 
-    await waitFor(() => {
-      expect(useIDEStore.getState().recentWorkspaces).toHaveLength(2);
-    });
-
-    expect(mockListRecentWorkspaces).toHaveBeenCalledTimes(2);
+    // Only the initial mount fetch should have occurred
+    expect(mockListRecentWorkspaces).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/__tests__/hooks/useRecentWorkspaces.test.ts
+++ b/frontend/src/__tests__/hooks/useRecentWorkspaces.test.ts
@@ -1,0 +1,104 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useIDEStore } from '../../stores/ideStore';
+
+const mockListRecentWorkspaces = jest.fn();
+
+jest.mock('../../../wailsjs/go/main/App', () => ({
+  ListRecentWorkspaces: mockListRecentWorkspaces,
+}));
+
+import { useRecentWorkspaces } from '../../hooks/useRecentWorkspaces';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useIDEStore.setState({
+    workspace: null,
+    recentWorkspaces: [],
+  });
+});
+
+describe('useRecentWorkspaces', () => {
+  it('should fetch recent workspaces on mount', async () => {
+    mockListRecentWorkspaces.mockResolvedValue([
+      { name: 'project-a', path: '/projects/a', lastOpened: '2026-01-02T00:00:00Z' },
+      { name: 'project-b', path: '/projects/b', lastOpened: '2026-01-01T00:00:00Z' },
+    ]);
+
+    renderHook(() => useRecentWorkspaces());
+
+    await waitFor(() => {
+      const state = useIDEStore.getState();
+      expect(state.recentWorkspaces).toHaveLength(2);
+      expect(state.recentWorkspaces[0].name).toBe('project-a');
+    });
+  });
+
+  it('should limit to 10 recent workspaces', async () => {
+    const many = Array.from({ length: 15 }, (_, i) => ({
+      name: `project-${i}`,
+      path: `/projects/${i}`,
+      lastOpened: `2026-01-${String(15 - i).padStart(2, '0')}T00:00:00Z`,
+    }));
+    mockListRecentWorkspaces.mockResolvedValue(many);
+
+    renderHook(() => useRecentWorkspaces());
+
+    await waitFor(() => {
+      expect(useIDEStore.getState().recentWorkspaces).toHaveLength(10);
+    });
+  });
+
+  it('should handle null response from backend', async () => {
+    mockListRecentWorkspaces.mockResolvedValue(null);
+
+    renderHook(() => useRecentWorkspaces());
+
+    await waitFor(() => {
+      expect(useIDEStore.getState().recentWorkspaces).toEqual([]);
+    });
+  });
+
+  it('should handle backend errors gracefully', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockListRecentWorkspaces.mockRejectedValue(new Error('disk read error'));
+
+    renderHook(() => useRecentWorkspaces());
+
+    await waitFor(() => {
+      expect(warnSpy).toHaveBeenCalledWith('Failed to load recent workspaces:', expect.any(Error));
+    });
+
+    // Store should remain empty (not corrupted)
+    expect(useIDEStore.getState().recentWorkspaces).toEqual([]);
+    warnSpy.mockRestore();
+  });
+
+  it('should refresh when workspace path changes', async () => {
+    mockListRecentWorkspaces.mockResolvedValue([
+      { name: 'project-a', path: '/projects/a', lastOpened: '2026-01-01T00:00:00Z' },
+    ]);
+
+    const { rerender } = renderHook(() => useRecentWorkspaces());
+
+    await waitFor(() => {
+      expect(useIDEStore.getState().recentWorkspaces).toHaveLength(1);
+    });
+
+    // Change workspace
+    mockListRecentWorkspaces.mockResolvedValue([
+      { name: 'project-a', path: '/projects/a', lastOpened: '2026-01-02T00:00:00Z' },
+      { name: 'project-b', path: '/projects/b', lastOpened: '2026-01-01T00:00:00Z' },
+    ]);
+    useIDEStore.setState({
+      workspace: { name: 'project-b', path: '/projects/b' },
+    });
+
+    rerender();
+
+    await waitFor(() => {
+      expect(useIDEStore.getState().recentWorkspaces).toHaveLength(2);
+    });
+
+    expect(mockListRecentWorkspaces).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/__tests__/utils/workspace.test.ts
+++ b/frontend/src/__tests__/utils/workspace.test.ts
@@ -1,0 +1,38 @@
+jest.mock('../../../wailsjs/runtime/runtime', () => ({
+  WindowSetTitle: jest.fn(),
+}));
+
+import { shortenPath } from '../../utils/workspace';
+
+describe('shortenPath', () => {
+  it('should shorten /Users/<name>/... paths', () => {
+    expect(shortenPath('/Users/alice/projects/my-app')).toBe('~/projects/my-app');
+  });
+
+  it('should shorten /home/<name>/... paths', () => {
+    expect(shortenPath('/home/alice/projects/my-app')).toBe('~/projects/my-app');
+  });
+
+  it('should shorten Windows C:\\Users\\<name>\\... paths', () => {
+    expect(shortenPath('C:\\Users\\alice\\projects\\my-app')).toBe('~\\projects\\my-app');
+  });
+
+  it('should return ~ for paths exactly at the home directory level', () => {
+    expect(shortenPath('/Users/alice/my-project')).toBe('~/my-project');
+    expect(shortenPath('/home/alice/my-project')).toBe('~/my-project');
+  });
+
+  it('should return ~ when path is just the home directory', () => {
+    expect(shortenPath('/Users/alice')).toBe('~');
+    expect(shortenPath('/home/alice')).toBe('~');
+  });
+
+  it('should return non-home paths unchanged', () => {
+    expect(shortenPath('/var/data/project')).toBe('/var/data/project');
+    expect(shortenPath('/opt/workspace')).toBe('/opt/workspace');
+  });
+
+  it('should handle empty/falsy input', () => {
+    expect(shortenPath('')).toBe('');
+  });
+});

--- a/frontend/src/components/Editor/Editor.module.css
+++ b/frontend/src/components/Editor/Editor.module.css
@@ -212,3 +212,89 @@
   color: var(--text-primary);
   letter-spacing: 1px;
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   Recent Projects (Welcome Screen)
+═══════════════════════════════════════════════════════════════ */
+
+.recentProjects {
+  margin-top: 36px;
+  width: 100%;
+  max-width: 360px;
+  text-align: left;
+}
+
+.recentTitle {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin-bottom: 10px;
+  padding-left: 8px;
+}
+
+.recentList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.recentItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all var(--transition);
+  text-align: left;
+}
+
+.recentItem:hover {
+  background: var(--surface-hover);
+  border-color: var(--surface-border-subtle);
+}
+
+.recentItem:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.recentIcon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  color: var(--accent);
+  opacity: 0.7;
+}
+
+.recentItemText {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.recentName {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.recentPath {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/frontend/src/components/Editor/Editor.tsx
+++ b/frontend/src/components/Editor/Editor.tsx
@@ -7,9 +7,17 @@
 
 import { useCallback } from 'react';
 import styles from './Editor.module.css';
-import { useOpenFiles, useActiveFile, useIDEStore } from '../../stores/ideStore';
+import {
+  useOpenFiles,
+  useActiveFile,
+  useIDEStore,
+  useRecentWorkspaces,
+  useWorkspace,
+} from '../../stores/ideStore';
 import { FileIcon } from '../FileExplorer/FileIcon';
+import { FolderOutlineIcon } from '../icons';
 import { formatShortcut } from '../../utils/platform';
+import { openWorkspaceByPath, shortenPath } from '../../utils/workspace';
 import { CodeMirrorEditor } from './CodeMirrorEditor';
 import { getLanguageName } from './codemirror';
 import firnLogo from '../../assets/branding/banner-transparent.svg';
@@ -17,6 +25,8 @@ import firnLogo from '../../assets/branding/banner-transparent.svg';
 export function Editor() {
   const openFiles = useOpenFiles();
   const activeFile = useActiveFile();
+  const workspace = useWorkspace();
+  const recentWorkspaces = useRecentWorkspaces();
   const setActiveFile = useIDEStore((state) => state.setActiveFile);
   const closeFile = useIDEStore((state) => state.closeFile);
   const updateFileContent = useIDEStore((state) => state.updateFileContent);
@@ -57,6 +67,9 @@ export function Editor() {
 
   // Welcome screen when no files are open
   if (openFiles.length === 0) {
+    // Filter out the currently open workspace from recent list
+    const recentProjects = recentWorkspaces.filter((w) => w.path !== workspace?.path);
+
     return (
       <div className={styles.editor}>
         <div className={styles.welcome}>
@@ -64,17 +77,39 @@ export function Editor() {
           <div className={styles.shortcuts}>
             <div className={styles.shortcutItem}>
               <span className={styles.shortcutLabel}>Open File</span>
-              <kbd>{formatShortcut('⌘O')}</kbd>
+              <kbd>{formatShortcut('\u2318O')}</kbd>
             </div>
             <div className={styles.shortcutItem}>
               <span className={styles.shortcutLabel}>Command Palette</span>
-              <kbd>{formatShortcut('⌘⇧P')}</kbd>
+              <kbd>{formatShortcut('\u2318\u21e7P')}</kbd>
             </div>
             <div className={styles.shortcutItem}>
               <span className={styles.shortcutLabel}>Quick Search</span>
-              <kbd>{formatShortcut('⌘K')}</kbd>
+              <kbd>{formatShortcut('\u2318K')}</kbd>
             </div>
           </div>
+          {recentProjects.length > 0 && (
+            <div className={styles.recentProjects}>
+              <h3 className={styles.recentTitle}>Recent Projects</h3>
+              <ul className={styles.recentList}>
+                {recentProjects.map((project) => (
+                  <li key={project.path}>
+                    <button
+                      className={styles.recentItem}
+                      onClick={() => openWorkspaceByPath(project.path)}
+                      title={project.path}
+                    >
+                      <FolderOutlineIcon className={styles.recentIcon} aria-hidden="true" />
+                      <div className={styles.recentItemText}>
+                        <span className={styles.recentName}>{project.name}</span>
+                        <span className={styles.recentPath}>{shortenPath(project.path)}</span>
+                      </div>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       </div>
     );

--- a/frontend/src/components/Header/Header.module.css
+++ b/frontend/src/components/Header/Header.module.css
@@ -74,6 +74,10 @@
 }
 
 /* Workspace Selector */
+.workspaceWrapper {
+  position: relative;
+}
+
 .workspaceBtn {
   display: flex;
   align-items: center;
@@ -126,6 +130,87 @@
   border-radius: 4px;
   color: var(--text-muted);
   letter-spacing: 0.5px;
+}
+
+/* Workspace Dropdown Menu */
+.workspaceMenu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 240px;
+  max-width: 320px;
+  max-height: 360px;
+  overflow-y: auto;
+  background: var(--surface-panel);
+  border: 1px solid var(--surface-border);
+  border-radius: 8px;
+  padding: 4px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  z-index: 100;
+}
+
+.menuItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 10px;
+  background: transparent;
+  border: none;
+  border-radius: 5px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition);
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.menuItem:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.menuItem:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.menuItemName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.menuIcon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+.menuShortcut {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-disabled);
+  letter-spacing: 0.5px;
+  flex-shrink: 0;
+}
+
+.menuDivider {
+  height: 1px;
+  background: var(--surface-border-subtle);
+  margin: 4px 6px;
+}
+
+.menuLabel {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  padding: 6px 10px 4px;
 }
 
 /* Spacer */

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,14 +1,121 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
 import styles from './Header.module.css';
-import { ChevronDownIcon, SearchIcon } from '../icons';
-import { useWorkspace } from '../../stores/ideStore';
+import { ChevronDownIcon, SearchIcon, FolderOutlineIcon, FolderOpenOutlineIcon } from '../icons';
+import { useWorkspace, useRecentWorkspaces } from '../../stores/ideStore';
 import { useOpenFolder } from '../../hooks/useOpenFolder';
+import { openWorkspaceByPath } from '../../utils/workspace';
 import { formatShortcut, isMac } from '../../utils/platform';
 import firnIcon from '../../assets/branding/icon.svg';
+
+const MENU_ID = 'workspace-menu';
 
 export function Header() {
   const workspace = useWorkspace();
   const workspaceName = workspace?.name || 'No workspace';
   const { openFolder } = useOpenFolder();
+  const recentWorkspaces = useRecentWorkspaces();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  // Filter out current workspace from recent list
+  const recentProjects = recentWorkspaces.filter((w) => w.path !== workspace?.path);
+
+  const toggleMenu = useCallback(() => {
+    setIsMenuOpen((prev) => !prev);
+  }, []);
+
+  const handleOpenFolder = useCallback(() => {
+    setIsMenuOpen(false);
+    openFolder();
+  }, [openFolder]);
+
+  const handleOpenRecent = useCallback((path: string) => {
+    setIsMenuOpen(false);
+    openWorkspaceByPath(path);
+  }, []);
+
+  // Keyboard support on the trigger button
+  const handleButtonKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (e.key === 'ArrowDown' && !isMenuOpen) {
+        e.preventDefault();
+        setIsMenuOpen(true);
+      }
+    },
+    [isMenuOpen]
+  );
+
+  // Arrow key / Home / End navigation within the menu
+  const handleMenuKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    const items = menuRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]');
+    if (!items?.length) return;
+
+    const currentIndex = Array.from(items).findIndex((el) => el === document.activeElement);
+    let nextIndex: number | null = null;
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        nextIndex = currentIndex < items.length - 1 ? currentIndex + 1 : 0;
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        nextIndex = currentIndex > 0 ? currentIndex - 1 : items.length - 1;
+        break;
+      case 'Home':
+        e.preventDefault();
+        nextIndex = 0;
+        break;
+      case 'End':
+        e.preventDefault();
+        nextIndex = items.length - 1;
+        break;
+    }
+
+    if (nextIndex !== null) {
+      items[nextIndex].focus();
+    }
+  }, []);
+
+  // Auto-focus first menu item when opened
+  useEffect(() => {
+    if (isMenuOpen) {
+      requestAnimationFrame(() => {
+        menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]')?.focus();
+      });
+    }
+  }, [isMenuOpen]);
+
+  // Close menu on outside click or Escape
+  useEffect(() => {
+    if (!isMenuOpen) return;
+
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(e.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(e.target as Node)
+      ) {
+        setIsMenuOpen(false);
+      }
+    }
+
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setIsMenuOpen(false);
+        buttonRef.current?.focus();
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isMenuOpen]);
 
   return (
     <>
@@ -21,18 +128,71 @@ export function Header() {
         <span className={styles.logoText}>Firn</span>
       </div>
 
-      {/* Workspace selector */}
-      <button className={styles.workspaceBtn} onClick={openFolder} aria-label="Open folder">
-        <span className={styles.workspaceDot} aria-hidden="true" />
-        <span className={styles.workspaceName}>{workspaceName}</span>
-        <ChevronDownIcon className={styles.chevron} aria-hidden="true" />
-      </button>
+      {/* Workspace selector with dropdown */}
+      <div className={styles.workspaceWrapper}>
+        <button
+          ref={buttonRef}
+          className={styles.workspaceBtn}
+          onClick={toggleMenu}
+          onKeyDown={handleButtonKeyDown}
+          aria-label="Workspace menu"
+          aria-expanded={isMenuOpen}
+          aria-haspopup="menu"
+          aria-controls={isMenuOpen ? MENU_ID : undefined}
+        >
+          <span className={styles.workspaceDot} aria-hidden="true" />
+          <span className={styles.workspaceName}>{workspaceName}</span>
+          <ChevronDownIcon className={styles.chevron} aria-hidden="true" />
+        </button>
+
+        {isMenuOpen && (
+          <div
+            ref={menuRef}
+            id={MENU_ID}
+            className={styles.workspaceMenu}
+            role="menu"
+            aria-label="Workspace"
+            onKeyDown={handleMenuKeyDown}
+          >
+            <button
+              className={styles.menuItem}
+              onClick={handleOpenFolder}
+              role="menuitem"
+              tabIndex={-1}
+            >
+              <FolderOpenOutlineIcon className={styles.menuIcon} aria-hidden="true" />
+              <span>Open Folder...</span>
+              <span className={styles.menuShortcut}>{formatShortcut('\u2318O')}</span>
+            </button>
+
+            {recentProjects.length > 0 && (
+              <>
+                <div className={styles.menuDivider} role="separator" />
+                <div className={styles.menuLabel}>Recent Projects</div>
+                {recentProjects.map((project) => (
+                  <button
+                    key={project.path}
+                    className={styles.menuItem}
+                    onClick={() => handleOpenRecent(project.path)}
+                    role="menuitem"
+                    tabIndex={-1}
+                    title={project.path}
+                  >
+                    <FolderOutlineIcon className={styles.menuIcon} aria-hidden="true" />
+                    <span className={styles.menuItemName}>{project.name}</span>
+                  </button>
+                ))}
+              </>
+            )}
+          </div>
+        )}
+      </div>
 
       {/* Search */}
       <button className={`${styles.headerBtn} ${styles.searchBtn}`} aria-label="Search everywhere">
         <SearchIcon aria-hidden="true" />
         <span>Search Everywhere</span>
-        <span className={styles.searchShortcut}>{formatShortcut('⇧⌘P')}</span>
+        <span className={styles.searchShortcut}>{formatShortcut('\u21e7\u2318P')}</span>
       </button>
 
       {/* Spacer */}

--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -178,6 +178,23 @@ export function FolderOpenIcon(props: IconProps) {
   );
 }
 
+export function FolderOutlineIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" {...props}>
+      <path d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+    </svg>
+  );
+}
+
+export function FolderOpenOutlineIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" {...props}>
+      <path d="M5 19h14a2 2 0 002-2v-7a2 2 0 00-2-2h-4l-2-2H5a2 2 0 00-2 2v9a2 2 0 002 2z" />
+      <path d="M15 13l-3 3m0 0l-3-3m3 3V8" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
 export function ImageIcon(props: IconProps) {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>

--- a/frontend/src/hooks/useOpenFolder.ts
+++ b/frontend/src/hooks/useOpenFolder.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useIDEStore } from '../stores/ideStore';
 import { OpenFolderDialog } from '../../wailsjs/go/main/App';
-import { WindowSetTitle } from '../../wailsjs/runtime/runtime';
+import { openWorkspaceByPath } from '../utils/workspace';
 
 // Module-level lock shared across all hook instances (Header, FileExplorer,
 // useKeyboardShortcuts) so concurrent triggers from different entry points
@@ -19,10 +19,6 @@ let isOpening = false;
  * keyboard shortcuts. Use `useKeyboardShortcuts` once at the app level for that.
  */
 export function useOpenFolder() {
-  const setWorkspace = useIDEStore((state) => state.setWorkspace);
-  const setTreeLoading = useIDEStore((state) => state.setTreeLoading);
-  const setDirectoryTree = useIDEStore((state) => state.setDirectoryTree);
-
   const openFolder = useCallback(async () => {
     // Guard against concurrent invocations (e.g., rapid double-click)
     if (isOpening) return;
@@ -34,20 +30,7 @@ export function useOpenFolder() {
       // User cancelled
       if (!folderPath) return;
 
-      // Extract folder name from path
-      const separator = folderPath.includes('\\') ? '\\' : '/';
-      const folderName = folderPath.split(separator).pop() || folderPath;
-
-      // Clear stale tree and mark loading *before* setting workspace so the
-      // UI never briefly shows old files under the new workspace name.
-      setDirectoryTree([]);
-      setTreeLoading(true);
-
-      // Set workspace — this triggers useDirectoryTree to fetch the tree
-      setWorkspace({ name: folderName, path: folderPath });
-
-      // Update window title
-      WindowSetTitle(`${folderName} — Firn`);
+      openWorkspaceByPath(folderPath);
     } catch (err) {
       console.error('Failed to open folder:', err);
       useIDEStore
@@ -59,7 +42,7 @@ export function useOpenFolder() {
     } finally {
       isOpening = false;
     }
-  }, [setWorkspace, setTreeLoading, setDirectoryTree]);
+  }, []);
 
   return { openFolder };
 }

--- a/frontend/src/hooks/useRecentWorkspaces.ts
+++ b/frontend/src/hooks/useRecentWorkspaces.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { useIDEStore } from '../stores/ideStore';
+import { ListRecentWorkspaces } from '../../wailsjs/go/main/App';
+
+const MAX_RECENT = 10;
+
+/**
+ * Fetches recent workspaces from the backend on mount and whenever the
+ * active workspace changes (since opening a workspace updates lastOpened).
+ */
+export function useRecentWorkspaces() {
+  const workspacePath = useIDEStore((state) => state.workspace?.path);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const all = await ListRecentWorkspaces();
+        if (cancelled) return;
+        const limited = (all ?? []).slice(0, MAX_RECENT);
+        useIDEStore.getState().setRecentWorkspaces(limited);
+      } catch (err) {
+        console.warn('Failed to load recent workspaces:', err);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [workspacePath]);
+}

--- a/frontend/src/hooks/useRecentWorkspaces.ts
+++ b/frontend/src/hooks/useRecentWorkspaces.ts
@@ -5,12 +5,15 @@ import { ListRecentWorkspaces } from '../../wailsjs/go/main/App';
 const MAX_RECENT = 10;
 
 /**
- * Fetches recent workspaces from the backend on mount and whenever the
- * active workspace changes (since opening a workspace updates lastOpened).
+ * Fetches recent workspaces from the backend on mount.
+ *
+ * In-session workspace switches are handled by the optimistic update in
+ * `openWorkspaceByPath`, so we intentionally do NOT refetch when
+ * `workspace.path` changes — the backend only persists `LastOpened`
+ * during `SaveWorkspaceState` (autosave / blur / close), so an
+ * immediate refetch would overwrite the optimistic state with stale data.
  */
 export function useRecentWorkspaces() {
-  const workspacePath = useIDEStore((state) => state.workspace?.path);
-
   useEffect(() => {
     let cancelled = false;
 
@@ -29,5 +32,5 @@ export function useRecentWorkspaces() {
     return () => {
       cancelled = true;
     };
-  }, [workspacePath]);
+  }, []);
 }

--- a/frontend/src/stores/ideStore.ts
+++ b/frontend/src/stores/ideStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { useShallow } from 'zustand/react/shallow';
-import type { filesystem } from '../../wailsjs/go/models';
+import type { filesystem, workspace } from '../../wailsjs/go/models';
 import type { RunProfile } from '../types/runProfile';
 
 // Types
@@ -105,6 +105,9 @@ interface IDEState {
   // Workspace persistence
   isRestoringWorkspace: boolean;
 
+  // Recent workspaces
+  recentWorkspaces: workspace.Summary[];
+
   // Status
   gitBranch: string;
   errorCount: number;
@@ -169,6 +172,9 @@ interface IDEActions {
   setRestoringWorkspace: (restoring: boolean) => void;
   resetWorkspaceSession: () => void;
 
+  // Recent workspaces actions
+  setRecentWorkspaces: (workspaces: workspace.Summary[]) => void;
+
   // Status actions
   setGitBranch: (branch: string) => void;
   setDiagnostics: (errors: number, warnings: number) => void;
@@ -195,6 +201,7 @@ export const useIDEStore = create<IDEStore>()(
       isLoadingProfiles: false,
       profilesError: null,
       isRestoringWorkspace: false,
+      recentWorkspaces: [],
       gitBranch: '',
       errorCount: 0,
       warningCount: 0,
@@ -464,6 +471,10 @@ export const useIDEStore = create<IDEStore>()(
       resetWorkspaceSession: () =>
         set(createDefaultWorkspaceSessionState(), false, 'resetWorkspaceSession'),
 
+      // Recent workspaces actions
+      setRecentWorkspaces: (recentWorkspaces) =>
+        set({ recentWorkspaces }, false, 'setRecentWorkspaces'),
+
       // Status actions
       setGitBranch: (gitBranch) => set({ gitBranch }, false, 'setGitBranch'),
 
@@ -516,3 +527,4 @@ export const useSavedProfiles = () =>
   useIDEStore(useShallow((state) => state.runProfiles.filter((p) => p.source === 'user')));
 export const useIsLoadingProfiles = () => useIDEStore((state) => state.isLoadingProfiles);
 export const useProfilesError = () => useIDEStore((state) => state.profilesError);
+export const useRecentWorkspaces = () => useIDEStore((state) => state.recentWorkspaces);

--- a/frontend/src/utils/workspace.ts
+++ b/frontend/src/utils/workspace.ts
@@ -1,0 +1,78 @@
+import { useIDEStore } from '../stores/ideStore';
+import { WindowSetTitle } from '../../wailsjs/runtime/runtime';
+
+const MAX_RECENT = 10;
+
+/**
+ * Opens a workspace by its absolute path. Handles clearing stale tree,
+ * setting workspace state, updating the window title, and optimistically
+ * updating the recent workspaces list.
+ *
+ * Shared by both the native dialog flow and recent-project clicks.
+ */
+export function openWorkspaceByPath(folderPath: string) {
+  if (!folderPath || !folderPath.trim()) {
+    return;
+  }
+
+  const store = useIDEStore.getState();
+
+  // Skip if already on this workspace
+  if (store.workspace?.path === folderPath) return;
+
+  const separator = folderPath.includes('\\') ? '\\' : '/';
+  const folderName = folderPath.split(separator).pop() || folderPath;
+
+  try {
+    // Clear stale tree and mark loading *before* setting workspace so the
+    // UI never briefly shows old files under the new workspace name.
+    store.setDirectoryTree([]);
+    store.setTreeLoading(true);
+
+    // Set workspace — this triggers useDirectoryTree to fetch the tree
+    store.setWorkspace({ name: folderName, path: folderPath });
+
+    // Update window title
+    WindowSetTitle(`${folderName} \u2014 Firn`);
+
+    // Optimistically update the recent workspaces list so the UI reflects
+    // the change immediately, without waiting for the backend save + refetch.
+    const now = new Date().toISOString();
+    const filtered = store.recentWorkspaces.filter((w) => w.path !== folderPath);
+    const updated = [{ name: folderName, path: folderPath, lastOpened: now }, ...filtered];
+    store.setRecentWorkspaces(updated.slice(0, MAX_RECENT));
+  } catch (err) {
+    console.error('Failed to open workspace:', err);
+    store.showToast(
+      `Failed to open workspace: ${err instanceof Error ? err.message : 'Unknown error'}`,
+      'error'
+    );
+  }
+}
+
+/**
+ * Shortens a filesystem path for display by replacing the home directory with ~.
+ */
+export function shortenPath(fullPath: string): string {
+  if (!fullPath) return fullPath;
+
+  // Unix: /Users/<name>/rest... or /home/<name>/rest... -> ~/rest...
+  if (fullPath.startsWith('/Users/') || fullPath.startsWith('/home/')) {
+    const parts = fullPath.split('/');
+    if (parts.length > 3) {
+      return '~/' + parts.slice(3).join('/');
+    }
+    return '~';
+  }
+
+  // Windows: C:\Users\<name>\rest... -> ~\rest...
+  if (/^[A-Z]:\\Users\\/i.test(fullPath)) {
+    const parts = fullPath.split('\\');
+    if (parts.length > 3) {
+      return '~\\' + parts.slice(3).join('\\');
+    }
+    return '~';
+  }
+
+  return fullPath;
+}


### PR DESCRIPTION
## Summary

- Adds a dropdown menu to the Header workspace button with "Open Folder..." and a recent projects list, replacing the previous direct-open button
- Shows recent projects on the Editor welcome screen (when no files are open), with shortened paths and one-click switching
- Extracts shared `openWorkspaceByPath` utility and `shortenPath` helper into `frontend/src/utils/workspace.ts` so both the native dialog flow and recent-project clicks use identical workspace-switching logic
- Adds `useRecentWorkspaces` hook that fetches from the backend on mount; in-session workspace switches are handled by optimistic updates to avoid a race with stale backend data
- Adds `recentWorkspaces` state and `setRecentWorkspaces` action to `ideStore`
- Adds `FolderOutlineIcon` and `FolderOpenOutlineIcon` SVG icons
- Full keyboard navigation (ArrowUp/Down, Home/End, Escape) and ARIA roles on the dropdown menu

## Test plan

- [x] Verify the Header workspace button opens a dropdown menu with "Open Folder..." and recent projects
- [x] Verify clicking "Open Folder..." opens the native dialog and switches workspace
- [x] Verify clicking a recent project switches workspace immediately
- [x] Verify the current workspace is excluded from the recent list in both the Header dropdown and welcome screen
- [x] Verify the welcome screen shows recent projects with shortened home-directory paths
- [x] Verify keyboard navigation works on the dropdown (ArrowDown to open, Escape to close, arrows to navigate)
- [x] Verify the dropdown closes on outside click
- [x] Run `npx jest` in `frontend/` -- all 34 affected tests pass

Generated with [Claude Code](https://claude.com/claude-code)