### PR TITLE
feat: add run profile executor with process lifecycle management

### DIFF
--- a/app.go
+++ b/app.go
@@ -19,19 +19,21 @@ import (
 // App represents the main application structure for Firn IDE.
 // It holds the application context for Wails runtime interactions.
 type App struct {
-	ctx            context.Context
-	dirReader      *filesystem.DirectoryReader
-	fileReader     *filesystem.FileReader
-	fileWriter     *filesystem.FileWriter
-	fileWatcher    watcher.Watcher
-	termManager    *terminal.Manager
-	profileMu      sync.RWMutex
-	profileManager *runprofile.Manager
-	osFS           filesystem.FileSystem
-	workspaceStore *workspace.Store
-	closeMu        sync.Mutex
-	isClosing      bool
-	closeReady     chan struct{}
+	ctx                  context.Context
+	dirReader            *filesystem.DirectoryReader
+	fileReader           *filesystem.FileReader
+	fileWriter           *filesystem.FileWriter
+	fileWatcher          watcher.Watcher
+	termManager          *terminal.Manager
+	profileMu            sync.RWMutex
+	profileManager       *runprofile.Manager
+	profileWorkspaceRoot string
+	executor             *runprofile.Executor
+	osFS                 filesystem.FileSystem
+	workspaceStore       *workspace.Store
+	closeMu              sync.Mutex
+	isClosing            bool
+	closeReady           chan struct{}
 }
 
 // NewApp creates and returns a new App instance.
@@ -62,11 +64,18 @@ func NewApp() *App {
 // It stores the context for later use with runtime methods.
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
+	a.executor = runprofile.NewExecutor(
+		func(event string, data ...any) {
+			runtime.EventsEmit(a.ctx, event, data...)
+		},
+		nil, // outputFn — wired in #60 (Output Streaming)
+	)
 }
 
 // beforeClose is called by Wails before the application window closes.
 // On the first call it prevents close, emits an event so the frontend can
-// perform a final state save, then schedules a forced quit after 500ms.
+// perform a final state save, and concurrently stops any running profiles.
+// Both must complete (or a 2-second deadline expires) before the app quits.
 // When the forced quit triggers OnBeforeClose again, the isClosing flag
 // is already set so it returns false immediately, allowing the close.
 func (a *App) beforeClose(ctx context.Context) (prevent bool) {
@@ -83,11 +92,31 @@ func (a *App) beforeClose(ctx context.Context) (prevent bool) {
 	runtime.EventsEmit(a.ctx, "app:beforeclose")
 
 	go func() {
-		// Give the frontend a chance to flush workspace state before forcing quit.
-		select {
-		case <-closeReady:
-		case <-time.After(2 * time.Second):
+		// Wait for both frontend state flush and runner cleanup, bounded by 2s.
+		runnerDone := make(chan struct{})
+		go func() {
+			if a.executor != nil {
+				_ = a.executor.StopAll(1500 * time.Millisecond)
+			}
+			close(runnerDone)
+		}()
+
+		deadline := time.After(2 * time.Second)
+		closeReadyCh := closeReady
+		runnerDoneCh := runnerDone
+
+		for closeReadyCh != nil || runnerDoneCh != nil {
+			select {
+			case <-closeReadyCh:
+				closeReadyCh = nil
+			case <-runnerDoneCh:
+				runnerDoneCh = nil
+			case <-deadline:
+				runtime.Quit(a.ctx)
+				return
+			}
 		}
+
 		runtime.Quit(a.ctx)
 	}()
 
@@ -230,18 +259,26 @@ func (a *App) CloseTerminal(id string) error {
 }
 
 // LoadRunProfiles initializes or reinitializes the run profile manager for the given workspace path.
-// The entire operation (create/reset + load) runs under the lock to prevent concurrent
-// LoadRunProfiles calls from interleaving.
+// If switching workspaces while profiles are running, stops all running profiles first.
 // This is exposed to the frontend via Wails bindings.
 func (a *App) LoadRunProfiles(workspacePath string) error {
 	a.profileMu.Lock()
 	defer a.profileMu.Unlock()
+
+	// Stop running profiles and clear stale terminal statuses when switching workspaces
+	if a.profileWorkspaceRoot != "" && a.profileWorkspaceRoot != workspacePath && a.executor != nil {
+		if ok := a.executor.StopAll(4 * time.Second); !ok {
+			return fmt.Errorf("failed to stop running profiles before switching workspace")
+		}
+		a.executor.ClearTerminalStatuses()
+	}
 
 	if a.profileManager == nil {
 		a.profileManager = runprofile.NewManager(a.osFS, workspacePath)
 	} else {
 		a.profileManager.SetWorkspaceRoot(workspacePath)
 	}
+	a.profileWorkspaceRoot = workspacePath
 	return a.profileManager.Load()
 }
 
@@ -339,6 +376,55 @@ func (a *App) LoadWorkspaceState(workspacePath string) (*workspace.State, error)
 // This is exposed to the frontend via Wails bindings.
 func (a *App) ListRecentWorkspaces() ([]workspace.Summary, error) {
 	return a.workspaceStore.ListRecent(0)
+}
+
+// StartRunProfile starts executing a run profile by ID.
+// This is exposed to the frontend via Wails bindings.
+func (a *App) StartRunProfile(profileID string) error {
+	a.profileMu.RLock()
+	if a.profileManager == nil {
+		a.profileMu.RUnlock()
+		return fmt.Errorf("no workspace loaded")
+	}
+	workspaceRoot := a.profileWorkspaceRoot
+	profiles := a.profileManager.GetAllProfiles()
+	a.profileMu.RUnlock()
+
+	var profile *runprofile.RunProfile
+	for i := range profiles {
+		if profiles[i].ID == profileID {
+			profile = &profiles[i]
+			break
+		}
+	}
+	if profile == nil {
+		return fmt.Errorf("profile not found: %s", profileID)
+	}
+
+	return a.executor.Start(workspaceRoot, *profile)
+}
+
+// StopRunProfile stops a running profile (SIGTERM → 3s → SIGKILL).
+// This is exposed to the frontend via Wails bindings.
+func (a *App) StopRunProfile(profileID string) error {
+	return a.executor.Stop(profileID)
+}
+
+// RestartRunProfile stops then starts a profile.
+// If the profile is not currently running, it just starts it.
+// Stop errors are ignored because the only failure mode is "not running",
+// which means we can safely proceed to Start.
+// This is exposed to the frontend via Wails bindings.
+func (a *App) RestartRunProfile(profileID string) error {
+	_ = a.StopRunProfile(profileID)
+	return a.StartRunProfile(profileID)
+}
+
+// GetRunStatus returns the current run status of a profile.
+// Returns RunStateIdle for profiles that are not running.
+// This is exposed to the frontend via Wails bindings.
+func (a *App) GetRunStatus(profileID string) runprofile.RunStatus {
+	return a.executor.GetStatus(profileID)
 }
 
 // ConfirmBeforeCloseReady signals that the frontend finished its final flush

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -148,12 +148,14 @@ Project View (unified) vs Workspace View (focused) with color-coded regions.
 - [x] Backend: 7 Wails bindings (Load/GetAll/Save/Delete/Pin/Validate/Detect)
 - [x] Frontend: Zustand store slice, useRunProfiles hook, basic sidebar panel
 
-### #17: Run Profiles - Execution Engine
-- [ ] Start process with configured env/cwd
-- [ ] Stream stdout/stderr to frontend
-- [ ] Handle process termination, support stop/restart
-- [ ] Parse clickable file:line:col references
-- [ ] Compound profile sequential execution
+### #17: Run Profiles - Execution Engine [Epic]
+Sub-issues:
+- [ ] #59: Core Process Runner — `os/exec` implementation, env/cwd/envFile, start/stop bindings
+- [ ] #60: Output Streaming — pipe stdout/stderr, Wails events, output panel
+- [ ] #61: Process Lifecycle UI — play/stop/restart controls, state indicators
+- [ ] #62: Clickable Error Links — `file:line:col` parsing, jump-to-error
+- [ ] #63: Compound Profile Execution — sequential steps, stop-on-failure
+- [ ] #64: Environment Variants — env file swapping by active variant
 
 ### #18: Run Profiles - UI Integration
 - [ ] Profile selector dropdown in header toolbar (`[▶ Profile ▾]`)

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -17,6 +17,8 @@ export function DetectRunProfiles():Promise<Array<runprofile.RunProfile>>;
 
 export function GetAllRunProfiles():Promise<Array<runprofile.RunProfile>>;
 
+export function GetRunStatus(arg1:string):Promise<runprofile.RunStatus>;
+
 export function GetWatchedPath():Promise<string>;
 
 export function GetWorkspaceInfo():Promise<main.WorkspaceInfo>;
@@ -39,11 +41,17 @@ export function ReadFile(arg1:string):Promise<filesystem.FileContent>;
 
 export function ResizeTerminal(arg1:string,arg2:number,arg3:number):Promise<void>;
 
+export function RestartRunProfile(arg1:string):Promise<void>;
+
 export function SaveRunProfile(arg1:runprofile.RunProfile):Promise<runprofile.ValidationResult>;
 
 export function SaveWorkspaceState(arg1:workspace.State):Promise<void>;
 
+export function StartRunProfile(arg1:string):Promise<void>;
+
 export function StartWatching(arg1:string):Promise<void>;
+
+export function StopRunProfile(arg1:string):Promise<void>;
 
 export function StopWatching():Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -26,6 +26,10 @@ export function GetAllRunProfiles() {
   return window['go']['main']['App']['GetAllRunProfiles']();
 }
 
+export function GetRunStatus(arg1) {
+  return window['go']['main']['App']['GetRunStatus'](arg1);
+}
+
 export function GetWatchedPath() {
   return window['go']['main']['App']['GetWatchedPath']();
 }
@@ -70,6 +74,10 @@ export function ResizeTerminal(arg1, arg2, arg3) {
   return window['go']['main']['App']['ResizeTerminal'](arg1, arg2, arg3);
 }
 
+export function RestartRunProfile(arg1) {
+  return window['go']['main']['App']['RestartRunProfile'](arg1);
+}
+
 export function SaveRunProfile(arg1) {
   return window['go']['main']['App']['SaveRunProfile'](arg1);
 }
@@ -78,8 +86,16 @@ export function SaveWorkspaceState(arg1) {
   return window['go']['main']['App']['SaveWorkspaceState'](arg1);
 }
 
+export function StartRunProfile(arg1) {
+  return window['go']['main']['App']['StartRunProfile'](arg1);
+}
+
 export function StartWatching(arg1) {
   return window['go']['main']['App']['StartWatching'](arg1);
+}
+
+export function StopRunProfile(arg1) {
+  return window['go']['main']['App']['StopRunProfile'](arg1);
 }
 
 export function StopWatching() {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -155,6 +155,24 @@ export namespace runprofile {
 		    return a;
 		}
 	}
+	export class RunStatus {
+	    profileId: string;
+	    state: string;
+	    exitCode: number;
+	    pid?: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new RunStatus(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.profileId = source["profileId"];
+	        this.state = source["state"];
+	        this.exitCode = source["exitCode"];
+	        this.pid = source["pid"];
+	    }
+	}
 	export class ValidationError {
 	    field: string;
 	    message: string;

--- a/internal/runprofile/dotenv.go
+++ b/internal/runprofile/dotenv.go
@@ -1,0 +1,61 @@
+package runprofile
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ParseEnvFile reads a .env file and returns key-value pairs.
+// Supports: KEY=VALUE, # comments, blank lines, single/double quoted values,
+// export prefix (stripped). Lines without '=' are skipped.
+// Returns error if the file cannot be read.
+func ParseEnvFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading env file: %w", err)
+	}
+	defer f.Close()
+
+	env := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip blank lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Strip optional "export " prefix
+		line = strings.TrimPrefix(line, "export ")
+
+		// Find first '=' — skip lines without one
+		idx := strings.IndexByte(line, '=')
+		if idx < 0 {
+			continue
+		}
+
+		key := strings.TrimSpace(line[:idx])
+		value := strings.TrimSpace(line[idx+1:])
+
+		// Strip matching outer quotes
+		if len(value) >= 2 {
+			first, last := value[0], value[len(value)-1]
+			if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+				value = value[1 : len(value)-1]
+			}
+		}
+
+		if key != "" {
+			env[key] = value
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading env file: %w", err)
+	}
+
+	return env, nil
+}

--- a/internal/runprofile/dotenv_test.go
+++ b/internal/runprofile/dotenv_test.go
@@ -1,0 +1,158 @@
+package runprofile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTempEnv(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestParseEnvFile_BasicPairs(t *testing.T) {
+	path := writeTempEnv(t, "KEY=VALUE\nFOO=BAR\n")
+	env, err := ParseEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env["KEY"] != "VALUE" {
+		t.Errorf("KEY = %q, want %q", env["KEY"], "VALUE")
+	}
+	if env["FOO"] != "BAR" {
+		t.Errorf("FOO = %q, want %q", env["FOO"], "BAR")
+	}
+}
+
+func TestParseEnvFile_Comments(t *testing.T) {
+	path := writeTempEnv(t, "# this is a comment\nKEY=VALUE\n  # indented comment\n")
+	env, err := ParseEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(env) != 1 {
+		t.Errorf("got %d entries, want 1", len(env))
+	}
+	if env["KEY"] != "VALUE" {
+		t.Errorf("KEY = %q, want %q", env["KEY"], "VALUE")
+	}
+}
+
+func TestParseEnvFile_BlankLines(t *testing.T) {
+	path := writeTempEnv(t, "\n\nKEY=VALUE\n\n")
+	env, err := ParseEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(env) != 1 {
+		t.Errorf("got %d entries, want 1", len(env))
+	}
+}
+
+func TestParseEnvFile_DoubleQuoted(t *testing.T) {
+	path := writeTempEnv(t, `KEY="hello world"`)
+	env, err := ParseEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env["KEY"] != "hello world" {
+		t.Errorf("KEY = %q, want %q", env["KEY"], "hello world")
+	}
+}
+
+func TestParseEnvFile_SingleQuoted(t *testing.T) {
+	path := writeTempEnv(t, `KEY='hello'`)
+	env, err := ParseEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env["KEY"] != "hello" {
+		t.Errorf("KEY = %q, want %q", env["KEY"], "hello")
+	}
+}
+
+func TestParseEnvFile_NoEqualsSkipped(t *testing.T) {
+	path := writeTempEnv(t, "INVALID LINE\nKEY=VALUE\n")
+	env, err := ParseEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(env) != 1 {
+		t.Errorf("got %d entries, want 1", len(env))
+	}
+	if env["KEY"] != "VALUE" {
+		t.Errorf("KEY = %q, want %q", env["KEY"], "VALUE")
+	}
+}
+
+func TestParseEnvFile_Whitespace(t *testing.T) {
+	path := writeTempEnv(t, "  KEY = VALUE  \n")
+	env, err := ParseEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env["KEY"] != "VALUE" {
+		t.Errorf("KEY = %q, want %q", env["KEY"], "VALUE")
+	}
+}
+
+func TestParseEnvFile_ExportPrefix(t *testing.T) {
+	path := writeTempEnv(t, "export KEY=VALUE\nexport FOO=\"bar\"\n")
+	env, err := ParseEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env["KEY"] != "VALUE" {
+		t.Errorf("KEY = %q, want %q", env["KEY"], "VALUE")
+	}
+	if env["FOO"] != "bar" {
+		t.Errorf("FOO = %q, want %q", env["FOO"], "bar")
+	}
+}
+
+func TestParseEnvFile_MissingFile(t *testing.T) {
+	_, err := ParseEnvFile("/nonexistent/.env")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestParseEnvFile_EmptyFile(t *testing.T) {
+	path := writeTempEnv(t, "")
+	env, err := ParseEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(env) != 0 {
+		t.Errorf("got %d entries, want 0", len(env))
+	}
+}
+
+func TestParseEnvFile_ValueWithEquals(t *testing.T) {
+	path := writeTempEnv(t, "DATABASE_URL=postgres://user:pass@host/db?sslmode=require\n")
+	env, err := ParseEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "postgres://user:pass@host/db?sslmode=require"
+	if env["DATABASE_URL"] != want {
+		t.Errorf("DATABASE_URL = %q, want %q", env["DATABASE_URL"], want)
+	}
+}
+
+func TestParseEnvFile_EmptyValue(t *testing.T) {
+	path := writeTempEnv(t, "KEY=\n")
+	env, err := ParseEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env["KEY"] != "" {
+		t.Errorf("KEY = %q, want empty string", env["KEY"])
+	}
+}

--- a/internal/runprofile/executor.go
+++ b/internal/runprofile/executor.go
@@ -1,0 +1,406 @@
+package runprofile
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RunState represents the lifecycle state of a profile execution.
+type RunState string
+
+const (
+	RunStateIdle    RunState = "idle"
+	RunStateRunning RunState = "running"
+	RunStateStopped RunState = "stopped" // user-initiated stop
+	RunStateFailed  RunState = "failed"  // non-zero exit code
+	RunStateSuccess RunState = "success" // exit code 0
+)
+
+const stopGracePeriod = 3 * time.Second
+
+// RunStatus is emitted to the frontend on every state transition.
+type RunStatus struct {
+	ProfileID string   `json:"profileId"`
+	State     RunState `json:"state"`
+	ExitCode  int      `json:"exitCode"`
+	Pid       int      `json:"pid,omitempty"`
+}
+
+// OutputFunc receives streaming process output.
+// stream is "stdout" or "stderr". data is the raw chunk.
+// The caller is responsible for buffering or backpressure.
+type OutputFunc func(profileID, stream, data string)
+
+// StatusFunc emits run status events (wraps runtime.EventsEmit in production).
+type StatusFunc func(event string, data ...any)
+
+// Executor manages the lifecycle of running profiles.
+type Executor struct {
+	mu         sync.Mutex
+	processes  map[string]*runningProcess
+	lastStatus map[string]RunStatus // terminal status retained after exit
+	emitFn     StatusFunc
+	outputFn   OutputFunc
+}
+
+// runningProcess tracks a single running profile execution.
+type runningProcess struct {
+	cmd      *exec.Cmd
+	status   RunStatus
+	stopped  bool         // set by Stop — tells Wait goroutine to use RunStateStopped
+	done     chan struct{} // closed when process exits and cleanup is complete
+	stopOnce sync.Once
+}
+
+// NewExecutor creates an Executor.
+// emitFn emits Wails events (or a test spy).
+// outputFn receives stdout/stderr chunks (nil = drain silently).
+func NewExecutor(emitFn StatusFunc, outputFn OutputFunc) *Executor {
+	return &Executor{
+		processes:  make(map[string]*runningProcess),
+		lastStatus: make(map[string]RunStatus),
+		emitFn:     emitFn,
+		outputFn:   outputFn,
+	}
+}
+
+// Start begins executing a run profile. Profile resolution (ID → RunProfile)
+// happens at the app.go binding level. The executor receives the resolved profile.
+func (e *Executor) Start(workspaceRoot string, profile RunProfile) error {
+	if workspaceRoot == "" {
+		return fmt.Errorf("no workspace loaded")
+	}
+
+	if profile.Type == ProfileTypeCompound {
+		return fmt.Errorf("compound profiles are not supported yet")
+	}
+
+	if strings.TrimSpace(profile.Command) == "" {
+		return fmt.Errorf("profile has no command: %s", profile.ID)
+	}
+
+	// Resolve effective working directory
+	effectiveDir, err := resolveWorkingDir(workspaceRoot, profile.WorkingDir)
+	if err != nil {
+		return err
+	}
+
+	// Hold the lock for the entire setup-through-insert sequence. This prevents
+	// concurrent starts for the same profile ID (TOCTOU) and ensures Stop/StopAll
+	// never see a partially-initialized entry. The locked work is fast: env merging
+	// (small .env file read), pipe setup, and fork.
+	e.mu.Lock()
+	if _, exists := e.processes[profile.ID]; exists {
+		e.mu.Unlock()
+		return fmt.Errorf("profile already running: %s", profile.ID)
+	}
+	delete(e.lastStatus, profile.ID)
+
+	// Build environment
+	env, err := buildEnv(profile.Env, profile.EnvFile, effectiveDir)
+	if err != nil {
+		e.mu.Unlock()
+		return err
+	}
+
+	// Create command via platform helper
+	cmd := shellCommand(profile.Command)
+	cmd.Dir = effectiveDir
+	cmd.Env = env
+	setSysProcAttr(cmd)
+
+	// Set up pipes
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		e.mu.Unlock()
+		return fmt.Errorf("creating stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		e.mu.Unlock()
+		return fmt.Errorf("creating stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		e.mu.Unlock()
+		return fmt.Errorf("starting process: %w", err)
+	}
+
+	rp := &runningProcess{
+		cmd: cmd,
+		status: RunStatus{
+			ProfileID: profile.ID,
+			State:     RunStateRunning,
+			Pid:       cmd.Process.Pid,
+		},
+		done: make(chan struct{}),
+	}
+	e.processes[profile.ID] = rp
+	e.mu.Unlock()
+
+	// Emit running status
+	e.emit(rp.status)
+
+	// Drain stdout/stderr
+	var pipesWg sync.WaitGroup
+	pipesWg.Add(2)
+	go e.drainPipe(&pipesWg, profile.ID, "stdout", stdout)
+	go e.drainPipe(&pipesWg, profile.ID, "stderr", stderr)
+
+	// Wait for process exit
+	go func() {
+		pipesWg.Wait()
+		exitCode := waitExitCode(cmd)
+
+		e.mu.Lock()
+		stopped := rp.stopped
+		if stopped {
+			rp.status.State = RunStateStopped
+		} else if exitCode == 0 {
+			rp.status.State = RunStateSuccess
+		} else {
+			rp.status.State = RunStateFailed
+		}
+		rp.status.ExitCode = exitCode
+		rp.status.Pid = 0
+		status := rp.status
+		e.lastStatus[profile.ID] = status
+		delete(e.processes, profile.ID)
+		e.mu.Unlock()
+
+		e.emit(status)
+		close(rp.done)
+	}()
+
+	return nil
+}
+
+// Stop terminates a running profile. Sends SIGTERM, waits up to 3 seconds,
+// then escalates to SIGKILL. Blocks until the process is fully cleaned up.
+func (e *Executor) Stop(profileID string) error {
+	e.mu.Lock()
+	rp, exists := e.processes[profileID]
+	if !exists {
+		e.mu.Unlock()
+		return fmt.Errorf("profile not running: %s", profileID)
+	}
+	e.mu.Unlock()
+
+	rp.stopOnce.Do(func() {
+		e.mu.Lock()
+		rp.stopped = true
+		e.mu.Unlock()
+
+		pid := rp.cmd.Process.Pid
+		_ = killProcessGroup(pid)
+
+		select {
+		case <-rp.done:
+			return
+		case <-time.After(stopGracePeriod):
+			_ = forceKillProcessGroup(pid)
+		}
+	})
+
+	// Block until fully cleaned up
+	<-rp.done
+	return nil
+}
+
+// StopAll terminates all running profiles within the given timeout.
+// Returns true if all processes were cleaned up before the deadline.
+func (e *Executor) StopAll(timeout time.Duration) bool {
+	e.mu.Lock()
+	if len(e.processes) == 0 {
+		e.mu.Unlock()
+		return true
+	}
+
+	// Copy entries for concurrent stop
+	type entry struct {
+		id string
+		rp *runningProcess
+	}
+	entries := make([]entry, 0, len(e.processes))
+	for id, rp := range e.processes {
+		entries = append(entries, entry{id, rp})
+	}
+
+	// Mark all as stopped
+	for _, ent := range entries {
+		ent.rp.stopped = true
+	}
+	e.mu.Unlock()
+
+	// Send SIGTERM to all
+	for _, ent := range entries {
+		pid := ent.rp.cmd.Process.Pid
+		_ = killProcessGroup(pid)
+	}
+
+	halfway := timeout / 2
+	deadline := time.After(timeout)
+	halfwayTimer := time.After(halfway)
+
+	// Collect done channels
+	allDone := make(chan struct{})
+	go func() {
+		for _, ent := range entries {
+			<-ent.rp.done
+		}
+		close(allDone)
+	}()
+
+	// Wait for halfway point — escalate survivors to SIGKILL
+	select {
+	case <-allDone:
+		return true
+	case <-halfwayTimer:
+		// Force-kill any survivors
+		e.mu.Lock()
+		for _, ent := range entries {
+			if _, stillRunning := e.processes[ent.id]; stillRunning {
+				pid := ent.rp.cmd.Process.Pid
+				_ = forceKillProcessGroup(pid)
+			}
+		}
+		e.mu.Unlock()
+	}
+
+	// Wait for full deadline
+	select {
+	case <-allDone:
+		return true
+	case <-deadline:
+		return false
+	}
+}
+
+// GetStatus returns the current run status of a profile.
+// Returns the terminal status (success/failed/stopped) if the profile has
+// completed but has not been restarted, or RunStateIdle if never started.
+func (e *Executor) GetStatus(profileID string) RunStatus {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if rp, exists := e.processes[profileID]; exists {
+		return rp.status
+	}
+	if last, exists := e.lastStatus[profileID]; exists {
+		return last
+	}
+	return RunStatus{ProfileID: profileID, State: RunStateIdle}
+}
+
+// ClearTerminalStatuses removes all retained terminal statuses.
+// Called on workspace switch so stale results from the previous workspace
+// cannot leak into a new workspace that reuses the same profile IDs.
+func (e *Executor) ClearTerminalStatuses() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	clear(e.lastStatus)
+}
+
+// emit sends a status event via the configured StatusFunc.
+func (e *Executor) emit(status RunStatus) {
+	if e.emitFn != nil {
+		e.emitFn("run:status", status)
+	}
+}
+
+// drainPipe reads from a pipe and either forwards to outputFn or discards.
+func (e *Executor) drainPipe(wg *sync.WaitGroup, profileID, stream string, pipe io.ReadCloser) {
+	defer wg.Done()
+	buf := make([]byte, 4096)
+	for {
+		n, err := pipe.Read(buf)
+		if n > 0 && e.outputFn != nil {
+			e.outputFn(profileID, stream, string(buf[:n]))
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// resolveWorkingDir converts a profile workingDir into an absolute path.
+// Empty workingDir defaults to workspaceRoot. Relative paths are resolved
+// against workspaceRoot. Validates the directory exists.
+func resolveWorkingDir(workspaceRoot, workingDir string) (string, error) {
+	var resolved string
+	switch {
+	case workingDir == "":
+		resolved = workspaceRoot
+	case filepath.IsAbs(workingDir):
+		resolved = workingDir
+	default:
+		resolved = filepath.Join(workspaceRoot, workingDir)
+	}
+
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", fmt.Errorf("working directory does not exist: %s", resolved)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("working directory is not a directory: %s", resolved)
+	}
+	return resolved, nil
+}
+
+// buildEnv merges environment sources in precedence order:
+// os.Environ() (base) → EnvFile values → profile.Env map (inline wins).
+// Relative envFilePath values are resolved against effectiveWorkingDir.
+func buildEnv(profileEnv map[string]string, envFilePath string, effectiveWorkingDir string) ([]string, error) {
+	// Start with current environment
+	envMap := make(map[string]string)
+	for _, entry := range os.Environ() {
+		if idx := strings.IndexByte(entry, '='); idx >= 0 {
+			envMap[entry[:idx]] = entry[idx+1:]
+		}
+	}
+
+	// Layer 2: env file (if specified)
+	if envFilePath != "" {
+		resolved := envFilePath
+		if !filepath.IsAbs(resolved) {
+			resolved = filepath.Join(effectiveWorkingDir, resolved)
+		}
+		fileEnv, err := ParseEnvFile(resolved)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range fileEnv {
+			envMap[k] = v
+		}
+	}
+
+	// Layer 3: inline env vars (highest precedence)
+	for k, v := range profileEnv {
+		envMap[k] = v
+	}
+
+	// Convert back to slice
+	result := make([]string, 0, len(envMap))
+	for k, v := range envMap {
+		result = append(result, k+"="+v)
+	}
+	return result, nil
+}
+
+// waitExitCode waits for the command to finish and extracts the exit code.
+func waitExitCode(cmd *exec.Cmd) int {
+	err := cmd.Wait()
+	if err == nil {
+		return 0
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return exitErr.ExitCode()
+	}
+	return 1
+}

--- a/internal/runprofile/executor_test.go
+++ b/internal/runprofile/executor_test.go
@@ -1,0 +1,687 @@
+//go:build !windows
+
+package runprofile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// emitSpy collects emitted events for test assertions.
+type emitSpy struct {
+	mu     sync.Mutex
+	events []emitEvent
+}
+
+type emitEvent struct {
+	event string
+	data  []any
+}
+
+func (s *emitSpy) emit(event string, data ...any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, emitEvent{event: event, data: data})
+}
+
+func (s *emitSpy) statuses() []RunStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var result []RunStatus
+	for _, e := range s.events {
+		if e.event == "run:status" && len(e.data) > 0 {
+			if st, ok := e.data[0].(RunStatus); ok {
+				result = append(result, st)
+			}
+		}
+	}
+	return result
+}
+
+func (s *emitSpy) waitForState(state RunState, timeout time.Duration) (RunStatus, bool) {
+	deadline := time.After(timeout)
+	for {
+		for _, st := range s.statuses() {
+			if st.State == state {
+				return st, true
+			}
+		}
+		select {
+		case <-deadline:
+			return RunStatus{}, false
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+// outputSpy collects output for test assertions.
+type outputSpy struct {
+	mu      sync.Mutex
+	entries []outputEntry
+}
+
+type outputEntry struct {
+	profileID string
+	stream    string
+	data      string
+}
+
+func (o *outputSpy) receive(profileID, stream, data string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.entries = append(o.entries, outputEntry{profileID, stream, data})
+}
+
+func (o *outputSpy) combined() string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	var sb strings.Builder
+	for _, e := range o.entries {
+		sb.WriteString(e.data)
+	}
+	return sb.String()
+}
+
+func (o *outputSpy) streamContent(stream string) string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	var sb strings.Builder
+	for _, e := range o.entries {
+		if e.stream == stream {
+			sb.WriteString(e.data)
+		}
+	}
+	return sb.String()
+}
+
+func newTestProfile(id, command string) RunProfile {
+	return RunProfile{
+		ID:      id,
+		Name:    id,
+		Type:    ProfileTypeSingle,
+		Command: command,
+	}
+}
+
+func TestExecutor_StartSuccess(t *testing.T) {
+	spy := &emitSpy{}
+	exec := NewExecutor(spy.emit, nil)
+	dir := t.TempDir()
+
+	profile := newTestProfile("test-echo", "echo hello")
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should transition to running, then success
+	if _, ok := spy.waitForState(RunStateSuccess, 5*time.Second); !ok {
+		t.Fatal("timed out waiting for success state")
+	}
+
+	statuses := spy.statuses()
+	if len(statuses) < 2 {
+		t.Fatalf("expected at least 2 status events, got %d", len(statuses))
+	}
+	if statuses[0].State != RunStateRunning {
+		t.Errorf("first state = %q, want %q", statuses[0].State, RunStateRunning)
+	}
+	if statuses[len(statuses)-1].ExitCode != 0 {
+		t.Errorf("exit code = %d, want 0", statuses[len(statuses)-1].ExitCode)
+	}
+}
+
+func TestExecutor_StartFailure(t *testing.T) {
+	spy := &emitSpy{}
+	exec := NewExecutor(spy.emit, nil)
+	dir := t.TempDir()
+
+	profile := newTestProfile("test-fail", "exit 1")
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	st, ok := spy.waitForState(RunStateFailed, 5*time.Second)
+	if !ok {
+		t.Fatal("timed out waiting for failed state")
+	}
+	if st.ExitCode != 1 {
+		t.Errorf("exit code = %d, want 1", st.ExitCode)
+	}
+}
+
+func TestExecutor_StartCompoundRejected(t *testing.T) {
+	exec := NewExecutor(nil, nil)
+	dir := t.TempDir()
+
+	profile := RunProfile{
+		ID:   "compound-test",
+		Name: "compound",
+		Type: ProfileTypeCompound,
+	}
+	err := exec.Start(dir, profile)
+	if err == nil {
+		t.Fatal("expected error for compound profile")
+	}
+	if !strings.Contains(err.Error(), "compound profiles are not supported yet") {
+		t.Errorf("error = %q, want compound rejection message", err.Error())
+	}
+}
+
+func TestExecutor_StopGraceful(t *testing.T) {
+	spy := &emitSpy{}
+	exec := NewExecutor(spy.emit, nil)
+	dir := t.TempDir()
+
+	profile := newTestProfile("test-sleep", "sleep 60")
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := spy.waitForState(RunStateRunning, 5*time.Second); !ok {
+		t.Fatal("timed out waiting for running state")
+	}
+
+	if err := exec.Stop("test-sleep"); err != nil {
+		t.Fatal(err)
+	}
+
+	st, ok := spy.waitForState(RunStateStopped, 5*time.Second)
+	if !ok {
+		t.Fatal("timed out waiting for stopped state")
+	}
+	if st.State != RunStateStopped {
+		t.Errorf("state = %q, want %q", st.State, RunStateStopped)
+	}
+}
+
+func TestExecutor_StopSetsStoppedFlag(t *testing.T) {
+	spy := &emitSpy{}
+	exec := NewExecutor(spy.emit, nil)
+	dir := t.TempDir()
+
+	profile := newTestProfile("test-stopped-flag", "sleep 60")
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := spy.waitForState(RunStateRunning, 5*time.Second); !ok {
+		t.Fatal("timed out waiting for running state")
+	}
+
+	if err := exec.Stop("test-stopped-flag"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The final state should be "stopped", not "failed" (even though the process
+	// was killed with a signal which normally produces a non-zero exit)
+	st, ok := spy.waitForState(RunStateStopped, 5*time.Second)
+	if !ok {
+		t.Fatal("timed out waiting for stopped state")
+	}
+	if st.State != RunStateStopped {
+		t.Errorf("state = %q, want %q — stop flag was not respected", st.State, RunStateStopped)
+	}
+}
+
+func TestExecutor_DuplicateStart(t *testing.T) {
+	exec := NewExecutor(nil, nil)
+	dir := t.TempDir()
+
+	profile := newTestProfile("test-dup", "sleep 60")
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+	defer exec.Stop("test-dup") //nolint:errcheck
+
+	err := exec.Start(dir, profile)
+	if err == nil {
+		t.Fatal("expected error for duplicate start")
+	}
+	if !strings.Contains(err.Error(), "already running") {
+		t.Errorf("error = %q, want 'already running'", err.Error())
+	}
+}
+
+func TestExecutor_StopNonExistent(t *testing.T) {
+	exec := NewExecutor(nil, nil)
+	err := exec.Stop("bogus-id")
+	if err == nil {
+		t.Fatal("expected error for non-existent profile")
+	}
+	if !strings.Contains(err.Error(), "not running") {
+		t.Errorf("error = %q, want 'not running'", err.Error())
+	}
+}
+
+func TestExecutor_EnvVars(t *testing.T) {
+	spy := &emitSpy{}
+	out := &outputSpy{}
+	exec := NewExecutor(spy.emit, out.receive)
+	dir := t.TempDir()
+
+	profile := newTestProfile("test-env", "env")
+	profile.Env = map[string]string{
+		"FIRN_TEST_VAR": "hello_from_firn",
+	}
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := spy.waitForState(RunStateSuccess, 5*time.Second); !ok {
+		t.Fatal("timed out waiting for success state")
+	}
+
+	output := out.combined()
+	if !strings.Contains(output, "FIRN_TEST_VAR=hello_from_firn") {
+		t.Errorf("env output does not contain FIRN_TEST_VAR=hello_from_firn\noutput:\n%s", output)
+	}
+}
+
+func TestExecutor_WorkingDirDefault(t *testing.T) {
+	spy := &emitSpy{}
+	out := &outputSpy{}
+	exec := NewExecutor(spy.emit, out.receive)
+	dir := t.TempDir()
+
+	profile := newTestProfile("test-pwd", "pwd")
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := spy.waitForState(RunStateSuccess, 5*time.Second); !ok {
+		t.Fatal("timed out waiting for success state")
+	}
+
+	output := strings.TrimSpace(out.combined())
+	// Resolve symlinks for macOS /private/var/folders... vs /var/folders...
+	resolvedDir, _ := filepath.EvalSymlinks(dir)
+	resolvedOutput, _ := filepath.EvalSymlinks(output)
+	if resolvedOutput != resolvedDir {
+		t.Errorf("pwd = %q, want %q", resolvedOutput, resolvedDir)
+	}
+}
+
+func TestExecutor_WorkingDirRelative(t *testing.T) {
+	spy := &emitSpy{}
+	out := &outputSpy{}
+	exec := NewExecutor(spy.emit, out.receive)
+	dir := t.TempDir()
+
+	subdir := filepath.Join(dir, "frontend")
+	if err := os.MkdirAll(subdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	profile := newTestProfile("test-pwd-rel", "pwd")
+	profile.WorkingDir = "frontend"
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := spy.waitForState(RunStateSuccess, 5*time.Second); !ok {
+		t.Fatal("timed out waiting for success state")
+	}
+
+	output := strings.TrimSpace(out.combined())
+	resolvedSubdir, _ := filepath.EvalSymlinks(subdir)
+	resolvedOutput, _ := filepath.EvalSymlinks(output)
+	if resolvedOutput != resolvedSubdir {
+		t.Errorf("pwd = %q, want %q", resolvedOutput, resolvedSubdir)
+	}
+}
+
+func TestExecutor_InvalidWorkingDir(t *testing.T) {
+	exec := NewExecutor(nil, nil)
+
+	profile := newTestProfile("test-bad-dir", "echo hello")
+	profile.WorkingDir = "/nonexistent/directory"
+	err := exec.Start("/tmp", profile)
+	if err == nil {
+		t.Fatal("expected error for invalid working directory")
+	}
+	if !strings.Contains(err.Error(), "working directory does not exist") {
+		t.Errorf("error = %q, want 'working directory does not exist'", err.Error())
+	}
+}
+
+func TestExecutor_EnvFileMerge(t *testing.T) {
+	spy := &emitSpy{}
+	out := &outputSpy{}
+	exec := NewExecutor(spy.emit, out.receive)
+	dir := t.TempDir()
+
+	// Create .env file with SHARED_VAR and FILE_VAR
+	envContent := "SHARED_VAR=from_file\nFILE_VAR=file_only\n"
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(envContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	profile := newTestProfile("test-env-merge", "env")
+	profile.EnvFile = ".env"
+	profile.Env = map[string]string{
+		"SHARED_VAR": "from_inline", // inline should win over file
+		"INLINE_VAR": "inline_only",
+	}
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := spy.waitForState(RunStateSuccess, 5*time.Second); !ok {
+		t.Fatal("timed out waiting for success state")
+	}
+
+	output := out.combined()
+	// Inline wins over file
+	if !strings.Contains(output, "SHARED_VAR=from_inline") {
+		t.Errorf("SHARED_VAR should be from_inline (inline wins), output:\n%s", output)
+	}
+	if !strings.Contains(output, "FILE_VAR=file_only") {
+		t.Errorf("FILE_VAR should be present from env file, output:\n%s", output)
+	}
+	if !strings.Contains(output, "INLINE_VAR=inline_only") {
+		t.Errorf("INLINE_VAR should be present from inline env, output:\n%s", output)
+	}
+}
+
+func TestExecutor_EnvFileRelativePath(t *testing.T) {
+	spy := &emitSpy{}
+	out := &outputSpy{}
+	exec := NewExecutor(spy.emit, out.receive)
+	dir := t.TempDir()
+
+	// Create .env.local in workspace root
+	envContent := "LOCAL_VAR=found_it\n"
+	if err := os.WriteFile(filepath.Join(dir, ".env.local"), []byte(envContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	profile := newTestProfile("test-env-rel", "env")
+	profile.EnvFile = ".env.local"
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := spy.waitForState(RunStateSuccess, 5*time.Second); !ok {
+		t.Fatal("timed out waiting for success state")
+	}
+
+	output := out.combined()
+	if !strings.Contains(output, "LOCAL_VAR=found_it") {
+		t.Errorf("LOCAL_VAR should be present from .env.local, output:\n%s", output)
+	}
+}
+
+func TestExecutor_EnvFileNotFound(t *testing.T) {
+	exec := NewExecutor(nil, nil)
+	dir := t.TempDir()
+
+	profile := newTestProfile("test-env-missing", "echo hello")
+	profile.EnvFile = ".env.nonexistent"
+	err := exec.Start(dir, profile)
+	if err == nil {
+		t.Fatal("expected error for missing env file")
+	}
+}
+
+func TestExecutor_ProcessGroupKill(t *testing.T) {
+	spy := &emitSpy{}
+	exec := NewExecutor(spy.emit, nil)
+	dir := t.TempDir()
+
+	// Start a shell that spawns a child. Both should die on Stop.
+	profile := newTestProfile("test-pgkill", "sh -c 'sleep 60 & sleep 60'")
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := spy.waitForState(RunStateRunning, 5*time.Second); !ok {
+		t.Fatal("timed out waiting for running state")
+	}
+
+	// Give the child processes a moment to spawn
+	time.Sleep(100 * time.Millisecond)
+
+	if err := exec.Stop("test-pgkill"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Process should be stopped
+	st, ok := spy.waitForState(RunStateStopped, 5*time.Second)
+	if !ok {
+		t.Fatal("timed out waiting for stopped state")
+	}
+	if st.State != RunStateStopped {
+		t.Errorf("state = %q, want %q", st.State, RunStateStopped)
+	}
+}
+
+func TestExecutor_StopAll(t *testing.T) {
+	spy := &emitSpy{}
+	exec := NewExecutor(spy.emit, nil)
+	dir := t.TempDir()
+
+	// Start two long-running profiles
+	for i := 0; i < 2; i++ {
+		profile := newTestProfile(fmt.Sprintf("test-stopall-%d", i), "sleep 60")
+		if err := exec.Start(dir, profile); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Wait for both to be running
+	time.Sleep(100 * time.Millisecond)
+
+	ok := exec.StopAll(5 * time.Second)
+	if !ok {
+		t.Fatal("StopAll returned false — processes not cleaned up in time")
+	}
+
+	// Verify both report stopped (terminal status persists)
+	for i := 0; i < 2; i++ {
+		st := exec.GetStatus(fmt.Sprintf("test-stopall-%d", i))
+		if st.State != RunStateStopped {
+			t.Errorf("profile %d state = %q, want %q", i, st.State, RunStateStopped)
+		}
+	}
+}
+
+func TestExecutor_GetStatusRunning(t *testing.T) {
+	exec := NewExecutor(nil, nil)
+	dir := t.TempDir()
+
+	profile := newTestProfile("test-getstatus", "sleep 60")
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+	defer exec.Stop("test-getstatus") //nolint:errcheck
+
+	// Brief pause for the start goroutine
+	time.Sleep(50 * time.Millisecond)
+
+	st := exec.GetStatus("test-getstatus")
+	if st.State != RunStateRunning {
+		t.Errorf("state = %q, want %q", st.State, RunStateRunning)
+	}
+	if st.Pid == 0 {
+		t.Error("pid should be non-zero for a running process")
+	}
+}
+
+func TestExecutor_GetStatusAfterSuccess(t *testing.T) {
+	spy := &emitSpy{}
+	exec := NewExecutor(spy.emit, nil)
+	dir := t.TempDir()
+
+	profile := newTestProfile("test-persist", "echo done")
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := spy.waitForState(RunStateSuccess, 5*time.Second); !ok {
+		t.Fatal("timed out waiting for success state")
+	}
+
+	st := exec.GetStatus("test-persist")
+	if st.State != RunStateSuccess {
+		t.Errorf("state = %q, want %q — terminal status should persist", st.State, RunStateSuccess)
+	}
+	if st.ExitCode != 0 {
+		t.Errorf("exit code = %d, want 0", st.ExitCode)
+	}
+}
+
+func TestExecutor_GetStatusAfterFailure(t *testing.T) {
+	spy := &emitSpy{}
+	exec := NewExecutor(spy.emit, nil)
+	dir := t.TempDir()
+
+	profile := newTestProfile("test-fail-persist", "exit 42")
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := spy.waitForState(RunStateFailed, 5*time.Second); !ok {
+		t.Fatal("timed out waiting for failed state")
+	}
+
+	st := exec.GetStatus("test-fail-persist")
+	if st.State != RunStateFailed {
+		t.Errorf("state = %q, want %q", st.State, RunStateFailed)
+	}
+	if st.ExitCode != 42 {
+		t.Errorf("exit code = %d, want 42", st.ExitCode)
+	}
+}
+
+func TestExecutor_GetStatusClearedOnRestart(t *testing.T) {
+	spy := &emitSpy{}
+	exec := NewExecutor(spy.emit, nil)
+	dir := t.TempDir()
+
+	// Run a failing profile
+	profile := newTestProfile("test-clear", "exit 1")
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := spy.waitForState(RunStateFailed, 5*time.Second); !ok {
+		t.Fatal("timed out waiting for failed state")
+	}
+
+	// Terminal status should be failed
+	st := exec.GetStatus("test-clear")
+	if st.State != RunStateFailed {
+		t.Errorf("state = %q, want %q", st.State, RunStateFailed)
+	}
+
+	// Restart the same profile ID with a successful command
+	profile2 := newTestProfile("test-clear", "echo ok")
+	if err := exec.Start(dir, profile2); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := spy.waitForState(RunStateSuccess, 5*time.Second); !ok {
+		t.Fatal("timed out waiting for success state")
+	}
+
+	// Should now show success, not the old failed status
+	st = exec.GetStatus("test-clear")
+	if st.State != RunStateSuccess {
+		t.Errorf("state = %q, want %q — old terminal status should be cleared on restart", st.State, RunStateSuccess)
+	}
+}
+
+func TestExecutor_ClearTerminalStatuses(t *testing.T) {
+	spy := &emitSpy{}
+	exec := NewExecutor(spy.emit, nil)
+	dir := t.TempDir()
+
+	profile := newTestProfile("test-clear-all", "echo done")
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := spy.waitForState(RunStateSuccess, 5*time.Second); !ok {
+		t.Fatal("timed out waiting for success state")
+	}
+
+	// Terminal status should persist
+	st := exec.GetStatus("test-clear-all")
+	if st.State != RunStateSuccess {
+		t.Fatalf("state = %q, want %q", st.State, RunStateSuccess)
+	}
+
+	// Clear all terminal statuses (simulates workspace switch)
+	exec.ClearTerminalStatuses()
+
+	// Should now return idle
+	st = exec.GetStatus("test-clear-all")
+	if st.State != RunStateIdle {
+		t.Errorf("state = %q, want %q after ClearTerminalStatuses", st.State, RunStateIdle)
+	}
+}
+
+func TestExecutor_GetStatusIdle(t *testing.T) {
+	exec := NewExecutor(nil, nil)
+
+	st := exec.GetStatus("never-started")
+	if st.State != RunStateIdle {
+		t.Errorf("state = %q, want %q", st.State, RunStateIdle)
+	}
+	if st.ProfileID != "never-started" {
+		t.Errorf("profileID = %q, want %q", st.ProfileID, "never-started")
+	}
+}
+
+func TestExecutor_EmptyCommand(t *testing.T) {
+	exec := NewExecutor(nil, nil)
+	dir := t.TempDir()
+
+	profile := newTestProfile("test-empty", "")
+	err := exec.Start(dir, profile)
+	if err == nil {
+		t.Fatal("expected error for empty command")
+	}
+	if !strings.Contains(err.Error(), "no command") {
+		t.Errorf("error = %q, want 'no command'", err.Error())
+	}
+}
+
+func TestExecutor_NoWorkspaceRoot(t *testing.T) {
+	exec := NewExecutor(nil, nil)
+	profile := newTestProfile("test", "echo hello")
+	err := exec.Start("", profile)
+	if err == nil {
+		t.Fatal("expected error for empty workspace root")
+	}
+	if !strings.Contains(err.Error(), "no workspace loaded") {
+		t.Errorf("error = %q, want 'no workspace loaded'", err.Error())
+	}
+}
+
+func TestExecutor_OutputCallback(t *testing.T) {
+	spy := &emitSpy{}
+	out := &outputSpy{}
+	exec := NewExecutor(spy.emit, out.receive)
+	dir := t.TempDir()
+
+	profile := newTestProfile("test-output", "echo stdout_test && echo stderr_test >&2")
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := spy.waitForState(RunStateSuccess, 5*time.Second); !ok {
+		t.Fatal("timed out waiting for success state")
+	}
+
+	stdout := out.streamContent("stdout")
+	stderr := out.streamContent("stderr")
+	if !strings.Contains(stdout, "stdout_test") {
+		t.Errorf("stdout should contain 'stdout_test', got: %q", stdout)
+	}
+	if !strings.Contains(stderr, "stderr_test") {
+		t.Errorf("stderr should contain 'stderr_test', got: %q", stderr)
+	}
+}

--- a/internal/runprofile/executor_unix.go
+++ b/internal/runprofile/executor_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package runprofile
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func setSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func shellCommand(command string) *exec.Cmd {
+	return exec.Command("sh", "-c", command)
+}
+
+func killProcessGroup(pid int) error {
+	return syscall.Kill(-pid, syscall.SIGTERM)
+}
+
+func forceKillProcessGroup(pid int) error {
+	return syscall.Kill(-pid, syscall.SIGKILL)
+}

--- a/internal/runprofile/executor_windows.go
+++ b/internal/runprofile/executor_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package runprofile
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"syscall"
+)
+
+func setSysProcAttr(cmd *exec.Cmd) {
+	// CREATE_NEW_PROCESS_GROUP so the wrapper and its children share a group.
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+}
+
+func shellCommand(command string) *exec.Cmd {
+	return exec.Command("cmd", "/C", command)
+}
+
+// killProcessGroup performs a graceful tree kill via taskkill /T (tree) without /F (force).
+// taskkill /T terminates the process and all child processes spawned by it.
+func killProcessGroup(pid int) error {
+	kill := exec.Command("taskkill", "/T", "/PID", strconv.Itoa(pid))
+	if out, err := kill.CombinedOutput(); err != nil {
+		return fmt.Errorf("taskkill: %s: %w", out, err)
+	}
+	return nil
+}
+
+// forceKillProcessGroup performs a forced tree kill via taskkill /T /F.
+func forceKillProcessGroup(pid int) error {
+	kill := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(pid))
+	if out, err := kill.CombinedOutput(); err != nil {
+		return fmt.Errorf("taskkill /F: %s: %w", out, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Closes #59

- Implement core process runner for run profiles: `os/exec`-based executor with start/stop/restart, graceful SIGTERM-then-SIGKILL shutdown, and process group termination (Unix `Setpgid`/`SIGTERM` vs Windows `taskkill /T`)
- Environment layering merges os environ, `.env` file values, and inline profile vars with correct precedence; `.env` parser handles quoting, comments, `export` prefix, and empty values
- Terminal status retention in `GetRunStatus` so the frontend can observe `success`/`failed`/`stopped` after a process exits, cleared on workspace switch to prevent cross-project ID collisions
- Four new Wails bindings (`StartRunProfile`, `StopRunProfile`, `RestartRunProfile`, `GetRunStatus`) and `beforeClose` integration that stops all runners before app quit

## Test plan

- [x] `go test ./...` passes (all packages)
- [x] `go test -race ./internal/runprofile` passes (no data races)
- [x] `GOOS=windows go test -c ./internal/runprofile` cross-compiles successfully
- Manual testing deferred to #61 (Process Lifecycle UI) when frontend controls exist

Generated with [Claude Code](https://claude.com/claude-code)