### PR TITLE
Fix FileExplorer dependency cycle and ErrorBoundary log formatting

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -21,7 +21,8 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
-    console.error('Firn IDE Error:', error, errorInfo);
+    console.error('Firn IDE Error:', error);
+    console.error('Component stack:', errorInfo.componentStack);
   }
 
   render(): ReactNode {

--- a/frontend/src/components/FileExplorer/FileExplorer.tsx
+++ b/frontend/src/components/FileExplorer/FileExplorer.tsx
@@ -76,31 +76,33 @@ export function FileExplorer() {
   const openFile = useIDEStore((state) => state.openFile);
   const toggleLeftPanel = useIDEStore((state) => state.toggleLeftPanel);
 
-  // Sync active file in editor to file tree selection
+  // Sync active file in editor to file tree selection.
+  // Only depends on activeFileId — reads expandedPaths from store snapshot
+  // to avoid a dependency cycle (Set references change on every update).
   useEffect(() => {
-    if (activeFileId && activeFileId !== selectedPath) {
+    if (activeFileId && activeFileId !== useIDEStore.getState().selectedPath) {
       setSelectedPath(activeFileId);
 
       // Expand all parent folders to reveal the file
-      if (workspace) {
-        const relativePath = activeFileId.replace(workspace.path + '/', '');
+      const ws = useIDEStore.getState().workspace;
+      if (ws) {
+        const currentExpanded = useIDEStore.getState().expandedPaths;
+        const relativePath = activeFileId.replace(ws.path + '/', '');
         const parts = relativePath.split('/');
-        let currentPath = workspace.path;
+        let currentPath = ws.path;
 
-        // Expand each parent folder
-        const newExpanded = new Set(expandedPaths);
+        const newExpanded = new Set(currentExpanded);
         for (let i = 0; i < parts.length - 1; i++) {
           currentPath += '/' + parts[i];
           newExpanded.add(currentPath);
         }
 
-        // Update expanded paths if changed
-        if (newExpanded.size !== expandedPaths.size) {
+        if (newExpanded.size !== currentExpanded.size) {
           useIDEStore.setState({ expandedPaths: newExpanded });
         }
       }
     }
-  }, [activeFileId, selectedPath, setSelectedPath, workspace, expandedPaths]);
+  }, [activeFileId, setSelectedPath]);
 
   const { openFolder } = useOpenFolder();
 


### PR DESCRIPTION
## Summary

- **FileExplorer**: Reads `expandedPaths` and `workspace` from store snapshot inside the effect instead of as reactive dependencies. The `Set` reference changes on every update, causing an infinite re-render loop when used as an effect dependency.
- **ErrorBoundary**: Splits error and componentStack into separate `console.error` calls for better readability in DevTools.

## Test plan

- [x] Verify file explorer syncs active file to tree selection without console spam
- [x] Verify error boundary logs are formatted correctly in DevTools