### PR TITLE
feat: output streaming with four view modes (#60)

### DIFF
--- a/app.go
+++ b/app.go
@@ -68,7 +68,14 @@ func (a *App) startup(ctx context.Context) {
 		func(event string, data ...any) {
 			runtime.EventsEmit(a.ctx, event, data...)
 		},
-		nil, // outputFn — wired in #60 (Output Streaming)
+		func(profileID, stream, data string, timestamp int64) {
+			runtime.EventsEmit(a.ctx, "run:output", map[string]any{
+				"profileId": profileID,
+				"stream":    stream,
+				"data":      data,
+				"timestamp": timestamp,
+			})
+		},
 	)
 }
 

--- a/app.go
+++ b/app.go
@@ -414,6 +414,9 @@ func (a *App) StartRunProfile(profileID string) error {
 // StopRunProfile stops a running profile (SIGTERM → 3s → SIGKILL).
 // This is exposed to the frontend via Wails bindings.
 func (a *App) StopRunProfile(profileID string) error {
+	if a.executor == nil {
+		return fmt.Errorf("application not initialized")
+	}
 	return a.executor.Stop(profileID)
 }
 
@@ -431,6 +434,9 @@ func (a *App) RestartRunProfile(profileID string) error {
 // Returns RunStateIdle for profiles that are not running.
 // This is exposed to the frontend via Wails bindings.
 func (a *App) GetRunStatus(profileID string) runprofile.RunStatus {
+	if a.executor == nil {
+		return runprofile.RunStatus{ProfileID: profileID, State: runprofile.RunStateIdle}
+	}
 	return a.executor.GetStatus(profileID)
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "@codemirror/state": "^6.5.4",
         "@codemirror/view": "^6.39.12",
         "@lezer/highlight": "^1.2.3",
+        "@tanstack/react-virtual": "^3.13.22",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "devicons-react": "^1.5.0",
@@ -2765,6 +2766,33 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.22",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.22.tgz",
+      "integrity": "sha512-EaOrBBJLi3M0bTMQRjGkxLXRw7Gizwntoy5E2Q2UnSbML7Mo2a1P/Hfkw5tw9FLzK62bj34Jl6VNbQfRV6eJcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.22",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.22.tgz",
+      "integrity": "sha512-isuUGKsc5TAPDoHSbWTbl1SCil54zOS2MiWz/9GCWHPUQOvNTQx8qJEWC7UWR0lShhbK0Lmkcf0SZYxvch7G3g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "@codemirror/state": "^6.5.4",
     "@codemirror/view": "^6.39.12",
     "@lezer/highlight": "^1.2.3",
+    "@tanstack/react-virtual": "^3.13.22",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "devicons-react": "^1.5.0",

--- a/frontend/src/__tests__/hooks/useRunOutput.test.ts
+++ b/frontend/src/__tests__/hooks/useRunOutput.test.ts
@@ -1,0 +1,55 @@
+const mockEventsOn = jest
+  .fn<() => void, [string, (...args: unknown[]) => void]>()
+  .mockImplementation(() => jest.fn());
+
+jest.mock('../../../wailsjs/runtime/runtime', () => ({
+  EventsOn: mockEventsOn,
+}));
+
+jest.mock('../../../wailsjs/go/main/App', () => ({}));
+
+import { renderHook } from '@testing-library/react';
+import { useRunOutputListener } from '../../hooks/useRunOutput';
+import { useIDEStore } from '../../stores/ideStore';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useIDEStore.setState({
+    runOutputs: {},
+    activeRunOutputId: null,
+    runOutputViewMode: 'merged',
+    runOutputAutoScroll: true,
+  });
+});
+
+describe('useRunOutputListener', () => {
+  it('should subscribe to run:output and run:status events', () => {
+    renderHook(() => useRunOutputListener());
+
+    expect(mockEventsOn).toHaveBeenCalledWith('run:output', expect.any(Function));
+    expect(mockEventsOn).toHaveBeenCalledWith('run:status', expect.any(Function));
+  });
+
+  it('should clean up event listeners on unmount', () => {
+    const cleanupOutput = jest.fn();
+    const cleanupStatus = jest.fn();
+    mockEventsOn.mockReturnValueOnce(cleanupOutput).mockReturnValueOnce(cleanupStatus);
+
+    const { unmount } = renderHook(() => useRunOutputListener());
+    unmount();
+
+    expect(cleanupOutput).toHaveBeenCalled();
+    expect(cleanupStatus).toHaveBeenCalled();
+  });
+
+  it('should auto-select first running profile', () => {
+    renderHook(() => useRunOutputListener());
+
+    const statusCallback = mockEventsOn.mock.calls.find(([event]) => event === 'run:status')?.[1];
+
+    expect(statusCallback).toBeDefined();
+    statusCallback!({ profileId: 'test-1', state: 'running', exitCode: 0 });
+
+    expect(useIDEStore.getState().activeRunOutputId).toBe('test-1');
+  });
+});

--- a/frontend/src/components/Editor/Editor.module.css
+++ b/frontend/src/components/Editor/Editor.module.css
@@ -162,11 +162,21 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   text-align: center;
   color: var(--text-muted);
   padding: 40px;
   user-select: none;
+  overflow-y: auto;
+  /* Use margin:auto on children for centering instead of justify-content:center.
+     justify-content:center clips the top when content overflows, preventing scroll. */
+}
+
+.welcome > :first-child {
+  margin-top: auto;
+}
+
+.welcome > :last-child {
+  margin-bottom: auto;
 }
 
 .welcomeLogo {

--- a/frontend/src/components/RunOutput/DiffView.tsx
+++ b/frontend/src/components/RunOutput/DiffView.tsx
@@ -1,0 +1,85 @@
+import { useRef, useMemo } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import type { OutputEntry } from '../../types/runOutput';
+import { diffOutputLines } from '../../utils/diffOutput';
+import styles from './RunOutput.module.css';
+
+interface DiffViewProps {
+  entries: OutputEntry[];
+  previousEntries: OutputEntry[];
+}
+
+export function DiffView({ entries, previousEntries }: DiffViewProps) {
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const diffLines = useMemo(() => {
+    return diffOutputLines(
+      previousEntries.map((e) => e.text),
+      entries.map((e) => e.text)
+    );
+  }, [entries, previousEntries]);
+
+  const virtualizer = useVirtualizer({
+    count: diffLines.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 20,
+    overscan: 20,
+  });
+
+  if (previousEntries.length === 0) {
+    return (
+      <div className={styles.emptyState}>
+        <p>Run this profile again to see what changed</p>
+      </div>
+    );
+  }
+
+  if (diffLines.length === 1 && diffLines[0].type === 'too-large') {
+    return (
+      <div className={styles.emptyState}>
+        <p>Output too large to diff (both runs exceed 5,000 lines)</p>
+      </div>
+    );
+  }
+
+  const added = diffLines.filter((l) => l.type === 'added').length;
+  const removed = diffLines.filter((l) => l.type === 'removed').length;
+
+  return (
+    <div ref={parentRef} className={styles.outputContent}>
+      <div className={styles.diffHeader}>
+        <span className={styles.diffLabelPrev}>Previous run</span>
+        <span className={styles.diffArrow}>→</span>
+        <span className={styles.diffLabelCurr}>Current run</span>
+        <span className={styles.diffStats}>
+          {added} added, {removed} removed
+        </span>
+      </div>
+      <div style={{ height: `${virtualizer.getTotalSize()}px`, position: 'relative' }}>
+        {virtualizer.getVirtualItems().map((virtualRow) => {
+          const line = diffLines[virtualRow.index];
+          return (
+            <div
+              key={virtualRow.index}
+              className={`${styles.diffLine} ${styles[line.type]}`}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRow.start}px)`,
+              }}
+              ref={virtualizer.measureElement}
+              data-index={virtualRow.index}
+            >
+              <span className={styles.diffMarker}>
+                {line.type === 'added' ? '+' : line.type === 'removed' ? '−' : ' '}
+              </span>
+              {line.text}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/RunOutput/DiffView.tsx
+++ b/frontend/src/components/RunOutput/DiffView.tsx
@@ -37,7 +37,7 @@ export function DiffView({ entries, previousEntries }: DiffViewProps) {
   if (diffLines.length === 1 && diffLines[0].type === 'too-large') {
     return (
       <div className={styles.emptyState}>
-        <p>Output too large to diff (both runs exceed 5,000 lines)</p>
+        <p>Output too large to diff</p>
       </div>
     );
   }

--- a/frontend/src/components/RunOutput/LanesView.tsx
+++ b/frontend/src/components/RunOutput/LanesView.tsx
@@ -1,0 +1,88 @@
+import { useRef, useEffect, useMemo } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import type { OutputEntry } from '../../types/runOutput';
+import styles from './RunOutput.module.css';
+
+interface LanesViewProps {
+  entries: OutputEntry[];
+  autoScroll: boolean;
+}
+
+interface LaneRow {
+  stdout: string | null;
+  stderr: string | null;
+}
+
+export function LanesView({ entries, autoScroll }: LanesViewProps) {
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const rows = useMemo(() => {
+    return entries.map(
+      (entry): LaneRow => ({
+        stdout: entry.stream === 'stdout' ? entry.text : null,
+        stderr: entry.stream === 'stderr' ? entry.text : null,
+      })
+    );
+  }, [entries]);
+
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 20,
+    overscan: 20,
+  });
+
+  useEffect(() => {
+    if (autoScroll && rows.length > 0) {
+      virtualizer.scrollToIndex(rows.length - 1, { align: 'end' });
+    }
+  }, [rows.length, autoScroll, virtualizer]);
+
+  if (entries.length === 0) {
+    return (
+      <div className={styles.emptyState}>
+        <p>No output to display</p>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={parentRef} className={styles.outputContent}>
+      <div className={styles.laneHeaders}>
+        <div className={`${styles.laneHeader} ${styles.stdoutHeader}`}>
+          <span className={styles.laneDot} />
+          stdout
+        </div>
+        <div className={`${styles.laneHeader} ${styles.stderrHeader}`}>
+          <span className={styles.laneDot} />
+          stderr
+        </div>
+      </div>
+      <div style={{ height: `${virtualizer.getTotalSize()}px`, position: 'relative' }}>
+        {virtualizer.getVirtualItems().map((virtualRow) => {
+          const row = rows[virtualRow.index];
+          return (
+            <div
+              key={virtualRow.index}
+              className={styles.laneRow}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRow.start}px)`,
+              }}
+              ref={virtualizer.measureElement}
+              data-index={virtualRow.index}
+            >
+              <div className={styles.laneLine}>{row.stdout ?? ''}</div>
+              <div className={`${styles.laneLine} ${row.stderr != null ? styles.stderr : ''}`}>
+                {row.stderr ?? ''}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/RunOutput/MergedView.tsx
+++ b/frontend/src/components/RunOutput/MergedView.tsx
@@ -1,0 +1,76 @@
+import { useRef, useEffect, useMemo } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import type { OutputEntry } from '../../types/runOutput';
+import { isFoldedRegion } from '../../types/runOutput';
+import { foldOutput } from '../../utils/foldOutput';
+import { SmartFold } from './SmartFold';
+import styles from './RunOutput.module.css';
+
+interface MergedViewProps {
+  entries: OutputEntry[];
+  autoScroll: boolean;
+  expandedFolds: Set<string>;
+  onToggleFold: (foldId: string) => void;
+}
+
+export function MergedView({ entries, autoScroll, expandedFolds, onToggleFold }: MergedViewProps) {
+  const parentRef = useRef<HTMLDivElement>(null);
+  const items = useMemo(() => foldOutput(entries), [entries]);
+
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 20,
+    overscan: 20,
+  });
+
+  useEffect(() => {
+    if (autoScroll && items.length > 0) {
+      virtualizer.scrollToIndex(items.length - 1, { align: 'end' });
+    }
+  }, [items.length, autoScroll, virtualizer]);
+
+  if (entries.length === 0) {
+    return (
+      <div className={styles.emptyState}>
+        <p>No output to display</p>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={parentRef} className={styles.outputContent}>
+      <div
+        style={{ height: `${virtualizer.getTotalSize()}px`, width: '100%', position: 'relative' }}
+      >
+        {virtualizer.getVirtualItems().map((virtualRow) => {
+          const item = items[virtualRow.index];
+          return (
+            <div
+              key={virtualRow.index}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRow.start}px)`,
+              }}
+              ref={virtualizer.measureElement}
+              data-index={virtualRow.index}
+            >
+              {isFoldedRegion(item) ? (
+                <SmartFold
+                  fold={item}
+                  isExpanded={expandedFolds.has(item.id)}
+                  onToggle={onToggleFold}
+                />
+              ) : (
+                <div className={`${styles.outputLine} ${styles[item.stream]}`}>{item.text}</div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/RunOutput/RunOutput.module.css
+++ b/frontend/src/components/RunOutput/RunOutput.module.css
@@ -211,26 +211,27 @@
 
 /* ── Lanes View ────────────────────────────────────────── */
 .lanesView {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+  display: flex;
+  flex-direction: column;
   height: 100%;
   flex: 1;
   overflow: hidden;
 }
 
 .laneHeaders {
-  display: contents; /* used as sticky row via separate sticky divs */
+  display: flex;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: #040406;
 }
 
 .laneHeader {
-  position: sticky;
-  top: 0;
-  z-index: 1;
+  flex: 1;
   display: flex;
   align-items: center;
   gap: 6px;
   padding: 4px 14px 6px;
-  background: #040406;
   font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
@@ -261,11 +262,13 @@
 }
 
 .laneRow {
-  display: contents;
+  display: flex;
 }
 
 .laneLine {
+  flex: 1;
   min-height: 20px;
+  min-width: 0;
   white-space: pre-wrap;
   word-break: break-all;
   color: #e2e8f0;

--- a/frontend/src/components/RunOutput/RunOutput.module.css
+++ b/frontend/src/components/RunOutput/RunOutput.module.css
@@ -1,0 +1,584 @@
+/* ═══════════════════════════════════════════════════════════════
+   RunOutput Panel — CSS Module
+   Firn Glacier Theme: deep navy/slate surfaces, glacier blue accents
+═══════════════════════════════════════════════════════════════ */
+
+/* ── Panel Container ──────────────────────────────────────── */
+.panelContainer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* ── Toolbar ──────────────────────────────────────────────── */
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background: var(--surface-elevated);
+  border-bottom: 1px solid color-mix(in srgb, var(--accent) 8%, transparent);
+  height: 32px;
+  flex-shrink: 0;
+}
+
+/* ── View Mode Segmented Button Group ─────────────────────── */
+.viewModeGroup {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  background: color-mix(in srgb, var(--accent) 5%, transparent);
+  border-radius: 5px;
+  padding: 1px;
+  border: 1px solid color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
+.viewModeBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 22px;
+  padding: 0 10px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 500;
+  font-family: var(--font-ui);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.viewModeBtn:hover {
+  color: var(--text-primary);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
+.viewModeBtn.active {
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  color: var(--accent);
+}
+
+/* ── Toolbar Action Buttons ───────────────────────────────── */
+.toolbarBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition);
+  flex-shrink: 0;
+}
+
+.toolbarBtn svg {
+  width: 13px;
+  height: 13px;
+}
+
+.toolbarBtn:hover {
+  color: var(--text-primary);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
+.toolbarBtn.danger {
+  color: var(--status-error);
+}
+
+.toolbarBtn.danger:hover {
+  color: var(--status-error);
+  background: rgba(239, 68, 68, 0.12);
+}
+
+.toolbarBtn:disabled {
+  color: var(--text-disabled);
+  cursor: not-allowed;
+  pointer-events: none;
+  opacity: 0.4;
+}
+
+/* ── Toolbar Divider ─────────────────────────────────────── */
+.toolbarDivider {
+  width: 1px;
+  height: 16px;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* ── Toolbar Spacer ─────────────────────────────────────── */
+.toolbarSpacer {
+  flex: 1;
+}
+
+/* ── Auto-scroll Indicator ─────────────────────────────── */
+.autoscrollIndicator {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 24px;
+  padding: 0 8px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  font-size: 10px;
+  font-family: var(--font-ui);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--transition);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.autoscrollIndicator:hover {
+  color: var(--text-secondary);
+  background: color-mix(in srgb, var(--accent) 6%, transparent);
+}
+
+.autoscrollIndicator.pinned {
+  color: var(--accent);
+}
+
+.autoscrollDot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  flex-shrink: 0;
+  transition: background var(--transition);
+}
+
+.autoscrollIndicator.pinned .autoscrollDot {
+  background: var(--accent);
+}
+
+/* ── Output Content Area ───────────────────────────────── */
+.outputContent {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: #040406; /* Glacier glow — near-black void, matches terminal */
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.5;
+  padding: 8px 14px;
+}
+
+.outputContent::-webkit-scrollbar {
+  width: 8px;
+}
+
+.outputContent::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.outputContent::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  border-radius: 4px;
+}
+
+.outputContent::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+/* ── Output Lines ──────────────────────────────────────── */
+.outputLine {
+  min-height: 20px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.outputLine.stdout {
+  color: #e2e8f0;
+}
+
+.outputLine.stderr {
+  color: #fca5a5;
+  border-left: 2px solid rgba(239, 68, 68, 0.4);
+  padding-left: 8px;
+}
+
+/* ── Lanes View ────────────────────────────────────────── */
+.lanesView {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  height: 100%;
+  flex: 1;
+  overflow: hidden;
+}
+
+.laneHeaders {
+  display: contents; /* used as sticky row via separate sticky divs */
+}
+
+.laneHeader {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 14px 6px;
+  background: #040406;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-muted);
+  border-bottom: 1px solid color-mix(in srgb, var(--accent) 6%, transparent);
+}
+
+.stdoutHeader .laneDot {
+  background: var(--accent);
+  opacity: 0.6;
+}
+
+.stderrHeader .laneDot {
+  background: var(--status-error);
+  opacity: 0.6;
+}
+
+.stderrHeader {
+  border-left: 1px solid color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
+.laneDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.laneRow {
+  display: contents;
+}
+
+.laneLine {
+  min-height: 20px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: #e2e8f0;
+  padding: 0 14px;
+}
+
+.laneLine.stderr {
+  color: #fca5a5;
+  border-left: 1px solid color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
+/* ── Diff View ─────────────────────────────────────────── */
+.diffView {
+  padding: 8px 14px;
+}
+
+.diffHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  margin-bottom: 8px;
+  background: color-mix(in srgb, var(--accent) 4%, transparent);
+  border-radius: 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.diffLabelPrev {
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 10px;
+  font-weight: 500;
+  background: rgba(239, 68, 68, 0.1);
+  color: #fca5a5;
+}
+
+.diffLabelCurr {
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 10px;
+  font-weight: 500;
+  background: rgba(34, 197, 94, 0.1);
+  color: #86efac;
+}
+
+.diffArrow {
+  color: var(--text-disabled);
+}
+
+.diffStats {
+  color: var(--text-muted);
+  font-size: 10px;
+  margin-left: auto;
+}
+
+.diffLine {
+  min-height: 20px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  padding: 0 4px;
+  border-radius: 2px;
+}
+
+.diffLine.unchanged {
+  color: var(--text-secondary);
+}
+
+.diffLine.added {
+  color: #86efac;
+  background: rgba(34, 197, 94, 0.08);
+  border-left: 2px solid rgba(34, 197, 94, 0.4);
+  padding-left: 8px;
+}
+
+.diffLine.removed {
+  color: var(--text-disabled);
+  background: rgba(239, 68, 68, 0.04);
+  border-left: 2px solid rgba(239, 68, 68, 0.2);
+  padding-left: 8px;
+  text-decoration: line-through;
+  text-decoration-color: rgba(239, 68, 68, 0.3);
+}
+
+.diffLine.too-large {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.diffMarker {
+  display: inline-block;
+  width: 14px;
+  font-weight: 600;
+  font-size: 12px;
+  flex-shrink: 0;
+  user-select: none;
+}
+
+/* ── Timeline View ─────────────────────────────────────── */
+.timelineView {
+  padding: 8px 14px;
+}
+
+.timelineLine {
+  display: flex;
+  gap: 8px;
+  min-height: 20px;
+  white-space: pre-wrap;
+  align-items: flex-start;
+}
+
+.timelineTimestamp {
+  color: var(--text-disabled);
+  font-size: 11px;
+  flex-shrink: 0;
+  width: 90px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+}
+
+.timelineProfile {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 3px;
+  flex-shrink: 0;
+  min-width: 60px;
+  text-align: center;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.timelineProfile.frontend {
+  background: rgba(56, 189, 248, 0.12);
+  color: var(--accent);
+}
+
+.timelineProfile.backend {
+  background: rgba(168, 85, 247, 0.12);
+  color: #d8b4fe;
+}
+
+.timelineProfile.lint {
+  background: rgba(245, 158, 11, 0.12);
+  color: #fde68a;
+}
+
+.timelineProfile.test {
+  background: rgba(34, 197, 94, 0.12);
+  color: #86efac;
+}
+
+.timelineProfile.deploy {
+  background: rgba(6, 182, 212, 0.12);
+  color: #67e8f9;
+}
+
+.timelineData {
+  flex: 1;
+  color: #e2e8f0;
+  word-break: break-all;
+}
+
+.timelineData.stderr {
+  color: #fca5a5;
+}
+
+/* ── Smart Fold (Collapsed) ────────────────────────────── */
+.foldRegion {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 12px;
+  margin: 4px 0;
+  background: color-mix(in srgb, var(--accent) 4%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 8%, transparent);
+  border-radius: 4px;
+  color: var(--text-muted);
+  font-size: 11px;
+  cursor: pointer;
+  transition: all var(--transition);
+  user-select: none;
+}
+
+.foldRegion:hover {
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  color: var(--text-secondary);
+  border-color: color-mix(in srgb, var(--accent) 15%, transparent);
+}
+
+.foldRegion:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+/* ── Fold Chevron ─────────────────────────────────────── */
+.foldChevron {
+  font-size: 10px;
+  color: var(--accent);
+  opacity: 0.5;
+  transition:
+    transform var(--transition),
+    opacity var(--transition);
+  flex-shrink: 0;
+}
+
+.foldRegion:hover .foldChevron {
+  opacity: 1;
+}
+
+.foldChevronOpen {
+  transform: rotate(90deg);
+  opacity: 0.7;
+}
+
+/* ── Fold Summary ─────────────────────────────────────── */
+.foldSummary {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Fold Count Badge ─────────────────────────────────── */
+.foldCount {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 1px 6px;
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  border-radius: 3px;
+  color: var(--accent);
+  opacity: 0.6;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+/* ── Expanded Fold ────────────────────────────────────── */
+.foldExpanded {
+  margin: 4px 0;
+  border: 1px solid color-mix(in srgb, var(--accent) 8%, transparent);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.foldExpandedHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 12px;
+  background: color-mix(in srgb, var(--accent) 6%, transparent);
+  color: var(--text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+  border-bottom: 1px solid color-mix(in srgb, var(--accent) 6%, transparent);
+  transition: all var(--transition);
+  user-select: none;
+}
+
+.foldExpandedHeader:hover {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.foldExpandedHeader:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.foldExpandedBody {
+  padding: 4px 14px;
+  max-height: 120px;
+  overflow-y: auto;
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.foldExpandedBody .outputLine {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.foldExpandedBody::-webkit-scrollbar {
+  width: 6px;
+}
+
+.foldExpandedBody::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.foldExpandedBody::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border-radius: 3px;
+}
+
+/* ── Empty State ────────────────────────────────────────── */
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  height: 100%;
+  gap: 8px;
+  color: color-mix(in srgb, var(--accent) 35%, transparent);
+  font-size: 12px;
+  font-family: var(--font-ui);
+  background: #040406;
+}
+
+.emptyState p {
+  margin: 0;
+}

--- a/frontend/src/components/RunOutput/RunOutputPanel.tsx
+++ b/frontend/src/components/RunOutput/RunOutputPanel.tsx
@@ -1,0 +1,66 @@
+import { useState, useCallback } from 'react';
+import {
+  useActiveRunOutput,
+  useRunOutputViewMode,
+  useRunOutputAutoScroll,
+  useRunOutputs,
+} from '../../stores/ideStore';
+import { RunOutputToolbar } from './RunOutputToolbar';
+import { MergedView } from './MergedView';
+import { LanesView } from './LanesView';
+import { DiffView } from './DiffView';
+import { TimelineView } from './TimelineView';
+import styles from './RunOutput.module.css';
+
+export function RunOutputPanel() {
+  const activeOutput = useActiveRunOutput();
+  const viewMode = useRunOutputViewMode();
+  const autoScroll = useRunOutputAutoScroll();
+  const runOutputs = useRunOutputs();
+  const [expandedFolds, setExpandedFolds] = useState<Set<string>>(new Set());
+
+  const handleToggleFold = useCallback((foldId: string) => {
+    setExpandedFolds((prev) => {
+      const next = new Set(prev);
+      if (next.has(foldId)) {
+        next.delete(foldId);
+      } else {
+        next.add(foldId);
+      }
+      return next;
+    });
+  }, []);
+
+  return (
+    <div className={styles.panelContainer}>
+      <RunOutputToolbar />
+      {viewMode === 'timeline' ? (
+        <TimelineView runOutputs={runOutputs} autoScroll={autoScroll} />
+      ) : activeOutput ? (
+        <>
+          {viewMode === 'merged' && (
+            <MergedView
+              entries={activeOutput.entries}
+              autoScroll={autoScroll}
+              expandedFolds={expandedFolds}
+              onToggleFold={handleToggleFold}
+            />
+          )}
+          {viewMode === 'lanes' && (
+            <LanesView entries={activeOutput.entries} autoScroll={autoScroll} />
+          )}
+          {viewMode === 'diff' && (
+            <DiffView
+              entries={activeOutput.entries}
+              previousEntries={activeOutput.previousEntries}
+            />
+          )}
+        </>
+      ) : (
+        <div className={styles.emptyState}>
+          <p>Run a profile to see output here</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/RunOutput/RunOutputToolbar.tsx
+++ b/frontend/src/components/RunOutput/RunOutputToolbar.tsx
@@ -1,0 +1,152 @@
+import {
+  useIDEStore,
+  useRunOutputViewMode,
+  useRunOutputAutoScroll,
+  useActiveRunOutputId,
+} from '../../stores/ideStore';
+import { RestartRunProfile, StopRunProfile } from '../../../wailsjs/go/main/App';
+import { ALL_PROFILES_ID } from '../../types/runOutput';
+import type { RunOutputViewMode } from '../../types/runOutput';
+import styles from './RunOutput.module.css';
+
+const VIEW_MODES: Array<{ id: RunOutputViewMode; label: string }> = [
+  { id: 'merged', label: 'Merged' },
+  { id: 'lanes', label: 'Lanes' },
+  { id: 'diff', label: 'Diff' },
+  { id: 'timeline', label: 'Timeline' },
+];
+
+export function RunOutputToolbar() {
+  const viewMode = useRunOutputViewMode();
+  const autoScroll = useRunOutputAutoScroll();
+  const activeId = useActiveRunOutputId();
+  const setViewMode = useIDEStore((s) => s.setRunOutputViewMode);
+  const toggleAutoScroll = useIDEStore((s) => s.toggleAutoScroll);
+  const clearRunOutput = useIDEStore((s) => s.clearRunOutput);
+  const clearAllRunOutputs = useIDEStore((s) => s.clearAllRunOutputs);
+  const setActiveRunOutput = useIDEStore((s) => s.setActiveRunOutput);
+  const runOutputs = useIDEStore((s) => s.runOutputs);
+
+  const isAllProfiles = activeId === ALL_PROFILES_ID;
+  const hasActiveProfile = activeId && !isAllProfiles;
+
+  const handleViewMode = (mode: RunOutputViewMode) => {
+    setViewMode(mode);
+    if (mode === 'timeline') {
+      setActiveRunOutput(ALL_PROFILES_ID);
+    } else if (isAllProfiles) {
+      const firstId = Object.keys(runOutputs)[0];
+      if (firstId) setActiveRunOutput(firstId);
+    }
+  };
+
+  const handleRerun = () => {
+    if (hasActiveProfile) {
+      RestartRunProfile(activeId).catch(() => {});
+    }
+  };
+
+  const handleStop = () => {
+    if (hasActiveProfile) {
+      StopRunProfile(activeId).catch(() => {});
+    }
+  };
+
+  const handleClear = () => {
+    if (isAllProfiles) {
+      clearAllRunOutputs();
+    } else if (activeId) {
+      clearRunOutput(activeId);
+    }
+  };
+
+  return (
+    <div className={styles.toolbar}>
+      <div className={styles.viewModeGroup}>
+        {VIEW_MODES.map(({ id, label }) => (
+          <button
+            key={id}
+            className={`${styles.viewModeBtn} ${viewMode === id ? styles.active : ''}`}
+            onClick={() => handleViewMode(id)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div className={styles.toolbarDivider} />
+
+      <button
+        className={styles.toolbarBtn}
+        onClick={handleRerun}
+        disabled={!hasActiveProfile}
+        title="Re-run"
+        aria-label="Re-run profile"
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <polyline points="23 4 23 10 17 10" />
+          <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+        </svg>
+      </button>
+
+      <button
+        className={`${styles.toolbarBtn} ${styles.danger}`}
+        onClick={handleStop}
+        disabled={!hasActiveProfile}
+        title="Stop"
+        aria-label="Stop profile"
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <rect x="6" y="6" width="12" height="12" rx="2" />
+        </svg>
+      </button>
+
+      <button
+        className={styles.toolbarBtn}
+        onClick={handleClear}
+        disabled={!activeId}
+        title="Clear output"
+        aria-label="Clear output"
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M3 6h18" />
+          <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+          <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+        </svg>
+      </button>
+
+      <div className={styles.toolbarSpacer} />
+
+      <button
+        className={`${styles.autoscrollIndicator} ${autoScroll ? styles.pinned : ''}`}
+        onClick={toggleAutoScroll}
+        title={autoScroll ? 'Auto-scroll enabled' : 'Auto-scroll disabled'}
+        aria-label="Toggle auto-scroll"
+      >
+        <span className={styles.autoscrollDot} />
+        Auto-scroll
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/RunOutput/RunOutputToolbar.tsx
+++ b/frontend/src/components/RunOutput/RunOutputToolbar.tsx
@@ -34,13 +34,19 @@ export function RunOutputToolbar() {
 
   const isAllProfiles = activeId === ALL_PROFILES_ID;
   const hasActiveProfile = activeId && !isAllProfiles;
+  const activeOutput = hasActiveProfile ? runOutputs[activeId] : undefined;
+  const isRunning = activeOutput?.state === 'running';
+  const outputIds = Object.keys(runOutputs);
+  const canTimeline = outputIds.length >= 2;
 
   const handleViewMode = (mode: RunOutputViewMode) => {
+    // Gate timeline mode: only allow with 2+ profiles
+    if (mode === 'timeline' && !canTimeline) return;
     setViewMode(mode);
     if (mode === 'timeline') {
       setActiveRunOutput(ALL_PROFILES_ID);
     } else if (isAllProfiles) {
-      const firstId = Object.keys(runOutputs)[0];
+      const firstId = outputIds[0];
       if (firstId) setActiveRunOutput(firstId);
     }
   };
@@ -52,7 +58,7 @@ export function RunOutputToolbar() {
   };
 
   const handleStop = () => {
-    if (hasActiveProfile) {
+    if (hasActiveProfile && isRunning) {
       StopRunProfile(activeId).catch((err: unknown) => showError('stop', activeId, err));
     }
   };
@@ -73,6 +79,7 @@ export function RunOutputToolbar() {
             key={id}
             className={`${styles.viewModeBtn} ${viewMode === id ? styles.active : ''}`}
             onClick={() => handleViewMode(id)}
+            disabled={id === 'timeline' && !canTimeline}
           >
             {label}
           </button>
@@ -104,7 +111,7 @@ export function RunOutputToolbar() {
       <button
         className={`${styles.toolbarBtn} ${styles.danger}`}
         onClick={handleStop}
-        disabled={!hasActiveProfile}
+        disabled={!isRunning}
         title="Stop"
         aria-label="Stop profile"
       >

--- a/frontend/src/components/RunOutput/RunOutputToolbar.tsx
+++ b/frontend/src/components/RunOutput/RunOutputToolbar.tsx
@@ -9,6 +9,11 @@ import { ALL_PROFILES_ID } from '../../types/runOutput';
 import type { RunOutputViewMode } from '../../types/runOutput';
 import styles from './RunOutput.module.css';
 
+function showError(action: string, profileId: string, err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+  useIDEStore.getState().showToast(`Failed to ${action} "${profileId}": ${message}`, 'error');
+}
+
 const VIEW_MODES: Array<{ id: RunOutputViewMode; label: string }> = [
   { id: 'merged', label: 'Merged' },
   { id: 'lanes', label: 'Lanes' },
@@ -42,13 +47,13 @@ export function RunOutputToolbar() {
 
   const handleRerun = () => {
     if (hasActiveProfile) {
-      RestartRunProfile(activeId).catch(() => {});
+      RestartRunProfile(activeId).catch((err: unknown) => showError('restart', activeId, err));
     }
   };
 
   const handleStop = () => {
     if (hasActiveProfile) {
-      StopRunProfile(activeId).catch(() => {});
+      StopRunProfile(activeId).catch((err: unknown) => showError('stop', activeId, err));
     }
   };
 

--- a/frontend/src/components/RunOutput/SmartFold.tsx
+++ b/frontend/src/components/RunOutput/SmartFold.tsx
@@ -1,0 +1,62 @@
+import type { FoldedRegion } from '../../types/runOutput';
+import styles from './RunOutput.module.css';
+
+interface SmartFoldProps {
+  fold: FoldedRegion;
+  isExpanded: boolean;
+  onToggle: (foldId: string) => void;
+}
+
+export function SmartFold({ fold, isExpanded, onToggle }: SmartFoldProps) {
+  if (!isExpanded) {
+    return (
+      <div
+        className={styles.foldRegion}
+        onClick={() => onToggle(fold.id)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onToggle(fold.id);
+          }
+        }}
+        aria-expanded={false}
+        aria-label={`${fold.summary} (${fold.lineCount} lines, click to expand)`}
+      >
+        <span className={styles.foldChevron}>▶</span>
+        <span className={styles.foldSummary}>{fold.summary}</span>
+        <span className={styles.foldCount}>{fold.lineCount} lines</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.foldExpanded}>
+      <div
+        className={styles.foldExpandedHeader}
+        onClick={() => onToggle(fold.id)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onToggle(fold.id);
+          }
+        }}
+        aria-expanded={true}
+      >
+        <span className={`${styles.foldChevron} ${styles.foldChevronOpen}`}>▶</span>
+        <span className={styles.foldSummary}>{fold.summary}</span>
+        <span className={styles.foldCount}>{fold.lineCount} lines</span>
+      </div>
+      <div className={styles.foldExpandedBody}>
+        {fold.entries.map((entry, idx) => (
+          <div key={idx} className={`${styles.outputLine} ${styles[entry.stream]}`}>
+            {entry.text}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/RunOutput/TimelineView.tsx
+++ b/frontend/src/components/RunOutput/TimelineView.tsx
@@ -12,7 +12,7 @@ interface TimelineEntry extends OutputEntry {
   profileId: string;
 }
 
-const PROFILE_COLORS = ['frontend', 'backend', 'lint', 'test', 'deploy'] as const;
+const PROFILE_COLOR_CLASSES = ['frontend', 'backend', 'lint', 'test', 'deploy'] as const;
 
 function formatTimestamp(ts: number): string {
   const d = new Date(ts);
@@ -22,6 +22,13 @@ function formatTimestamp(ts: number): string {
 export function TimelineView({ runOutputs, autoScroll }: TimelineViewProps) {
   const parentRef = useRef<HTMLDivElement>(null);
   const profileIds = useMemo(() => Object.keys(runOutputs), [runOutputs]);
+  const profileColorMap = useMemo(() => {
+    const map = new Map<string, string>();
+    profileIds.forEach((id, idx) => {
+      map.set(id, PROFILE_COLOR_CLASSES[idx % PROFILE_COLOR_CLASSES.length]);
+    });
+    return map;
+  }, [profileIds]);
 
   const entries = useMemo(() => {
     const all: TimelineEntry[] = [];
@@ -61,8 +68,7 @@ export function TimelineView({ runOutputs, autoScroll }: TimelineViewProps) {
       <div style={{ height: `${virtualizer.getTotalSize()}px`, position: 'relative' }}>
         {virtualizer.getVirtualItems().map((virtualRow) => {
           const entry = entries[virtualRow.index];
-          const colorIdx = profileIds.indexOf(entry.profileId);
-          const colorClass = PROFILE_COLORS[colorIdx % PROFILE_COLORS.length];
+          const colorClass = profileColorMap.get(entry.profileId) ?? PROFILE_COLOR_CLASSES[0];
           return (
             <div
               key={virtualRow.index}

--- a/frontend/src/components/RunOutput/TimelineView.tsx
+++ b/frontend/src/components/RunOutput/TimelineView.tsx
@@ -1,0 +1,95 @@
+import { useRef, useEffect, useMemo } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import type { RunOutput, OutputEntry } from '../../types/runOutput';
+import styles from './RunOutput.module.css';
+
+interface TimelineViewProps {
+  runOutputs: Record<string, RunOutput>;
+  autoScroll: boolean;
+}
+
+interface TimelineEntry extends OutputEntry {
+  profileId: string;
+}
+
+const PROFILE_COLORS = ['frontend', 'backend', 'lint', 'test', 'deploy'] as const;
+
+function formatTimestamp(ts: number): string {
+  const d = new Date(ts);
+  return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}:${d.getSeconds().toString().padStart(2, '0')}.${d.getMilliseconds().toString().padStart(3, '0')}`;
+}
+
+export function TimelineView({ runOutputs, autoScroll }: TimelineViewProps) {
+  const parentRef = useRef<HTMLDivElement>(null);
+  const profileIds = useMemo(() => Object.keys(runOutputs), [runOutputs]);
+
+  const entries = useMemo(() => {
+    const all: TimelineEntry[] = [];
+    for (const id of profileIds) {
+      const output = runOutputs[id];
+      for (const entry of output.entries) {
+        all.push({ ...entry, profileId: output.profileId });
+      }
+    }
+    all.sort((a, b) => a.timestamp - b.timestamp);
+    return all;
+  }, [runOutputs, profileIds]);
+
+  const virtualizer = useVirtualizer({
+    count: entries.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 20,
+    overscan: 20,
+  });
+
+  useEffect(() => {
+    if (autoScroll && entries.length > 0) {
+      virtualizer.scrollToIndex(entries.length - 1, { align: 'end' });
+    }
+  }, [entries.length, autoScroll, virtualizer]);
+
+  if (entries.length === 0) {
+    return (
+      <div className={styles.emptyState}>
+        <p>No output from any profile</p>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={parentRef} className={styles.outputContent}>
+      <div style={{ height: `${virtualizer.getTotalSize()}px`, position: 'relative' }}>
+        {virtualizer.getVirtualItems().map((virtualRow) => {
+          const entry = entries[virtualRow.index];
+          const colorIdx = profileIds.indexOf(entry.profileId);
+          const colorClass = PROFILE_COLORS[colorIdx % PROFILE_COLORS.length];
+          return (
+            <div
+              key={virtualRow.index}
+              className={styles.timelineLine}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRow.start}px)`,
+              }}
+              ref={virtualizer.measureElement}
+              data-index={virtualRow.index}
+            >
+              <span className={styles.timelineTimestamp}>{formatTimestamp(entry.timestamp)}</span>
+              <span className={`${styles.timelineProfile} ${styles[colorClass]}`}>
+                {entry.profileId}
+              </span>
+              <span
+                className={`${styles.timelineData} ${entry.stream === 'stderr' ? styles.stderr : ''}`}
+              >
+                {entry.text}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/RunOutput/index.ts
+++ b/frontend/src/components/RunOutput/index.ts
@@ -1,0 +1,7 @@
+export { RunOutputPanel } from './RunOutputPanel';
+export { RunOutputToolbar } from './RunOutputToolbar';
+export { MergedView } from './MergedView';
+export { LanesView } from './LanesView';
+export { DiffView } from './DiffView';
+export { TimelineView } from './TimelineView';
+export { SmartFold } from './SmartFold';

--- a/frontend/src/components/Terminal/Terminal.module.css
+++ b/frontend/src/components/Terminal/Terminal.module.css
@@ -342,3 +342,40 @@
   background: rgba(239, 68, 68, 0.12);
   color: var(--status-error);
 }
+
+/* ── Run output state dots ──────────────────────────────────────── */
+.stateDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.stateRunning {
+  background: var(--status-success);
+  box-shadow: 0 0 6px rgba(34, 197, 94, 0.5);
+  animation: statePulse 2s ease-in-out infinite;
+}
+
+.stateSuccess {
+  background: var(--status-success);
+  opacity: 0.7;
+}
+
+.stateFailed {
+  background: var(--status-error);
+}
+
+.stateStopped {
+  background: var(--text-muted);
+}
+
+@keyframes statePulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}

--- a/frontend/src/components/Terminal/Terminal.tsx
+++ b/frontend/src/components/Terminal/Terminal.tsx
@@ -7,8 +7,13 @@ import {
   useWarningCount,
   useTerminalSessions,
   useActiveTerminalSessionId,
+  useRunOutputs,
+  useActiveRunOutputId,
 } from '../../stores/ideStore';
 import { useEffect, useRef, useState, useCallback } from 'react';
+import { useRunOutputListener } from '../../hooks/useRunOutput';
+import { RunOutputPanel } from '../RunOutput';
+import { ALL_PROFILES_ID } from '../../types/runOutput';
 import { Terminal as XTerm } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
@@ -116,6 +121,14 @@ export function Terminal() {
   const renameSession = useIDEStore((state) => state.renameTerminalSession);
   const reorderSessions = useIDEStore((state) => state.reorderTerminalSessions);
   const showToast = useIDEStore((state) => state.showToast);
+
+  useRunOutputListener();
+
+  const runOutputs = useRunOutputs();
+  const activeRunOutputId = useActiveRunOutputId();
+  const setActiveRunOutput = useIDEStore((s) => s.setActiveRunOutput);
+  const setViewMode = useIDEStore((s) => s.setRunOutputViewMode);
+  const outputIds = Object.keys(runOutputs);
 
   const sessionCountRef = useRef(0);
   const isCreatingRef = useRef(false);
@@ -317,6 +330,66 @@ export function Terminal() {
             >
               <PlusIcon aria-hidden="true" />
             </button>
+          </>
+        )}
+        {activeTab === 'output' && outputIds.length > 0 && (
+          <>
+            <div className={styles.divider} />
+            {outputIds.length >= 2 && (
+              <button
+                className={`${styles.sessionTab} ${activeRunOutputId === ALL_PROFILES_ID ? styles.active : ''}`}
+                onClick={() => {
+                  setActiveRunOutput(ALL_PROFILES_ID);
+                  setViewMode('timeline');
+                }}
+                title="All Profiles Timeline"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  width="11"
+                  height="11"
+                  style={{ flexShrink: 0 }}
+                >
+                  <circle cx="12" cy="12" r="10" />
+                  <polyline points="12 6 12 12 16 14" />
+                </svg>
+                <span className={styles.sessionTabLabel}>All</span>
+              </button>
+            )}
+            {outputIds.map((id) => {
+              const output = runOutputs[id];
+              const isActive = id === activeRunOutputId;
+              const stateClass =
+                output.state === 'running'
+                  ? styles.stateRunning
+                  : output.state === 'success'
+                    ? styles.stateSuccess
+                    : output.state === 'failed'
+                      ? styles.stateFailed
+                      : output.state === 'stopped'
+                        ? styles.stateStopped
+                        : '';
+
+              return (
+                <button
+                  key={id}
+                  className={`${styles.sessionTab} ${isActive ? styles.active : ''}`}
+                  onClick={() => {
+                    setActiveRunOutput(id);
+                    if (useIDEStore.getState().runOutputViewMode === 'timeline') {
+                      setViewMode('merged');
+                    }
+                  }}
+                  title={id}
+                >
+                  <span className={`${styles.stateDot} ${stateClass}`} />
+                  <span className={styles.sessionTabLabel}>{id}</span>
+                </button>
+              );
+            })}
           </>
         )}
       </div>
@@ -523,11 +596,7 @@ function TerminalContent({ sessionId, isVisible }: TerminalContentProps) {
 }
 
 function OutputContent() {
-  return (
-    <div className={styles.emptyState}>
-      <p>No output to display</p>
-    </div>
-  );
+  return <RunOutputPanel />;
 }
 
 interface ProblemsContentProps {

--- a/frontend/src/hooks/useRunOutput.ts
+++ b/frontend/src/hooks/useRunOutput.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { EventsOn } from '../../wailsjs/runtime/runtime';
+import { useIDEStore } from '../stores/ideStore';
+import type { OutputChunk, RunState } from '../types/runOutput';
+import { ALL_PROFILES_ID } from '../types/runOutput';
+
+export function useRunOutputListener(): void {
+  useEffect(() => {
+    const cleanupOutput = EventsOn('run:output', (chunk: OutputChunk) => {
+      useIDEStore.getState().appendRunOutput(chunk);
+    });
+
+    const cleanupStatus = EventsOn(
+      'run:status',
+      (status: { profileId: string; state: string; exitCode: number }) => {
+        const store = useIDEStore.getState();
+        store.setRunState(status.profileId, status.state as RunState, status.exitCode);
+
+        if (
+          status.state === 'running' &&
+          (!store.activeRunOutputId || store.activeRunOutputId === ALL_PROFILES_ID)
+        ) {
+          store.setActiveRunOutput(status.profileId);
+        }
+      }
+    );
+
+    return () => {
+      cleanupOutput();
+      cleanupStatus();
+    };
+  }, []);
+}

--- a/frontend/src/hooks/useRunProfiles.ts
+++ b/frontend/src/hooks/useRunProfiles.ts
@@ -77,6 +77,8 @@ export function useRunProfilesLoader(workspacePath: string | null | undefined): 
       return;
     }
 
+    useIDEStore.getState().clearAllRunOutputs();
+
     let cancelled = false;
     const { setProfilesLoading, setRunProfiles, setProfilesError } = useIDEStore.getState();
 

--- a/frontend/src/stores/ideStore.ts
+++ b/frontend/src/stores/ideStore.ts
@@ -609,7 +609,13 @@ export const useIDEStore = create<IDEStore>()(
             const { [profileId]: _discarded, ...rest } = state.runOutputs;
             lineAssemblers.delete(profileId);
             assemblerCallbacks.delete(profileId);
-            return { runOutputs: rest };
+            // If the cleared profile was active, select the first remaining or null
+            let activeRunOutputId = state.activeRunOutputId;
+            if (activeRunOutputId === profileId) {
+              const remaining = Object.keys(rest);
+              activeRunOutputId = remaining.length > 0 ? remaining[0] : null;
+            }
+            return { runOutputs: rest, activeRunOutputId };
           },
           false,
           'clearRunOutput'

--- a/frontend/src/stores/ideStore.ts
+++ b/frontend/src/stores/ideStore.ts
@@ -3,6 +3,15 @@ import { devtools } from 'zustand/middleware';
 import { useShallow } from 'zustand/react/shallow';
 import type { filesystem, workspace } from '../../wailsjs/go/models';
 import type { RunProfile } from '../types/runProfile';
+import { LineAssembler } from '../utils/lineAssembler';
+import type {
+  OutputChunk,
+  OutputEntry,
+  RunOutput,
+  RunState,
+  RunOutputViewMode,
+} from '../types/runOutput';
+import { MAX_OUTPUT_ENTRIES } from '../types/runOutput';
 
 // Types
 export type SidebarView = 'explorer' | 'search' | 'git' | 'run';
@@ -98,6 +107,12 @@ interface IDEState {
   isLoadingProfiles: boolean;
   profilesError: string | null;
 
+  // Run Output
+  runOutputs: Record<string, RunOutput>;
+  activeRunOutputId: string | null;
+  runOutputViewMode: RunOutputViewMode;
+  runOutputAutoScroll: boolean;
+
   // Per-file view state (for persistence)
   scrollPositions: Record<string, number>; // fileId -> scrollTop
   cursorPositions: Record<string, CursorPosition>; // fileId -> cursor
@@ -165,6 +180,15 @@ interface IDEActions {
   addOrUpdateProfile: (profile: RunProfile) => void;
   removeProfile: (id: string) => void;
 
+  // Run Output actions
+  appendRunOutput: (chunk: OutputChunk) => void;
+  setRunState: (profileId: string, state: RunState, exitCode: number) => void;
+  clearRunOutput: (profileId: string) => void;
+  clearAllRunOutputs: () => void;
+  setActiveRunOutput: (id: string | null) => void;
+  setRunOutputViewMode: (mode: RunOutputViewMode) => void;
+  toggleAutoScroll: () => void;
+
   // Per-file view state actions
   setScrollPosition: (fileId: string, scrollTop: number) => void;
   setFileCursorPosition: (fileId: string, position: CursorPosition) => void;
@@ -182,6 +206,21 @@ interface IDEActions {
 }
 
 type IDEStore = IDEState & IDEActions;
+
+// Line assemblers are per-profile, stored outside Zustand (mutable, not serializable)
+const lineAssemblers = new Map<string, LineAssembler>();
+
+function getOrCreateAssembler(
+  profileId: string,
+  appendEntry: (profileId: string, entry: OutputEntry) => void
+): LineAssembler {
+  let assembler = lineAssemblers.get(profileId);
+  if (!assembler) {
+    assembler = new LineAssembler((entry) => appendEntry(profileId, entry));
+    lineAssemblers.set(profileId, assembler);
+  }
+  return assembler;
+}
 
 export const useIDEStore = create<IDEStore>()(
   devtools(
@@ -201,6 +240,10 @@ export const useIDEStore = create<IDEStore>()(
       runProfiles: [],
       isLoadingProfiles: false,
       profilesError: null,
+      runOutputs: {},
+      activeRunOutputId: null,
+      runOutputViewMode: 'merged' as RunOutputViewMode,
+      runOutputAutoScroll: true,
       isRestoringWorkspace: false,
       recentWorkspaces: [],
       recentWorkspacesVersion: 0,
@@ -447,6 +490,118 @@ export const useIDEStore = create<IDEStore>()(
           'removeProfile'
         ),
 
+      // Run Output actions
+      appendRunOutput: (chunk) => {
+        const appendEntry = (profileId: string, entry: OutputEntry) => {
+          set(
+            (state) => {
+              const existing = state.runOutputs[profileId] ?? {
+                profileId,
+                state: 'idle' as RunState,
+                exitCode: 0,
+                runCount: 0,
+                entries: [],
+                previousEntries: [],
+              };
+              let entries = [...existing.entries, entry];
+              if (entries.length > MAX_OUTPUT_ENTRIES) {
+                entries = entries.slice(entries.length - MAX_OUTPUT_ENTRIES + 1);
+                entries.unshift({
+                  stream: 'stdout',
+                  text: '[truncated — oldest output removed]',
+                  timestamp: entries[0]?.timestamp ?? Date.now(),
+                });
+              }
+              return {
+                runOutputs: {
+                  ...state.runOutputs,
+                  [profileId]: { ...existing, entries },
+                },
+              };
+            },
+            false,
+            'appendRunOutput'
+          );
+        };
+
+        const assembler = getOrCreateAssembler(chunk.profileId, appendEntry);
+        assembler.push(chunk.stream, chunk.data, chunk.timestamp);
+      },
+
+      setRunState: (profileId, newState, exitCode) => {
+        // Flush line assembler BEFORE updating state to avoid nested set() calls.
+        if (newState === 'stopped' || newState === 'failed' || newState === 'success') {
+          const assembler = lineAssemblers.get(profileId);
+          if (assembler) {
+            assembler.flush();
+            lineAssemblers.delete(profileId);
+          }
+        }
+
+        set(
+          (state) => {
+            const existing = state.runOutputs[profileId] ?? {
+              profileId,
+              state: 'idle' as RunState,
+              exitCode: 0,
+              runCount: 0,
+              entries: [],
+              previousEntries: [],
+            };
+
+            const updated = { ...existing, state: newState, exitCode };
+
+            if (newState === 'running') {
+              updated.runCount = existing.runCount + 1;
+              if (updated.runCount > 1) {
+                let prev = existing.entries;
+                if (prev.length > MAX_OUTPUT_ENTRIES) {
+                  prev = prev.slice(prev.length - MAX_OUTPUT_ENTRIES);
+                }
+                updated.previousEntries = prev;
+                updated.entries = [];
+                lineAssemblers.delete(profileId);
+              }
+            }
+
+            return {
+              runOutputs: { ...state.runOutputs, [profileId]: updated },
+            };
+          },
+          false,
+          'setRunState'
+        );
+      },
+
+      clearRunOutput: (profileId) =>
+        set(
+          (state) => {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const { [profileId]: _discarded, ...rest } = state.runOutputs;
+            lineAssemblers.delete(profileId);
+            return { runOutputs: rest };
+          },
+          false,
+          'clearRunOutput'
+        ),
+
+      clearAllRunOutputs: () => {
+        lineAssemblers.clear();
+        set({ runOutputs: {}, activeRunOutputId: null }, false, 'clearAllRunOutputs');
+      },
+
+      setActiveRunOutput: (id) => set({ activeRunOutputId: id }, false, 'setActiveRunOutput'),
+
+      setRunOutputViewMode: (mode) =>
+        set({ runOutputViewMode: mode }, false, 'setRunOutputViewMode'),
+
+      toggleAutoScroll: () =>
+        set(
+          (state) => ({ runOutputAutoScroll: !state.runOutputAutoScroll }),
+          false,
+          'toggleAutoScroll'
+        ),
+
       // Per-file view state actions
       setScrollPosition: (fileId, scrollTop) =>
         set(
@@ -530,3 +685,12 @@ export const useSavedProfiles = () =>
 export const useIsLoadingProfiles = () => useIDEStore((state) => state.isLoadingProfiles);
 export const useProfilesError = () => useIDEStore((state) => state.profilesError);
 export const useRecentWorkspaces = () => useIDEStore((state) => state.recentWorkspaces);
+export const useRunOutputs = () => useIDEStore((state) => state.runOutputs);
+export const useActiveRunOutputId = () => useIDEStore((state) => state.activeRunOutputId);
+export const useActiveRunOutput = () =>
+  useIDEStore((state) => {
+    const id = state.activeRunOutputId;
+    return id && id !== '__all__' ? (state.runOutputs[id] ?? null) : null;
+  });
+export const useRunOutputViewMode = () => useIDEStore((state) => state.runOutputViewMode);
+export const useRunOutputAutoScroll = () => useIDEStore((state) => state.runOutputAutoScroll);

--- a/frontend/src/stores/ideStore.ts
+++ b/frontend/src/stores/ideStore.ts
@@ -545,10 +545,15 @@ export const useIDEStore = create<IDEStore>()(
       },
 
       setRunState: (profileId, newState, exitCode) => {
-        // Flush line assembler BEFORE updating state to avoid nested set() calls.
+        // On terminal states, flush the line assembler's carry-over into a local
+        // array so we can merge it into the store in a single set() call.
+        // We can't reuse the appendRunOutput collector because it references a
+        // dead pendingEntries array from a previous call.
+        const flushedEntries: OutputEntry[] = [];
         if (newState === 'stopped' || newState === 'failed' || newState === 'success') {
           const assembler = lineAssemblers.get(profileId);
           if (assembler) {
+            assemblerCallbacks.set(profileId, (entry) => flushedEntries.push(entry));
             assembler.flush();
             lineAssemblers.delete(profileId);
             assemblerCallbacks.delete(profileId);
@@ -566,7 +571,13 @@ export const useIDEStore = create<IDEStore>()(
               previousEntries: [],
             };
 
-            const updated = { ...existing, state: newState, exitCode };
+            // Merge any flushed carry-over entries
+            const mergedEntries =
+              flushedEntries.length > 0
+                ? [...existing.entries, ...flushedEntries]
+                : existing.entries;
+
+            const updated = { ...existing, state: newState, exitCode, entries: mergedEntries };
 
             if (newState === 'running') {
               updated.runCount = existing.runCount + 1;

--- a/frontend/src/stores/ideStore.ts
+++ b/frontend/src/stores/ideStore.ts
@@ -214,6 +214,11 @@ type IDEStore = IDEState & IDEActions;
 const lineAssemblers = new Map<string, LineAssembler>();
 const assemblerCallbacks = new Map<string, (entry: OutputEntry) => void>();
 
+// Generation counter to discard stale events after workspace switch.
+// Incremented by clearAllRunOutputs. appendRunOutput captures the generation
+// at call time and discards the result if it's stale by the time set() runs.
+let outputGeneration = 0;
+
 function getOrCreateAssembler(
   profileId: string,
   emitFn: (entry: OutputEntry) => void
@@ -500,6 +505,10 @@ export const useIDEStore = create<IDEStore>()(
 
       // Run Output actions
       appendRunOutput: (chunk) => {
+        // Capture the current generation to detect stale events from a
+        // previous workspace that arrive after clearAllRunOutputs.
+        const gen = outputGeneration;
+
         // Collect all lines from this chunk into a local array, then commit
         // to the store in a single set() call. This avoids store thrashing
         // when a chunk contains many newlines (e.g. npm install burst).
@@ -512,6 +521,9 @@ export const useIDEStore = create<IDEStore>()(
         assembler.push(chunk.stream, chunk.data, chunk.timestamp);
 
         if (pendingEntries.length === 0) return;
+
+        // Discard if a workspace switch occurred during assembly
+        if (gen !== outputGeneration) return;
 
         set(
           (state) => {
@@ -545,6 +557,9 @@ export const useIDEStore = create<IDEStore>()(
       },
 
       setRunState: (profileId, newState, exitCode) => {
+        // Discard stale events from a previous workspace
+        const gen = outputGeneration;
+
         // On terminal states, flush the line assembler's carry-over into a local
         // array so we can merge it into the store in a single set() call.
         // We can't reuse the appendRunOutput collector because it references a
@@ -559,6 +574,9 @@ export const useIDEStore = create<IDEStore>()(
             assemblerCallbacks.delete(profileId);
           }
         }
+
+        // Discard if a workspace switch occurred during flush
+        if (gen !== outputGeneration) return;
 
         set(
           (state) => {
@@ -605,6 +623,21 @@ export const useIDEStore = create<IDEStore>()(
       clearRunOutput: (profileId) =>
         set(
           (state) => {
+            const existing = state.runOutputs[profileId];
+            if (!existing) return state;
+
+            // If the profile is still running, only clear entries — preserve
+            // the RunOutput record so state/runCount stay correct for the
+            // active process. Otherwise remove the record entirely.
+            if (existing.state === 'running') {
+              return {
+                runOutputs: {
+                  ...state.runOutputs,
+                  [profileId]: { ...existing, entries: [], previousEntries: [] },
+                },
+              };
+            }
+
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { [profileId]: _discarded, ...rest } = state.runOutputs;
             lineAssemblers.delete(profileId);
@@ -622,6 +655,7 @@ export const useIDEStore = create<IDEStore>()(
         ),
 
       clearAllRunOutputs: () => {
+        outputGeneration++;
         lineAssemblers.clear();
         assemblerCallbacks.clear();
         set({ runOutputs: {}, activeRunOutputId: null }, false, 'clearAllRunOutputs');

--- a/frontend/src/stores/ideStore.ts
+++ b/frontend/src/stores/ideStore.ts
@@ -208,15 +208,23 @@ interface IDEActions {
 type IDEStore = IDEState & IDEActions;
 
 // Line assemblers are per-profile, stored outside Zustand (mutable, not serializable)
+// Line assemblers are per-profile, stored outside Zustand (mutable, not serializable).
+// Each assembler's emit callback is swappable so appendRunOutput can collect lines
+// into a local array per chunk, then commit once to the store.
 const lineAssemblers = new Map<string, LineAssembler>();
+const assemblerCallbacks = new Map<string, (entry: OutputEntry) => void>();
 
 function getOrCreateAssembler(
   profileId: string,
-  appendEntry: (profileId: string, entry: OutputEntry) => void
+  emitFn: (entry: OutputEntry) => void
 ): LineAssembler {
+  assemblerCallbacks.set(profileId, emitFn);
   let assembler = lineAssemblers.get(profileId);
   if (!assembler) {
-    assembler = new LineAssembler((entry) => appendEntry(profileId, entry));
+    assembler = new LineAssembler((entry) => {
+      const cb = assemblerCallbacks.get(profileId);
+      if (cb) cb(entry);
+    });
     lineAssemblers.set(profileId, assembler);
   }
   return assembler;
@@ -492,40 +500,48 @@ export const useIDEStore = create<IDEStore>()(
 
       // Run Output actions
       appendRunOutput: (chunk) => {
-        const appendEntry = (profileId: string, entry: OutputEntry) => {
-          set(
-            (state) => {
-              const existing = state.runOutputs[profileId] ?? {
-                profileId,
-                state: 'idle' as RunState,
-                exitCode: 0,
-                runCount: 0,
-                entries: [],
-                previousEntries: [],
-              };
-              let entries = [...existing.entries, entry];
-              if (entries.length > MAX_OUTPUT_ENTRIES) {
-                entries = entries.slice(entries.length - MAX_OUTPUT_ENTRIES + 1);
-                entries.unshift({
-                  stream: 'stdout',
-                  text: '[truncated — oldest output removed]',
-                  timestamp: entries[0]?.timestamp ?? Date.now(),
-                });
-              }
-              return {
-                runOutputs: {
-                  ...state.runOutputs,
-                  [profileId]: { ...existing, entries },
-                },
-              };
-            },
-            false,
-            'appendRunOutput'
-          );
+        // Collect all lines from this chunk into a local array, then commit
+        // to the store in a single set() call. This avoids store thrashing
+        // when a chunk contains many newlines (e.g. npm install burst).
+        const pendingEntries: OutputEntry[] = [];
+        const collector = (entry: OutputEntry) => {
+          pendingEntries.push(entry);
         };
 
-        const assembler = getOrCreateAssembler(chunk.profileId, appendEntry);
+        const assembler = getOrCreateAssembler(chunk.profileId, collector);
         assembler.push(chunk.stream, chunk.data, chunk.timestamp);
+
+        if (pendingEntries.length === 0) return;
+
+        set(
+          (state) => {
+            const existing = state.runOutputs[chunk.profileId] ?? {
+              profileId: chunk.profileId,
+              state: 'idle' as RunState,
+              exitCode: 0,
+              runCount: 0,
+              entries: [],
+              previousEntries: [],
+            };
+            let entries = [...existing.entries, ...pendingEntries];
+            if (entries.length > MAX_OUTPUT_ENTRIES) {
+              entries = entries.slice(entries.length - MAX_OUTPUT_ENTRIES + 1);
+              entries.unshift({
+                stream: 'stdout',
+                text: '[truncated — oldest output removed]',
+                timestamp: entries[0]?.timestamp ?? Date.now(),
+              });
+            }
+            return {
+              runOutputs: {
+                ...state.runOutputs,
+                [chunk.profileId]: { ...existing, entries },
+              },
+            };
+          },
+          false,
+          'appendRunOutput'
+        );
       },
 
       setRunState: (profileId, newState, exitCode) => {
@@ -535,6 +551,7 @@ export const useIDEStore = create<IDEStore>()(
           if (assembler) {
             assembler.flush();
             lineAssemblers.delete(profileId);
+            assemblerCallbacks.delete(profileId);
           }
         }
 
@@ -561,6 +578,7 @@ export const useIDEStore = create<IDEStore>()(
                 updated.previousEntries = prev;
                 updated.entries = [];
                 lineAssemblers.delete(profileId);
+                assemblerCallbacks.delete(profileId);
               }
             }
 
@@ -579,6 +597,7 @@ export const useIDEStore = create<IDEStore>()(
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { [profileId]: _discarded, ...rest } = state.runOutputs;
             lineAssemblers.delete(profileId);
+            assemblerCallbacks.delete(profileId);
             return { runOutputs: rest };
           },
           false,
@@ -587,6 +606,7 @@ export const useIDEStore = create<IDEStore>()(
 
       clearAllRunOutputs: () => {
         lineAssemblers.clear();
+        assemblerCallbacks.clear();
         set({ runOutputs: {}, activeRunOutputId: null }, false, 'clearAllRunOutputs');
       },
 

--- a/frontend/src/stores/ideStore.ts
+++ b/frontend/src/stores/ideStore.ts
@@ -214,11 +214,6 @@ type IDEStore = IDEState & IDEActions;
 const lineAssemblers = new Map<string, LineAssembler>();
 const assemblerCallbacks = new Map<string, (entry: OutputEntry) => void>();
 
-// Generation counter to discard stale events after workspace switch.
-// Incremented by clearAllRunOutputs. appendRunOutput captures the generation
-// at call time and discards the result if it's stale by the time set() runs.
-let outputGeneration = 0;
-
 function getOrCreateAssembler(
   profileId: string,
   emitFn: (entry: OutputEntry) => void
@@ -505,9 +500,11 @@ export const useIDEStore = create<IDEStore>()(
 
       // Run Output actions
       appendRunOutput: (chunk) => {
-        // Capture the current generation to detect stale events from a
-        // previous workspace that arrive after clearAllRunOutputs.
-        const gen = outputGeneration;
+        // Only append to profiles that already have a RunOutput record
+        // (created by setRunState on 'running' transition). This prevents
+        // stale events from a previous workspace from recreating entries
+        // after clearAllRunOutputs wiped them.
+        if (!useIDEStore.getState().runOutputs[chunk.profileId]) return;
 
         // Collect all lines from this chunk into a local array, then commit
         // to the store in a single set() call. This avoids store thrashing
@@ -522,19 +519,10 @@ export const useIDEStore = create<IDEStore>()(
 
         if (pendingEntries.length === 0) return;
 
-        // Discard if a workspace switch occurred during assembly
-        if (gen !== outputGeneration) return;
-
         set(
           (state) => {
-            const existing = state.runOutputs[chunk.profileId] ?? {
-              profileId: chunk.profileId,
-              state: 'idle' as RunState,
-              exitCode: 0,
-              runCount: 0,
-              entries: [],
-              previousEntries: [],
-            };
+            const existing = state.runOutputs[chunk.profileId];
+            if (!existing) return state; // profile was cleared between check and set
             let entries = [...existing.entries, ...pendingEntries];
             if (entries.length > MAX_OUTPUT_ENTRIES) {
               entries = entries.slice(entries.length - MAX_OUTPUT_ENTRIES + 1);
@@ -557,9 +545,6 @@ export const useIDEStore = create<IDEStore>()(
       },
 
       setRunState: (profileId, newState, exitCode) => {
-        // Discard stale events from a previous workspace
-        const gen = outputGeneration;
-
         // On terminal states, flush the line assembler's carry-over into a local
         // array so we can merge it into the store in a single set() call.
         // We can't reuse the appendRunOutput collector because it references a
@@ -574,9 +559,6 @@ export const useIDEStore = create<IDEStore>()(
             assemblerCallbacks.delete(profileId);
           }
         }
-
-        // Discard if a workspace switch occurred during flush
-        if (gen !== outputGeneration) return;
 
         set(
           (state) => {
@@ -630,6 +612,9 @@ export const useIDEStore = create<IDEStore>()(
             // the RunOutput record so state/runCount stay correct for the
             // active process. Otherwise remove the record entirely.
             if (existing.state === 'running') {
+              // Reset assembler so partial carry-over doesn't leak into fresh output
+              lineAssemblers.delete(profileId);
+              assemblerCallbacks.delete(profileId);
               return {
                 runOutputs: {
                   ...state.runOutputs,
@@ -655,10 +640,24 @@ export const useIDEStore = create<IDEStore>()(
         ),
 
       clearAllRunOutputs: () => {
-        outputGeneration++;
         lineAssemblers.clear();
         assemblerCallbacks.clear();
-        set({ runOutputs: {}, activeRunOutputId: null }, false, 'clearAllRunOutputs');
+        set(
+          (state) => {
+            // Preserve RunOutput records for still-running profiles so their
+            // state/runCount stays correct. Only clear their entries.
+            const preserved: Record<string, RunOutput> = {};
+            for (const [id, output] of Object.entries(state.runOutputs)) {
+              if (output.state === 'running') {
+                preserved[id] = { ...output, entries: [], previousEntries: [] };
+              }
+            }
+            const firstId = Object.keys(preserved)[0] ?? null;
+            return { runOutputs: preserved, activeRunOutputId: firstId };
+          },
+          false,
+          'clearAllRunOutputs'
+        );
       },
 
       setActiveRunOutput: (id) => set({ activeRunOutputId: id }, false, 'setActiveRunOutput'),

--- a/frontend/src/types/runOutput.ts
+++ b/frontend/src/types/runOutput.ts
@@ -1,0 +1,46 @@
+/** Sentinel value for the "All Profiles" virtual tab in Timeline view */
+export const ALL_PROFILES_ID = '__all__';
+
+/** Max entries per profile before FIFO truncation */
+export const MAX_OUTPUT_ENTRIES = 10_000;
+
+/** Raw event payload from backend (chunk-oriented, may split/merge lines) */
+export interface OutputChunk {
+  profileId: string;
+  stream: 'stdout' | 'stderr';
+  data: string;
+  timestamp: number;
+}
+
+/** Stored entry (line-oriented, always one complete line per entry) */
+export interface OutputEntry {
+  stream: 'stdout' | 'stderr';
+  text: string;
+  timestamp: number;
+}
+
+export type RunState = 'idle' | 'running' | 'stopped' | 'failed' | 'success';
+export type RunOutputViewMode = 'merged' | 'lanes' | 'diff' | 'timeline';
+
+export interface RunOutput {
+  profileId: string;
+  state: RunState;
+  exitCode: number;
+  runCount: number;
+  entries: OutputEntry[];
+  previousEntries: OutputEntry[];
+}
+
+export interface FoldedRegion {
+  kind: 'fold';
+  id: string;
+  summary: string;
+  lineCount: number;
+  entries: OutputEntry[];
+}
+
+export type FoldedItem = OutputEntry | FoldedRegion;
+
+export function isFoldedRegion(item: FoldedItem): item is FoldedRegion {
+  return (item as FoldedRegion).kind === 'fold';
+}

--- a/frontend/src/utils/diffOutput.test.ts
+++ b/frontend/src/utils/diffOutput.test.ts
@@ -1,0 +1,58 @@
+import { diffOutputLines } from './diffOutput';
+
+describe('diffOutputLines', () => {
+  it('empty arrays return empty result', () => {
+    expect(diffOutputLines([], [])).toEqual([]);
+  });
+
+  it('all added when prev is empty', () => {
+    const result = diffOutputLines([], ['a', 'b', 'c']);
+    expect(result).toHaveLength(3);
+    expect(result.every((l) => l.type === 'added')).toBe(true);
+    expect(result.map((l) => l.text)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('all removed when curr is empty', () => {
+    const result = diffOutputLines(['x', 'y'], []);
+    expect(result).toHaveLength(2);
+    expect(result.every((l) => l.type === 'removed')).toBe(true);
+    expect(result.map((l) => l.text)).toEqual(['x', 'y']);
+  });
+
+  it('identical lines are all unchanged', () => {
+    const lines = ['foo', 'bar', 'baz'];
+    const result = diffOutputLines(lines, lines);
+    expect(result).toHaveLength(3);
+    expect(result.every((l) => l.type === 'unchanged')).toBe(true);
+  });
+
+  it('mixed additions and removals', () => {
+    const prev = ['a', 'b', 'c'];
+    const curr = ['a', 'x', 'c'];
+    const result = diffOutputLines(prev, curr);
+    const unchanged = result.filter((l) => l.type === 'unchanged');
+    const added = result.filter((l) => l.type === 'added');
+    const removed = result.filter((l) => l.type === 'removed');
+    expect(unchanged.map((l) => l.text)).toContain('a');
+    expect(unchanged.map((l) => l.text)).toContain('c');
+    expect(added.map((l) => l.text)).toContain('x');
+    expect(removed.map((l) => l.text)).toContain('b');
+  });
+
+  it('too-large guard when both exceed 5000', () => {
+    const big = Array.from({ length: 5001 }, (_, i) => `line ${i}`);
+    const result = diffOutputLines(big, big);
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('too-large');
+  });
+
+  it('single side exceeding limit still computes when other side is small', () => {
+    const big = Array.from({ length: 5001 }, (_, i) => `line ${i}`);
+    const small = ['only one line'];
+    const result = diffOutputLines(big, small);
+    // Should not return too-large since only one side exceeds the limit
+    expect(result.every((l) => l.type !== 'too-large')).toBe(true);
+    expect(result.some((l) => l.type === 'added')).toBe(true);
+    expect(result.some((l) => l.type === 'removed')).toBe(true);
+  });
+});

--- a/frontend/src/utils/diffOutput.test.ts
+++ b/frontend/src/utils/diffOutput.test.ts
@@ -39,18 +39,19 @@ describe('diffOutputLines', () => {
     expect(removed.map((l) => l.text)).toContain('b');
   });
 
-  it('too-large guard when both exceed 5000', () => {
-    const big = Array.from({ length: 5001 }, (_, i) => `line ${i}`);
+  it('too-large guard when product exceeds threshold', () => {
+    // 2001 x 2001 = 4,004,001 > 4,000,000 limit
+    const big = Array.from({ length: 2001 }, (_, i) => `line ${i}`);
     const result = diffOutputLines(big, big);
     expect(result).toHaveLength(1);
     expect(result[0].type).toBe('too-large');
   });
 
-  it('single side exceeding limit still computes when other side is small', () => {
+  it('large one-sided diff still computes when product is under limit', () => {
     const big = Array.from({ length: 5001 }, (_, i) => `line ${i}`);
     const small = ['only one line'];
+    // 5001 x 1 = 5001 < 4,000,000 — computes fine
     const result = diffOutputLines(big, small);
-    // Should not return too-large since only one side exceeds the limit
     expect(result.every((l) => l.type !== 'too-large')).toBe(true);
     expect(result.some((l) => l.type === 'added')).toBe(true);
     expect(result.some((l) => l.type === 'removed')).toBe(true);

--- a/frontend/src/utils/diffOutput.ts
+++ b/frontend/src/utils/diffOutput.ts
@@ -1,4 +1,5 @@
-const DIFF_SIZE_LIMIT = 5000;
+/** Max product of input sizes before the LCS computation is skipped */
+const DIFF_PRODUCT_LIMIT = 4_000_000; // ~4M cells ≈ 32MB, safe for main thread
 
 export interface DiffLine {
   type: 'unchanged' | 'added' | 'removed' | 'too-large';
@@ -8,7 +9,7 @@ export interface DiffLine {
 export function diffOutputLines(prev: string[], curr: string[]): DiffLine[] {
   if (prev.length === 0 && curr.length === 0) return [];
 
-  if (prev.length > DIFF_SIZE_LIMIT && curr.length > DIFF_SIZE_LIMIT) {
+  if (prev.length * curr.length > DIFF_PRODUCT_LIMIT) {
     return [{ type: 'too-large', text: '' }];
   }
 

--- a/frontend/src/utils/diffOutput.ts
+++ b/frontend/src/utils/diffOutput.ts
@@ -1,0 +1,57 @@
+const DIFF_SIZE_LIMIT = 5000;
+
+export interface DiffLine {
+  type: 'unchanged' | 'added' | 'removed' | 'too-large';
+  text: string;
+}
+
+export function diffOutputLines(prev: string[], curr: string[]): DiffLine[] {
+  if (prev.length === 0 && curr.length === 0) return [];
+
+  if (prev.length > DIFF_SIZE_LIMIT && curr.length > DIFF_SIZE_LIMIT) {
+    return [{ type: 'too-large', text: '' }];
+  }
+
+  if (prev.length === 0) {
+    return curr.map((text) => ({ type: 'added' as const, text }));
+  }
+
+  if (curr.length === 0) {
+    return prev.map((text) => ({ type: 'removed' as const, text }));
+  }
+
+  const m = prev.length;
+  const n = curr.length;
+
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (prev[i - 1] === curr[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+
+  const result: DiffLine[] = [];
+  let i = m;
+  let j = n;
+
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && prev[i - 1] === curr[j - 1]) {
+      result.push({ type: 'unchanged', text: prev[i - 1] });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      result.push({ type: 'added', text: curr[j - 1] });
+      j--;
+    } else {
+      result.push({ type: 'removed', text: prev[i - 1] });
+      i--;
+    }
+  }
+
+  return result.reverse();
+}

--- a/frontend/src/utils/foldOutput.test.ts
+++ b/frontend/src/utils/foldOutput.test.ts
@@ -1,0 +1,93 @@
+import { foldOutput } from './foldOutput';
+import { isFoldedRegion } from '../types/runOutput';
+import type { OutputEntry, FoldedRegion } from '../types/runOutput';
+
+function makeEntry(
+  text: string,
+  stream: 'stdout' | 'stderr' = 'stdout',
+  timestamp = 1000
+): OutputEntry {
+  return { stream, text, timestamp };
+}
+
+function makeEntries(texts: string[]): OutputEntry[] {
+  return texts.map((t) => makeEntry(t));
+}
+
+describe('foldOutput', () => {
+  it('returns entries as-is when fewer than 10', () => {
+    const entries = makeEntries(['a', 'b', 'c']);
+    const result = foldOutput(entries);
+    expect(result).toEqual(entries);
+  });
+
+  it('returns entries as-is when no repetitive prefix detected', () => {
+    // 10 entries but all different prefixes
+    const entries = makeEntries([
+      'alpha one',
+      'beta two',
+      'gamma three',
+      'delta four',
+      'epsilon five',
+      'zeta six',
+      'eta seven',
+      'theta eight',
+      'iota nine',
+      'kappa ten',
+    ]);
+    const result = foldOutput(entries);
+    expect(result).toHaveLength(10);
+    expect(result.every((item) => !isFoldedRegion(item))).toBe(true);
+  });
+
+  it('folds 10+ consecutive lines with same prefix', () => {
+    const entries = makeEntries([
+      'npm warn deprecated package-a',
+      'npm warn deprecated package-b',
+      'npm warn deprecated package-c',
+      'npm warn deprecated package-d',
+      'npm warn deprecated package-e',
+      'npm warn deprecated package-f',
+      'npm warn deprecated package-g',
+      'npm warn deprecated package-h',
+      'npm warn deprecated package-i',
+      'npm warn deprecated package-j',
+    ]);
+    const result = foldOutput(entries);
+    expect(result).toHaveLength(1);
+    expect(isFoldedRegion(result[0])).toBe(true);
+    const fold = result[0] as FoldedRegion;
+    expect(fold.lineCount).toBe(10);
+    expect(fold.entries).toHaveLength(10);
+  });
+
+  it('does not fold fewer than 10 consecutive matching lines', () => {
+    const entries = makeEntries([
+      'npm warn deprecated package-a',
+      'npm warn deprecated package-b',
+      'npm warn deprecated package-c',
+      'npm warn deprecated package-d',
+      'npm warn deprecated package-e',
+      'npm warn deprecated package-f',
+      'npm warn deprecated package-g',
+      'npm warn deprecated package-h',
+      'npm warn deprecated package-i',
+    ]);
+    const result = foldOutput(entries);
+    // 9 entries total — below minimum fold size, returns unchanged
+    expect(result).toEqual(entries);
+  });
+
+  it('produces stable content-based fold IDs (same input = same ID)', () => {
+    const entries = makeEntries(Array.from({ length: 10 }, (_, i) => `downloading chunk ${i}`));
+    const result1 = foldOutput(entries);
+    const result2 = foldOutput(entries);
+    expect(isFoldedRegion(result1[0])).toBe(true);
+    expect(isFoldedRegion(result2[0])).toBe(true);
+    expect((result1[0] as FoldedRegion).id).toBe((result2[0] as FoldedRegion).id);
+  });
+
+  it('handles empty input', () => {
+    expect(foldOutput([])).toEqual([]);
+  });
+});

--- a/frontend/src/utils/foldOutput.ts
+++ b/frontend/src/utils/foldOutput.ts
@@ -1,0 +1,76 @@
+import type { OutputEntry, FoldedRegion, FoldedItem } from '../types/runOutput';
+
+const MIN_FOLD_SIZE = 10;
+const PREFIX_LENGTH = 6;
+
+function createFoldId(summary: string, entries: OutputEntry[]): string {
+  const first = entries[0];
+  const last = entries[entries.length - 1];
+  const head = entries
+    .slice(0, 3)
+    .map((e) => e.text)
+    .join('\n');
+  const tail = entries
+    .slice(-3)
+    .map((e) => e.text)
+    .join('\n');
+  const raw = `${summary}|${entries.length}|${first?.timestamp}|${first?.text}|${first?.stream}|${last?.timestamp}|${last?.text}|${last?.stream}|${head}|${tail}`;
+  let hash = 0;
+  for (let i = 0; i < raw.length; i++) {
+    hash = ((hash << 5) - hash + raw.charCodeAt(i)) | 0;
+  }
+  return `fold-${hash.toString(36)}`;
+}
+
+export function foldOutput(entries: OutputEntry[]): FoldedItem[] {
+  if (entries.length < MIN_FOLD_SIZE) return entries;
+
+  const result: FoldedItem[] = [];
+  let i = 0;
+
+  while (i < entries.length) {
+    const prefix = getPrefix(entries[i].text);
+
+    if (prefix.length >= PREFIX_LENGTH) {
+      let j = i + 1;
+      while (j < entries.length && getPrefix(entries[j].text) === prefix) {
+        j++;
+      }
+
+      const runLength = j - i;
+      if (runLength >= MIN_FOLD_SIZE) {
+        const foldEntries = entries.slice(i, j);
+        const summary = `${prefix.trim()} — ${inferCategory(prefix)}`;
+        result.push({
+          kind: 'fold',
+          id: createFoldId(summary, foldEntries),
+          summary,
+          lineCount: runLength,
+          entries: foldEntries,
+        } as FoldedRegion);
+        i = j;
+        continue;
+      }
+    }
+
+    result.push(entries[i]);
+    i++;
+  }
+
+  return result;
+}
+
+function getPrefix(text: string): string {
+  const spaceIdx = text.indexOf(' ', PREFIX_LENGTH);
+  if (spaceIdx === -1) return text.slice(0, PREFIX_LENGTH);
+  return text.slice(0, spaceIdx);
+}
+
+function inferCategory(prefix: string): string {
+  const p = prefix.trim().toLowerCase();
+  if (p.startsWith('added')) return 'packages installed';
+  if (p.startsWith('npm warn') || p.startsWith('npm notice')) return 'npm warnings';
+  if (p.startsWith('dist/') || p.startsWith('build/')) return 'build output';
+  if (p.startsWith('downloading')) return 'downloads';
+  return 'repeated output';
+}

--- a/frontend/src/utils/lineAssembler.test.ts
+++ b/frontend/src/utils/lineAssembler.test.ts
@@ -1,0 +1,88 @@
+import { LineAssembler } from './lineAssembler';
+import type { OutputEntry } from '../types/runOutput';
+
+function makeAssembler(): { assembler: LineAssembler; entries: OutputEntry[] } {
+  const entries: OutputEntry[] = [];
+  const assembler = new LineAssembler((entry) => entries.push(entry));
+  return { assembler, entries };
+}
+
+describe('LineAssembler', () => {
+  it('splits a complete line', () => {
+    const { assembler, entries } = makeAssembler();
+    assembler.push('stdout', 'hello\n', 1000);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({ stream: 'stdout', text: 'hello', timestamp: 1000 });
+  });
+
+  it('splits multiple lines in one chunk', () => {
+    const { assembler, entries } = makeAssembler();
+    assembler.push('stdout', 'line1\nline2\nline3\n', 2000);
+    expect(entries).toHaveLength(3);
+    expect(entries[0].text).toBe('line1');
+    expect(entries[1].text).toBe('line2');
+    expect(entries[2].text).toBe('line3');
+  });
+
+  it('carries over partial lines', () => {
+    const { assembler, entries } = makeAssembler();
+    assembler.push('stdout', 'hel', 1000);
+    expect(entries).toHaveLength(0);
+    assembler.push('stdout', 'lo\n', 1001);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].text).toBe('hello');
+    expect(entries[0].timestamp).toBe(1000);
+  });
+
+  it('handles separate streams independently', () => {
+    const { assembler, entries } = makeAssembler();
+    assembler.push('stdout', 'out partial', 1000);
+    assembler.push('stderr', 'err partial', 2000);
+    assembler.push('stdout', ' done\n', 1001);
+    assembler.push('stderr', ' done\n', 2001);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toEqual({ stream: 'stdout', text: 'out partial done', timestamp: 1000 });
+    expect(entries[1]).toEqual({ stream: 'stderr', text: 'err partial done', timestamp: 2000 });
+  });
+
+  it('flush emits remaining carry as final entry', () => {
+    const { assembler, entries } = makeAssembler();
+    assembler.push('stdout', 'no newline', 3000);
+    expect(entries).toHaveLength(0);
+    assembler.flush();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({ stream: 'stdout', text: 'no newline', timestamp: 3000 });
+  });
+
+  it('flush is a no-op when carry is empty', () => {
+    const { assembler, entries } = makeAssembler();
+    assembler.push('stdout', 'complete\n', 1000);
+    assembler.flush();
+    expect(entries).toHaveLength(1);
+  });
+
+  it('handles empty chunks', () => {
+    const { assembler, entries } = makeAssembler();
+    assembler.push('stdout', '', 1000);
+    assembler.push('stdout', 'line\n', 1001);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].text).toBe('line');
+  });
+
+  it('handles \\r\\n line endings', () => {
+    const { assembler, entries } = makeAssembler();
+    assembler.push('stdout', 'windows\r\nline\r\n', 1000);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].text).toBe('windows');
+    expect(entries[1].text).toBe('line');
+  });
+
+  it('handles lone \\r as part of line', () => {
+    const { assembler, entries } = makeAssembler();
+    assembler.push('stdout', 'progress\r', 1000);
+    expect(entries).toHaveLength(0);
+    assembler.flush();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].text).toBe('progress\r');
+  });
+});

--- a/frontend/src/utils/lineAssembler.ts
+++ b/frontend/src/utils/lineAssembler.ts
@@ -1,0 +1,59 @@
+import type { OutputEntry } from '../types/runOutput';
+
+type EmitFn = (entry: OutputEntry) => void;
+
+/**
+ * Normalizes arbitrary byte chunks into line-oriented OutputEntry values.
+ * Maintains per-stream carry-over for partial lines across chunks.
+ */
+export class LineAssembler {
+  private carry: Record<string, { data: string; timestamp: number }> = {};
+  private emit: EmitFn;
+
+  constructor(emit: EmitFn) {
+    this.emit = emit;
+  }
+
+  push(stream: 'stdout' | 'stderr', data: string, timestamp: number): void {
+    if (data.length === 0) return;
+
+    const carried = this.carry[stream];
+    const combined = carried ? carried.data + data : data;
+    const carriedTimestamp = carried ? carried.timestamp : timestamp;
+
+    const parts = combined.split('\n');
+
+    for (let i = 0; i < parts.length - 1; i++) {
+      const text = parts[i].endsWith('\r') ? parts[i].slice(0, -1) : parts[i];
+      this.emit({
+        stream,
+        text,
+        timestamp: i === 0 ? carriedTimestamp : timestamp,
+      });
+    }
+
+    const lastPart = parts[parts.length - 1];
+    if (lastPart.length > 0) {
+      this.carry[stream] = {
+        data: lastPart,
+        timestamp: parts.length === 1 ? carriedTimestamp : timestamp,
+      };
+    } else {
+      delete this.carry[stream];
+    }
+  }
+
+  flush(): void {
+    for (const stream of Object.keys(this.carry) as Array<'stdout' | 'stderr'>) {
+      const carried = this.carry[stream];
+      if (carried && carried.data.length > 0) {
+        this.emit({
+          stream,
+          text: carried.data,
+          timestamp: carried.timestamp,
+        });
+      }
+    }
+    this.carry = {};
+  }
+}

--- a/internal/runprofile/batcher.go
+++ b/internal/runprofile/batcher.go
@@ -6,12 +6,13 @@ import (
 	"time"
 )
 
-// batchEntry holds the accumulated data for one stream within a tick window.
-type batchEntry struct {
+// pendingWrite is a coalesced segment of output for one stream,
+// preserving insertion order across interleaved stdout/stderr.
+type pendingWrite struct {
 	profileID string
 	stream    string
 	data      strings.Builder
-	timestamp int64 // timestamp of the first write in this batch
+	timestamp int64 // timestamp of the first write in this segment
 }
 
 // writeMsg is sent over writeCh to the timer goroutine.
@@ -23,8 +24,9 @@ type writeMsg struct {
 }
 
 // outputBatcher accumulates output chunks and flushes them at a fixed interval.
-// This reduces the number of IPC events sent to the frontend while keeping
-// latency bounded to ~16 ms (one animation frame).
+// Writes are coalesced in insertion order: contiguous same-stream writes are
+// merged, but interleaving between stdout and stderr is preserved. This reduces
+// IPC events while maintaining correct chronological ordering for the frontend.
 type outputBatcher struct {
 	outputFn OutputFunc
 	interval time.Duration
@@ -70,23 +72,7 @@ func (b *outputBatcher) Close() {
 	})
 }
 
-// accumWrite adds a write message to the accumulator.
-func accumWrite(accum map[string]*batchEntry, msg writeMsg) {
-	key := msg.profileID + "\x00" + msg.stream
-	if entry, ok := accum[key]; ok {
-		entry.data.WriteString(msg.data)
-	} else {
-		entry := &batchEntry{
-			profileID: msg.profileID,
-			stream:    msg.stream,
-			timestamp: msg.timestamp,
-		}
-		entry.data.WriteString(msg.data)
-		accum[key] = entry
-	}
-}
-
-// run is the timer goroutine. It owns the accumulator map and is the only
+// run is the timer goroutine. It owns the pending list and is the only
 // place that reads from writeCh or flushes.
 func (b *outputBatcher) run() {
 	defer close(b.closed)
@@ -94,24 +80,41 @@ func (b *outputBatcher) run() {
 	ticker := time.NewTicker(b.interval)
 	defer ticker.Stop()
 
-	// accumulator: key = profileID + "\x00" + stream
-	accum := make(map[string]*batchEntry)
+	// Ordered list of coalesced segments. Contiguous same-stream writes
+	// are merged; stream transitions create a new segment.
+	var pending []*pendingWrite
+
+	accumulate := func(msg writeMsg) {
+		// Coalesce with the last segment if same profile+stream
+		if n := len(pending); n > 0 {
+			last := pending[n-1]
+			if last.profileID == msg.profileID && last.stream == msg.stream {
+				last.data.WriteString(msg.data)
+				return
+			}
+		}
+		pw := &pendingWrite{
+			profileID: msg.profileID,
+			stream:    msg.stream,
+			timestamp: msg.timestamp,
+		}
+		pw.data.WriteString(msg.data)
+		pending = append(pending, pw)
+	}
 
 	flush := func() {
-		if b.outputFn == nil {
-			clear(accum)
-			return
+		if b.outputFn != nil {
+			for _, pw := range pending {
+				b.outputFn(pw.profileID, pw.stream, pw.data.String(), pw.timestamp)
+			}
 		}
-		for k, entry := range accum {
-			b.outputFn(entry.profileID, entry.stream, entry.data.String(), entry.timestamp)
-			delete(accum, k)
-		}
+		pending = pending[:0]
 	}
 
 	for {
 		select {
 		case msg := <-b.writeCh:
-			accumWrite(accum, msg)
+			accumulate(msg)
 
 		case <-ticker.C:
 			flush()
@@ -121,7 +124,7 @@ func (b *outputBatcher) run() {
 			for {
 				select {
 				case msg := <-b.writeCh:
-					accumWrite(accum, msg)
+					accumulate(msg)
 				default:
 					flush()
 					return

--- a/internal/runprofile/batcher.go
+++ b/internal/runprofile/batcher.go
@@ -1,0 +1,138 @@
+package runprofile
+
+import (
+	"sync"
+	"time"
+)
+
+// batchEntry holds the accumulated data for one stream within a tick window.
+type batchEntry struct {
+	profileID string
+	stream    string
+	data      string
+	timestamp int64 // timestamp of the first write in this batch
+}
+
+// writeMsg is sent over writeCh to the timer goroutine.
+type writeMsg struct {
+	profileID string
+	stream    string
+	data      string
+	timestamp int64
+}
+
+// outputBatcher accumulates output chunks and flushes them at a fixed interval.
+// This reduces the number of IPC events sent to the frontend while keeping
+// latency bounded to ~16 ms (one animation frame).
+type outputBatcher struct {
+	outputFn OutputFunc
+	interval time.Duration
+
+	writeCh chan writeMsg
+	done    chan struct{}
+	closed  chan struct{}
+
+	closeOnce sync.Once
+}
+
+// newOutputBatcher creates an outputBatcher and starts its timer goroutine.
+// interval is the flush period (typically 16 ms).
+func newOutputBatcher(outputFn OutputFunc, interval time.Duration) *outputBatcher {
+	b := &outputBatcher{
+		outputFn: outputFn,
+		interval: interval,
+		writeCh:  make(chan writeMsg, 256),
+		done:     make(chan struct{}),
+		closed:   make(chan struct{}),
+	}
+	go b.run()
+	return b
+}
+
+// Write enqueues a chunk for batching. Safe to call from multiple goroutines.
+// Silently drops the write if the batcher has been closed.
+func (b *outputBatcher) Write(profileID, stream, data string, timestamp int64) {
+	select {
+	case b.writeCh <- writeMsg{profileID, stream, data, timestamp}:
+	case <-b.closed:
+		// batcher is closed; discard
+	}
+}
+
+// Close stops the goroutine and performs a synchronous final flush.
+// Idempotent — safe to call multiple times.
+func (b *outputBatcher) Close() {
+	b.closeOnce.Do(func() {
+		close(b.done)
+		// Wait for the goroutine to finish (and perform final flush).
+		<-b.closed
+	})
+}
+
+// run is the timer goroutine. It owns the accumulator map and is the only
+// place that reads from writeCh or flushes.
+func (b *outputBatcher) run() {
+	defer close(b.closed)
+
+	ticker := time.NewTicker(b.interval)
+	defer ticker.Stop()
+
+	// accumulator: key = profileID + "\x00" + stream
+	accum := make(map[string]*batchEntry)
+
+	flush := func() {
+		if b.outputFn == nil {
+			// Clear the accumulator even when no outputFn — avoids memory growth.
+			for k := range accum {
+				delete(accum, k)
+			}
+			return
+		}
+		for k, entry := range accum {
+			b.outputFn(entry.profileID, entry.stream, entry.data, entry.timestamp)
+			delete(accum, k)
+		}
+	}
+
+	for {
+		select {
+		case msg := <-b.writeCh:
+			key := msg.profileID + "\x00" + msg.stream
+			if entry, ok := accum[key]; ok {
+				entry.data += msg.data
+			} else {
+				accum[key] = &batchEntry{
+					profileID: msg.profileID,
+					stream:    msg.stream,
+					data:      msg.data,
+					timestamp: msg.timestamp,
+				}
+			}
+
+		case <-ticker.C:
+			flush()
+
+		case <-b.done:
+			// Drain any writes that arrived before done was closed.
+			for {
+				select {
+				case msg := <-b.writeCh:
+					key := msg.profileID + "\x00" + msg.stream
+					if entry, ok := accum[key]; ok {
+						entry.data += msg.data
+					} else {
+						accum[key] = &batchEntry{
+							profileID: msg.profileID,
+							stream:    msg.stream,
+							data:      msg.data,
+							timestamp: msg.timestamp,
+						}
+					}
+				default:
+					flush()
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/runprofile/batcher.go
+++ b/internal/runprofile/batcher.go
@@ -1,6 +1,7 @@
 package runprofile
 
 import (
+	"strings"
 	"sync"
 	"time"
 )
@@ -9,7 +10,7 @@ import (
 type batchEntry struct {
 	profileID string
 	stream    string
-	data      string
+	data      strings.Builder
 	timestamp int64 // timestamp of the first write in this batch
 }
 
@@ -69,6 +70,22 @@ func (b *outputBatcher) Close() {
 	})
 }
 
+// accumWrite adds a write message to the accumulator.
+func accumWrite(accum map[string]*batchEntry, msg writeMsg) {
+	key := msg.profileID + "\x00" + msg.stream
+	if entry, ok := accum[key]; ok {
+		entry.data.WriteString(msg.data)
+	} else {
+		entry := &batchEntry{
+			profileID: msg.profileID,
+			stream:    msg.stream,
+			timestamp: msg.timestamp,
+		}
+		entry.data.WriteString(msg.data)
+		accum[key] = entry
+	}
+}
+
 // run is the timer goroutine. It owns the accumulator map and is the only
 // place that reads from writeCh or flushes.
 func (b *outputBatcher) run() {
@@ -82,14 +99,11 @@ func (b *outputBatcher) run() {
 
 	flush := func() {
 		if b.outputFn == nil {
-			// Clear the accumulator even when no outputFn — avoids memory growth.
-			for k := range accum {
-				delete(accum, k)
-			}
+			clear(accum)
 			return
 		}
 		for k, entry := range accum {
-			b.outputFn(entry.profileID, entry.stream, entry.data, entry.timestamp)
+			b.outputFn(entry.profileID, entry.stream, entry.data.String(), entry.timestamp)
 			delete(accum, k)
 		}
 	}
@@ -97,17 +111,7 @@ func (b *outputBatcher) run() {
 	for {
 		select {
 		case msg := <-b.writeCh:
-			key := msg.profileID + "\x00" + msg.stream
-			if entry, ok := accum[key]; ok {
-				entry.data += msg.data
-			} else {
-				accum[key] = &batchEntry{
-					profileID: msg.profileID,
-					stream:    msg.stream,
-					data:      msg.data,
-					timestamp: msg.timestamp,
-				}
-			}
+			accumWrite(accum, msg)
 
 		case <-ticker.C:
 			flush()
@@ -117,17 +121,7 @@ func (b *outputBatcher) run() {
 			for {
 				select {
 				case msg := <-b.writeCh:
-					key := msg.profileID + "\x00" + msg.stream
-					if entry, ok := accum[key]; ok {
-						entry.data += msg.data
-					} else {
-						accum[key] = &batchEntry{
-							profileID: msg.profileID,
-							stream:    msg.stream,
-							data:      msg.data,
-							timestamp: msg.timestamp,
-						}
-					}
+					accumWrite(accum, msg)
 				default:
 					flush()
 					return

--- a/internal/runprofile/batcher_test.go
+++ b/internal/runprofile/batcher_test.go
@@ -1,0 +1,187 @@
+//go:build !windows
+
+package runprofile
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// batchCall records one call to the OutputFunc.
+type batchCall struct {
+	profileID string
+	stream    string
+	data      string
+	timestamp int64
+}
+
+// batchSpy collects OutputFunc calls.
+type batchSpy struct {
+	mu    sync.Mutex
+	calls []batchCall
+}
+
+func (s *batchSpy) receive(profileID, stream, data string, timestamp int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, batchCall{profileID, stream, data, timestamp})
+}
+
+func (s *batchSpy) snapshot() []batchCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]batchCall, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+// waitForCalls polls until at least n calls have been recorded or timeout expires.
+func (s *batchSpy) waitForCalls(n int, timeout time.Duration) bool {
+	deadline := time.After(timeout)
+	for {
+		if len(s.snapshot()) >= n {
+			return true
+		}
+		select {
+		case <-deadline:
+			return false
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+// TestBatcher_BasicFlush verifies that two writes to the same stream are
+// coalesced into a single OutputFunc call by the timer.
+func TestBatcher_BasicFlush(t *testing.T) {
+	spy := &batchSpy{}
+	b := newOutputBatcher(spy.receive, 16*time.Millisecond)
+	defer b.Close()
+
+	b.Write("p1", "stdout", "hello ", 1000)
+	b.Write("p1", "stdout", "world", 1001)
+
+	if !spy.waitForCalls(1, 500*time.Millisecond) {
+		t.Fatal("timed out waiting for a flush")
+	}
+
+	calls := spy.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d: %+v", len(calls), calls)
+	}
+	if calls[0].data != "hello world" {
+		t.Errorf("data = %q, want %q", calls[0].data, "hello world")
+	}
+}
+
+// TestBatcher_SeparateStreams verifies that stdout and stderr produce
+// separate OutputFunc calls.
+func TestBatcher_SeparateStreams(t *testing.T) {
+	spy := &batchSpy{}
+	b := newOutputBatcher(spy.receive, 16*time.Millisecond)
+	defer b.Close()
+
+	b.Write("p1", "stdout", "out", 1000)
+	b.Write("p1", "stderr", "err", 1001)
+
+	if !spy.waitForCalls(2, 500*time.Millisecond) {
+		t.Fatal("timed out waiting for 2 flush calls")
+	}
+
+	calls := spy.snapshot()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls (one per stream), got %d", len(calls))
+	}
+
+	streams := map[string]string{}
+	for _, c := range calls {
+		streams[c.stream] = c.data
+	}
+	if streams["stdout"] != "out" {
+		t.Errorf("stdout = %q, want %q", streams["stdout"], "out")
+	}
+	if streams["stderr"] != "err" {
+		t.Errorf("stderr = %q, want %q", streams["stderr"], "err")
+	}
+}
+
+// TestBatcher_CloseFlushesRemaining verifies that Close() flushes any data
+// that has accumulated before the next timer tick.
+func TestBatcher_CloseFlushesRemaining(t *testing.T) {
+	spy := &batchSpy{}
+	// Use a very long interval so the timer won't fire during the test.
+	b := newOutputBatcher(spy.receive, 10*time.Second)
+
+	b.Write("p1", "stdout", "pending data", 2000)
+
+	// Close should flush synchronously.
+	b.Close()
+
+	calls := spy.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call after Close, got %d", len(calls))
+	}
+	if calls[0].data != "pending data" {
+		t.Errorf("data = %q, want %q", calls[0].data, "pending data")
+	}
+}
+
+// TestBatcher_CloseIdempotent verifies that calling Close() twice does not panic.
+func TestBatcher_CloseIdempotent(t *testing.T) {
+	b := newOutputBatcher(nil, 16*time.Millisecond)
+	b.Close()
+	b.Close() // must not panic
+}
+
+// TestBatcher_TimestampPreserved verifies that the first write's timestamp is
+// used for the batched call, not the last write's timestamp.
+func TestBatcher_TimestampPreserved(t *testing.T) {
+	spy := &batchSpy{}
+	b := newOutputBatcher(spy.receive, 16*time.Millisecond)
+	defer b.Close()
+
+	const firstTS int64 = 5000
+	const secondTS int64 = 9999
+
+	b.Write("p1", "stdout", "first", firstTS)
+	b.Write("p1", "stdout", "second", secondTS)
+
+	if !spy.waitForCalls(1, 500*time.Millisecond) {
+		t.Fatal("timed out waiting for flush")
+	}
+
+	calls := spy.snapshot()
+	if calls[0].timestamp != firstTS {
+		t.Errorf("timestamp = %d, want %d (first write's timestamp)", calls[0].timestamp, firstTS)
+	}
+}
+
+// TestBatcher_NilOutputFn verifies that a nil outputFn doesn't cause a panic.
+func TestBatcher_NilOutputFn(t *testing.T) {
+	b := newOutputBatcher(nil, 16*time.Millisecond)
+	defer b.Close()
+
+	// These should not panic.
+	b.Write("p1", "stdout", "data", 1000)
+	time.Sleep(50 * time.Millisecond) // let the timer fire
+}
+
+// TestBatcher_QuietProcessFlushes verifies that data is flushed by the timer
+// even when no additional writes arrive after the initial write.
+func TestBatcher_QuietProcessFlushes(t *testing.T) {
+	spy := &batchSpy{}
+	b := newOutputBatcher(spy.receive, 16*time.Millisecond)
+	defer b.Close()
+
+	b.Write("p1", "stdout", "quiet data", 3000)
+
+	// Wait longer than one tick — data should flush on its own.
+	if !spy.waitForCalls(1, 500*time.Millisecond) {
+		t.Fatal("timed out waiting for timer-triggered flush")
+	}
+
+	calls := spy.snapshot()
+	if calls[0].data != "quiet data" {
+		t.Errorf("data = %q, want %q", calls[0].data, "quiet data")
+	}
+}

--- a/internal/runprofile/executor.go
+++ b/internal/runprofile/executor.go
@@ -148,15 +148,17 @@ func (e *Executor) Start(workspaceRoot string, profile RunProfile) error {
 	// Emit running status
 	e.emit(rp.status)
 
-	// Drain stdout/stderr
+	// Drain stdout/stderr through the output batcher
+	batcher := newOutputBatcher(e.outputFn, 16*time.Millisecond)
 	var pipesWg sync.WaitGroup
 	pipesWg.Add(2)
-	go e.drainPipe(&pipesWg, profile.ID, "stdout", stdout)
-	go e.drainPipe(&pipesWg, profile.ID, "stderr", stderr)
+	go e.drainPipe(&pipesWg, profile.ID, "stdout", stdout, batcher)
+	go e.drainPipe(&pipesWg, profile.ID, "stderr", stderr, batcher)
 
 	// Wait for process exit
 	go func() {
 		pipesWg.Wait()
+		batcher.Close()
 		exitCode := waitExitCode(cmd)
 
 		e.mu.Lock()
@@ -315,14 +317,14 @@ func (e *Executor) emit(status RunStatus) {
 	}
 }
 
-// drainPipe reads from a pipe and either forwards to outputFn or discards.
-func (e *Executor) drainPipe(wg *sync.WaitGroup, profileID, stream string, pipe io.ReadCloser) {
+// drainPipe reads from a pipe and forwards chunks to the output batcher.
+func (e *Executor) drainPipe(wg *sync.WaitGroup, profileID, stream string, pipe io.ReadCloser, batcher *outputBatcher) {
 	defer wg.Done()
 	buf := make([]byte, 4096)
 	for {
 		n, err := pipe.Read(buf)
-		if n > 0 && e.outputFn != nil {
-			e.outputFn(profileID, stream, string(buf[:n]), time.Now().UnixMilli())
+		if n > 0 {
+			batcher.Write(profileID, stream, string(buf[:n]), time.Now().UnixMilli())
 		}
 		if err != nil {
 			return

--- a/internal/runprofile/executor.go
+++ b/internal/runprofile/executor.go
@@ -34,8 +34,9 @@ type RunStatus struct {
 
 // OutputFunc receives streaming process output.
 // stream is "stdout" or "stderr". data is the raw chunk.
+// timestamp is the Unix millisecond time when the data was read.
 // The caller is responsible for buffering or backpressure.
-type OutputFunc func(profileID, stream, data string)
+type OutputFunc func(profileID, stream, data string, timestamp int64)
 
 // StatusFunc emits run status events (wraps runtime.EventsEmit in production).
 type StatusFunc func(event string, data ...any)
@@ -321,7 +322,7 @@ func (e *Executor) drainPipe(wg *sync.WaitGroup, profileID, stream string, pipe 
 	for {
 		n, err := pipe.Read(buf)
 		if n > 0 && e.outputFn != nil {
-			e.outputFn(profileID, stream, string(buf[:n]))
+			e.outputFn(profileID, stream, string(buf[:n]), time.Now().UnixMilli())
 		}
 		if err != nil {
 			return

--- a/internal/runprofile/executor_test.go
+++ b/internal/runprofile/executor_test.go
@@ -69,12 +69,13 @@ type outputEntry struct {
 	profileID string
 	stream    string
 	data      string
+	timestamp int64
 }
 
-func (o *outputSpy) receive(profileID, stream, data string) {
+func (o *outputSpy) receive(profileID, stream, data string, timestamp int64) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	o.entries = append(o.entries, outputEntry{profileID, stream, data})
+	o.entries = append(o.entries, outputEntry{profileID, stream, data, timestamp})
 }
 
 func (o *outputSpy) combined() string {


### PR DESCRIPTION
## Summary

- Stream process stdout/stderr to the frontend in real-time via batched Wails events
- Four novel view modes: Merged, Stream Lanes, Run Diff, and Unified Timeline
- Smart Folding auto-collapses repetitive output (npm install, build chunks, etc.)
- Backend: 16ms timer-based output batcher preserving stdout/stderr interleaving order
- Frontend: line assembler normalizes pipe chunks into complete lines, virtualized rendering via @tanstack/react-virtual
- Run output sub-tabs in the Output panel with state indicators (running/success/failed/stopped)

## Key design decisions

- **Line assembler** at the store boundary converts arbitrary byte chunks into complete line-oriented entries, making all downstream views (diff, fold, file:line:col) operate on clean data
- **Ordered batcher** coalesces contiguous same-stream writes but preserves cross-stream interleaving within each 16ms window
- **Existence-based stale event guard** prevents events from a previous workspace from recreating entries after clearAllRunOutputs
- **runCount field** distinguishes first run from re-runs, enabling correct diff history without ambiguity from event ordering

## Test plan

Run profiles cannot be executed from the UI yet (play button wiring is #61), so manual end-to-end testing is not possible in this PR. Verification is based on automated tests and build checks.

- [x] `go test ./...` -- all 7 Go packages pass (batcher, executor integration)
- [x] `npm test` -- all 248 frontend tests pass (lineAssembler, diffOutput, foldOutput, useRunOutput hook)
- [x] `npx tsc --noEmit` -- clean TypeScript compilation
- [x] Output tab in bottom panel renders the RunOutputPanel with empty state and toolbar
- [x] View mode buttons (Merged/Lanes/Diff/Timeline) render; Timeline disabled with 0 profiles
- [ ] Full end-to-end output streaming -- blocked on #61 (Process Lifecycle UI)

Generated with [Claude Code](https://claude.ai/claude-code)