### PR TITLE
feat(lsp): Phase 3 - TypeScript vertical slice

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { useWorkspacePersistence } from './hooks/useWorkspacePersistence';
 import { useRecentWorkspaces } from './hooks/useRecentWorkspaces';
 import { useRunProfilesLoader } from './hooks/useRunProfiles';
 import { useLSPDocumentSync } from './hooks/useLSPDocumentSync';
+import { useLSPEvents } from './hooks/useLSPEvents';
 import { useFileWatcher } from './hooks/useFileWatcher';
 import { useWorkspace, useIDEStore } from './stores/ideStore';
 import { ReadDirectory, ReadFile } from '../wailsjs/go/main/App';
@@ -28,6 +29,7 @@ function App() {
   useAutosave();
   useWorkspacePersistence();
   useLSPDocumentSync();
+  useLSPEvents();
   useRecentWorkspaces();
   const workspace = useWorkspace();
   useRunProfilesLoader(workspace?.path);

--- a/frontend/src/__tests__/hooks/useLSPEvents.test.ts
+++ b/frontend/src/__tests__/hooks/useLSPEvents.test.ts
@@ -1,0 +1,195 @@
+import { renderHook, act } from '@testing-library/react';
+import { useLSPEvents } from '../../hooks/useLSPEvents';
+import { useLSPStore } from '../../stores/lspStore';
+import { useIDEStore } from '../../stores/ideStore';
+import { EventsOn } from '../../../wailsjs/runtime/runtime';
+
+const mockEventsOn = EventsOn as jest.MockedFunction<typeof EventsOn>;
+
+function captureEventHandlers() {
+  const handlers: Record<string, (...args: unknown[]) => void> = {};
+  mockEventsOn.mockImplementation((event: string, callback: (...args: unknown[]) => void) => {
+    handlers[event] = callback;
+    return jest.fn(); // cancel function
+  });
+  return handlers;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useLSPStore.setState(useLSPStore.getInitialState());
+  useIDEStore.setState({ toast: null } as Partial<ReturnType<typeof useIDEStore.getState>>);
+});
+
+describe('useLSPEvents', () => {
+  it('subscribes to lsp:diagnostics, lsp:status, and lsp:error', () => {
+    renderHook(() => useLSPEvents());
+
+    const events = mockEventsOn.mock.calls.map((call) => call[0]);
+    expect(events).toContain('lsp:diagnostics');
+    expect(events).toContain('lsp:status');
+    expect(events).toContain('lsp:error');
+  });
+
+  it('updates lspStore on lsp:diagnostics event', () => {
+    const handlers = captureEventHandlers();
+    renderHook(() => useLSPEvents());
+
+    act(() => {
+      handlers['lsp:diagnostics']({
+        workspace: '/project',
+        uri: 'file:///test.ts',
+        diagnostics: [
+          {
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } },
+            severity: 1,
+            message: 'Type error',
+          },
+        ],
+      });
+    });
+
+    const diags = useLSPStore.getState().diagnostics.get('file:///test.ts');
+    expect(diags).toHaveLength(1);
+    expect(diags![0].message).toBe('Type error');
+  });
+
+  it('ignores lsp:diagnostics from a different workspace', () => {
+    const handlers = captureEventHandlers();
+    // Set active workspace
+    useIDEStore.setState({
+      workspace: { name: 'project', path: '/project' },
+    } as Partial<ReturnType<typeof useIDEStore.getState>>);
+    renderHook(() => useLSPEvents());
+
+    act(() => {
+      handlers['lsp:diagnostics']({
+        workspace: '/other-project',
+        uri: 'file:///other/test.ts',
+        diagnostics: [
+          {
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } },
+            severity: 1,
+            message: 'Stale error',
+          },
+        ],
+      });
+    });
+
+    expect(useLSPStore.getState().diagnostics.size).toBe(0);
+  });
+
+  it('updates lspStore on lsp:status event', () => {
+    const handlers = captureEventHandlers();
+    renderHook(() => useLSPEvents());
+
+    act(() => {
+      handlers['lsp:status']({
+        family: 'typescript',
+        workspace: '/project',
+        state: 'ready',
+      });
+    });
+
+    const status = useLSPStore.getState().serverStatuses.get('/project::typescript');
+    expect(status?.state).toBe('ready');
+  });
+
+  it('shows Toast on lsp:status with state=error (e.g., missing server binary)', () => {
+    const handlers = captureEventHandlers();
+    renderHook(() => useLSPEvents());
+
+    act(() => {
+      handlers['lsp:status']({
+        family: 'typescript',
+        workspace: '/project',
+        state: 'error',
+        error:
+          'typescript-language-server not found: install it with "npm install -g typescript-language-server typescript"',
+      });
+    });
+
+    const toast = useIDEStore.getState().toast;
+    expect(toast).not.toBeNull();
+    expect(toast!.type).toBe('error');
+    expect(toast!.message).toContain('typescript-language-server not found');
+  });
+
+  it('does not show Toast on non-error lsp:status events', () => {
+    const handlers = captureEventHandlers();
+    renderHook(() => useLSPEvents());
+
+    act(() => {
+      handlers['lsp:status']({
+        family: 'typescript',
+        workspace: '/project',
+        state: 'ready',
+      });
+    });
+
+    expect(useIDEStore.getState().toast).toBeNull();
+  });
+
+  it('does not show duplicate Toast for same error', () => {
+    const handlers = captureEventHandlers();
+    renderHook(() => useLSPEvents());
+
+    // First error status — should set toast
+    act(() => {
+      handlers['lsp:status']({
+        family: 'typescript',
+        workspace: '/project',
+        state: 'error',
+        error: 'server crashed, restarting in 1s (attempt 1/5)',
+      });
+    });
+
+    const firstToast = useIDEStore.getState().toast;
+    expect(firstToast).not.toBeNull();
+
+    // Clear the toast to detect if a second one is set
+    useIDEStore.getState().clearToast();
+    expect(useIDEStore.getState().toast).toBeNull();
+
+    // Second error status for same workspace::family — should NOT set toast
+    act(() => {
+      handlers['lsp:status']({
+        family: 'typescript',
+        workspace: '/project',
+        state: 'error',
+        error: 'server crashed, restarting in 2s (attempt 2/5)',
+      });
+    });
+
+    expect(useIDEStore.getState().toast).toBeNull();
+  });
+
+  it('shows Toast on lsp:error event (crash recovery exhausted)', () => {
+    const handlers = captureEventHandlers();
+    renderHook(() => useLSPEvents());
+
+    act(() => {
+      handlers['lsp:error']({
+        family: 'typescript',
+        workspace: '/project',
+        message: 'Language server for typescript crashed repeatedly.',
+      });
+    });
+
+    const toast = useIDEStore.getState().toast;
+    expect(toast).not.toBeNull();
+    expect(toast!.type).toBe('error');
+    expect(toast!.message).toContain('crashed repeatedly');
+  });
+
+  it('cleans up subscriptions on unmount', () => {
+    const cancelFns = [jest.fn(), jest.fn(), jest.fn()];
+    let callIdx = 0;
+    mockEventsOn.mockImplementation(() => cancelFns[callIdx++]);
+
+    const { unmount } = renderHook(() => useLSPEvents());
+    unmount();
+
+    cancelFns.forEach((fn) => expect(fn).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/__tests__/hooks/useLSPEvents.test.ts
+++ b/frontend/src/__tests__/hooks/useLSPEvents.test.ts
@@ -15,10 +15,14 @@ function captureEventHandlers() {
   return handlers;
 }
 
+function setActiveWorkspace(path = '/project') {
+  useIDEStore.getState().setWorkspace({ name: path.split('/').pop() || path, path });
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   useLSPStore.setState(useLSPStore.getInitialState());
-  useIDEStore.setState({ toast: null } as Partial<ReturnType<typeof useIDEStore.getState>>);
+  useIDEStore.setState(useIDEStore.getInitialState());
 });
 
 describe('useLSPEvents', () => {
@@ -31,7 +35,7 @@ describe('useLSPEvents', () => {
     expect(events).toContain('lsp:error');
   });
 
-  it('updates lspStore on lsp:diagnostics event', () => {
+  it('updates lspStore and IDE diagnostic counts on lsp:diagnostics event', () => {
     const handlers = captureEventHandlers();
     renderHook(() => useLSPEvents());
 
@@ -52,14 +56,13 @@ describe('useLSPEvents', () => {
     const diags = useLSPStore.getState().diagnostics.get('file:///test.ts');
     expect(diags).toHaveLength(1);
     expect(diags![0].message).toBe('Type error');
+    expect(useIDEStore.getState().errorCount).toBe(1);
+    expect(useIDEStore.getState().warningCount).toBe(0);
   });
 
   it('ignores lsp:diagnostics from a different workspace', () => {
     const handlers = captureEventHandlers();
-    // Set active workspace
-    useIDEStore.setState({
-      workspace: { name: 'project', path: '/project' },
-    } as Partial<ReturnType<typeof useIDEStore.getState>>);
+    setActiveWorkspace();
     renderHook(() => useLSPEvents());
 
     act(() => {
@@ -79,6 +82,44 @@ describe('useLSPEvents', () => {
     expect(useLSPStore.getState().diagnostics.size).toBe(0);
   });
 
+  it('clears LSP state and IDE diagnostic counts on workspace switch', () => {
+    const handlers = captureEventHandlers();
+    setActiveWorkspace('/project');
+    renderHook(() => useLSPEvents());
+
+    act(() => {
+      handlers['lsp:diagnostics']({
+        workspace: '/project',
+        uri: 'file:///project/test.ts',
+        diagnostics: [
+          {
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } },
+            severity: 1,
+            message: 'Type error',
+          },
+        ],
+      });
+      handlers['lsp:status']({
+        family: 'typescript',
+        workspace: '/project',
+        state: 'ready',
+      });
+    });
+
+    expect(useLSPStore.getState().diagnostics.size).toBe(1);
+    expect(useLSPStore.getState().serverStatuses.size).toBe(1);
+    expect(useIDEStore.getState().errorCount).toBe(1);
+
+    act(() => {
+      useIDEStore.getState().setWorkspace({ name: 'other-project', path: '/other-project' });
+    });
+
+    expect(useLSPStore.getState().diagnostics.size).toBe(0);
+    expect(useLSPStore.getState().serverStatuses.size).toBe(0);
+    expect(useIDEStore.getState().errorCount).toBe(0);
+    expect(useIDEStore.getState().warningCount).toBe(0);
+  });
+
   it('updates lspStore on lsp:status event', () => {
     const handlers = captureEventHandlers();
     renderHook(() => useLSPEvents());
@@ -93,6 +134,24 @@ describe('useLSPEvents', () => {
 
     const status = useLSPStore.getState().serverStatuses.get('/project::typescript');
     expect(status?.state).toBe('ready');
+  });
+
+  it('ignores lsp:status from a different workspace', () => {
+    const handlers = captureEventHandlers();
+    setActiveWorkspace('/project');
+    renderHook(() => useLSPEvents());
+
+    act(() => {
+      handlers['lsp:status']({
+        family: 'typescript',
+        workspace: '/other-project',
+        state: 'error',
+        error: 'stale server error',
+      });
+    });
+
+    expect(useLSPStore.getState().serverStatuses.size).toBe(0);
+    expect(useIDEStore.getState().toast).toBeNull();
   });
 
   it('shows Toast on lsp:status with state=error (e.g., missing server binary)', () => {
@@ -180,6 +239,22 @@ describe('useLSPEvents', () => {
     expect(toast).not.toBeNull();
     expect(toast!.type).toBe('error');
     expect(toast!.message).toContain('crashed repeatedly');
+  });
+
+  it('ignores lsp:error from a different workspace', () => {
+    const handlers = captureEventHandlers();
+    setActiveWorkspace('/project');
+    renderHook(() => useLSPEvents());
+
+    act(() => {
+      handlers['lsp:error']({
+        family: 'typescript',
+        workspace: '/other-project',
+        message: 'Language server for typescript crashed repeatedly.',
+      });
+    });
+
+    expect(useIDEStore.getState().toast).toBeNull();
   });
 
   it('cleans up subscriptions on unmount', () => {

--- a/frontend/src/__tests__/stores/lspStore.test.ts
+++ b/frontend/src/__tests__/stores/lspStore.test.ts
@@ -71,15 +71,13 @@ describe('lspStore', () => {
           message: 'err2',
         },
       ]);
-      useLSPStore
-        .getState()
-        .setDiagnostics('file:///b.ts', [
-          {
-            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
-            severity: 2,
-            message: 'warn1',
-          },
-        ]);
+      useLSPStore.getState().setDiagnostics('file:///b.ts', [
+        {
+          range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+          severity: 2,
+          message: 'warn1',
+        },
+      ]);
 
       expect(useLSPStore.getState().errorCount()).toBe(2);
       expect(useLSPStore.getState().warningCount()).toBe(1);

--- a/frontend/src/__tests__/stores/lspStore.test.ts
+++ b/frontend/src/__tests__/stores/lspStore.test.ts
@@ -1,0 +1,165 @@
+import { useLSPStore } from '../../stores/lspStore';
+import type { LSPDiagnostic } from '../../stores/lspStore';
+
+beforeEach(() => {
+  useLSPStore.setState(useLSPStore.getInitialState());
+});
+
+describe('lspStore', () => {
+  describe('diagnostics', () => {
+    const sampleDiag: LSPDiagnostic = {
+      range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } },
+      severity: 1,
+      message: 'Type error',
+      source: 'ts',
+    };
+
+    it('stores diagnostics by URI', () => {
+      useLSPStore.getState().setDiagnostics('file:///test.ts', [sampleDiag]);
+      expect(useLSPStore.getState().diagnostics.get('file:///test.ts')).toEqual([sampleDiag]);
+    });
+
+    it('replaces previous diagnostics for same URI', () => {
+      const { setDiagnostics } = useLSPStore.getState();
+      setDiagnostics('file:///test.ts', [sampleDiag]);
+      setDiagnostics('file:///test.ts', []);
+      expect(useLSPStore.getState().diagnostics.get('file:///test.ts')).toEqual([]);
+    });
+
+    it('tracks diagnostics for multiple URIs independently', () => {
+      const { setDiagnostics } = useLSPStore.getState();
+      setDiagnostics('file:///a.ts', [sampleDiag]);
+      setDiagnostics('file:///b.ts', [{ ...sampleDiag, severity: 2, message: 'Warning' }]);
+
+      const diags = useLSPStore.getState().diagnostics;
+      expect(diags.size).toBe(2);
+      expect(diags.get('file:///a.ts')![0].severity).toBe(1);
+      expect(diags.get('file:///b.ts')![0].severity).toBe(2);
+    });
+
+    it('removes diagnostics for a single URI', () => {
+      const { setDiagnostics, removeDiagnostics } = useLSPStore.getState();
+      setDiagnostics('file:///a.ts', [sampleDiag]);
+      setDiagnostics('file:///b.ts', [sampleDiag]);
+      removeDiagnostics('file:///a.ts');
+
+      const diags = useLSPStore.getState().diagnostics;
+      expect(diags.has('file:///a.ts')).toBe(false);
+      expect(diags.has('file:///b.ts')).toBe(true);
+    });
+
+    it('clears all diagnostics', () => {
+      const { setDiagnostics, clearAllDiagnostics } = useLSPStore.getState();
+      setDiagnostics('file:///a.ts', [sampleDiag]);
+      setDiagnostics('file:///b.ts', [sampleDiag]);
+      clearAllDiagnostics();
+      expect(useLSPStore.getState().diagnostics.size).toBe(0);
+    });
+  });
+
+  describe('derived counts', () => {
+    it('counts errors (severity 1) and warnings (severity 2)', () => {
+      useLSPStore.getState().setDiagnostics('file:///a.ts', [
+        {
+          range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+          severity: 1,
+          message: 'err1',
+        },
+        {
+          range: { start: { line: 1, character: 0 }, end: { line: 1, character: 1 } },
+          severity: 1,
+          message: 'err2',
+        },
+      ]);
+      useLSPStore
+        .getState()
+        .setDiagnostics('file:///b.ts', [
+          {
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+            severity: 2,
+            message: 'warn1',
+          },
+        ]);
+
+      expect(useLSPStore.getState().errorCount()).toBe(2);
+      expect(useLSPStore.getState().warningCount()).toBe(1);
+    });
+
+    it('returns 0 when no diagnostics', () => {
+      expect(useLSPStore.getState().errorCount()).toBe(0);
+      expect(useLSPStore.getState().warningCount()).toBe(0);
+    });
+  });
+
+  describe('server status', () => {
+    it('stores server status keyed by workspace::family', () => {
+      useLSPStore.getState().setServerStatus({
+        family: 'typescript',
+        workspace: '/project',
+        state: 'ready',
+      });
+
+      const key = '/project::typescript';
+      const statuses = useLSPStore.getState().serverStatuses;
+      expect(statuses.get(key)).toEqual({
+        family: 'typescript',
+        workspace: '/project',
+        state: 'ready',
+      });
+    });
+
+    it('updates existing server status', () => {
+      const { setServerStatus } = useLSPStore.getState();
+      setServerStatus({ family: 'typescript', workspace: '/project', state: 'starting' });
+      setServerStatus({ family: 'typescript', workspace: '/project', state: 'ready' });
+
+      expect(useLSPStore.getState().serverStatuses.get('/project::typescript')?.state).toBe(
+        'ready'
+      );
+    });
+
+    it('tracks different workspaces independently', () => {
+      const { setServerStatus } = useLSPStore.getState();
+      setServerStatus({ family: 'typescript', workspace: '/project-a', state: 'ready' });
+      setServerStatus({ family: 'typescript', workspace: '/project-b', state: 'starting' });
+
+      const statuses = useLSPStore.getState().serverStatuses;
+      expect(statuses.get('/project-a::typescript')?.state).toBe('ready');
+      expect(statuses.get('/project-b::typescript')?.state).toBe('starting');
+    });
+
+    it('removes server status', () => {
+      const { setServerStatus, removeServerStatus } = useLSPStore.getState();
+      setServerStatus({ family: 'typescript', workspace: '/project', state: 'ready' });
+      removeServerStatus('/project', 'typescript');
+      expect(useLSPStore.getState().serverStatuses.has('/project::typescript')).toBe(false);
+    });
+
+    it('clears all statuses', () => {
+      const { setServerStatus, clearAllStatuses } = useLSPStore.getState();
+      setServerStatus({ family: 'typescript', workspace: '/project', state: 'ready' });
+      clearAllStatuses();
+      expect(useLSPStore.getState().serverStatuses.size).toBe(0);
+    });
+  });
+
+  describe('workspace cleanup', () => {
+    it('clears all state for a workspace', () => {
+      const state = useLSPStore.getState();
+      state.setDiagnostics('file:///project/a.ts', [
+        {
+          range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+          severity: 1,
+          message: 'err',
+        },
+      ]);
+      state.setServerStatus({ family: 'typescript', workspace: '/project', state: 'ready' });
+
+      useLSPStore.getState().clearWorkspaceState('/project');
+
+      expect(useLSPStore.getState().serverStatuses.has('/project::typescript')).toBe(false);
+      // Diagnostics are not cleared by workspace since URIs don't embed workspace paths reliably.
+      // The frontend clears diagnostics via clearAllDiagnostics on workspace switch.
+    });
+  });
+});

--- a/frontend/src/hooks/useLSPEvents.ts
+++ b/frontend/src/hooks/useLSPEvents.ts
@@ -17,6 +17,11 @@ interface ErrorPayload {
   message: string;
 }
 
+function isActiveWorkspaceEvent(workspace?: string): boolean {
+  const activeWorkspace = useIDEStore.getState().workspace?.path;
+  return !activeWorkspace || !workspace || workspace === activeWorkspace;
+}
+
 /**
  * useLSPEvents subscribes to backend LSP Wails events and routes them
  * into lspStore. Shows Toast notifications for actionable errors.
@@ -30,12 +35,35 @@ export function useLSPEvents() {
   const toastedErrors = useRef(new Set<string>());
 
   useEffect(() => {
+    const syncDiagnosticCounts = () => {
+      const lspState = useLSPStore.getState();
+      useIDEStore.getState().setDiagnostics(lspState.errorCount(), lspState.warningCount());
+    };
+
+    syncDiagnosticCounts();
+
+    const cancelLSPStore = useLSPStore.subscribe((state, prevState) => {
+      if (state.diagnostics !== prevState.diagnostics) {
+        syncDiagnosticCounts();
+      }
+    });
+
+    const cancelWorkspace = useIDEStore.subscribe((state, prevState) => {
+      const workspacePath = state.workspace?.path ?? null;
+      const prevWorkspacePath = prevState.workspace?.path ?? null;
+      if (workspacePath === prevWorkspacePath) return;
+
+      const lspState = useLSPStore.getState();
+      lspState.clearAllDiagnostics();
+      lspState.clearAllStatuses();
+      toastedErrors.current.clear();
+    });
+
     const cancelDiagnostics = EventsOn('lsp:diagnostics', (payload: DiagnosticsPayload) => {
       if (!payload?.uri) return;
 
       // Reject diagnostics from a non-active workspace
-      const activeWorkspace = useIDEStore.getState().workspace?.path;
-      if (activeWorkspace && payload.workspace && payload.workspace !== activeWorkspace) {
+      if (!isActiveWorkspaceEvent(payload.workspace)) {
         return;
       }
 
@@ -44,6 +72,8 @@ export function useLSPEvents() {
 
     const cancelStatus = EventsOn('lsp:status', (payload: LSPServerStatus) => {
       if (!payload?.family) return;
+      if (!isActiveWorkspaceEvent(payload.workspace)) return;
+
       useLSPStore.getState().setServerStatus(payload);
 
       if (payload.state === 'error' && payload.error) {
@@ -62,11 +92,15 @@ export function useLSPEvents() {
 
     const cancelError = EventsOn('lsp:error', (payload: ErrorPayload) => {
       if (!payload?.message) return;
+      if (!isActiveWorkspaceEvent(payload.workspace)) return;
+
       // Terminal errors (crash exhaustion) always show a Toast regardless of dedup
       useIDEStore.getState().showToast(payload.message, 'error');
     });
 
     return () => {
+      cancelLSPStore();
+      cancelWorkspace();
       cancelDiagnostics();
       cancelStatus();
       cancelError();

--- a/frontend/src/hooks/useLSPEvents.ts
+++ b/frontend/src/hooks/useLSPEvents.ts
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from 'react';
+import { EventsOn } from '../../wailsjs/runtime/runtime';
+import { useLSPStore } from '../stores/lspStore';
+import { useIDEStore } from '../stores/ideStore';
+import type { LSPDiagnostic, LSPServerStatus } from '../stores/lspStore';
+
+interface DiagnosticsPayload {
+  workspace: string;
+  uri: string;
+  version?: number;
+  diagnostics: LSPDiagnostic[];
+}
+
+interface ErrorPayload {
+  family: string;
+  workspace: string;
+  message: string;
+}
+
+/**
+ * useLSPEvents subscribes to backend LSP Wails events and routes them
+ * into lspStore. Shows Toast notifications for actionable errors.
+ *
+ * Toast deduplication: Only one Toast per workspace::family error state.
+ * Crash-retry status updates update the store but don't spam Toasts.
+ */
+export function useLSPEvents() {
+  // Track which workspace::family combos have already shown an error Toast
+  // to avoid spamming on crash-retry backoff cycles.
+  const toastedErrors = useRef(new Set<string>());
+
+  useEffect(() => {
+    const cancelDiagnostics = EventsOn('lsp:diagnostics', (payload: DiagnosticsPayload) => {
+      if (!payload?.uri) return;
+
+      // Reject diagnostics from a non-active workspace
+      const activeWorkspace = useIDEStore.getState().workspace?.path;
+      if (activeWorkspace && payload.workspace && payload.workspace !== activeWorkspace) {
+        return;
+      }
+
+      useLSPStore.getState().setDiagnostics(payload.uri, payload.diagnostics ?? []);
+    });
+
+    const cancelStatus = EventsOn('lsp:status', (payload: LSPServerStatus) => {
+      if (!payload?.family) return;
+      useLSPStore.getState().setServerStatus(payload);
+
+      if (payload.state === 'error' && payload.error) {
+        // Deduplicate: only toast once per workspace::family error state
+        const dedupeKey = `${payload.workspace}::${payload.family}`;
+        if (!toastedErrors.current.has(dedupeKey)) {
+          toastedErrors.current.add(dedupeKey);
+          useIDEStore.getState().showToast(payload.error, 'error');
+        }
+      } else if (payload.state === 'ready') {
+        // Server recovered — clear the dedup guard so future errors can toast again
+        const dedupeKey = `${payload.workspace}::${payload.family}`;
+        toastedErrors.current.delete(dedupeKey);
+      }
+    });
+
+    const cancelError = EventsOn('lsp:error', (payload: ErrorPayload) => {
+      if (!payload?.message) return;
+      // Terminal errors (crash exhaustion) always show a Toast regardless of dedup
+      useIDEStore.getState().showToast(payload.message, 'error');
+    });
+
+    return () => {
+      cancelDiagnostics();
+      cancelStatus();
+      cancelError();
+    };
+  }, []);
+}

--- a/frontend/src/stores/lspStore.ts
+++ b/frontend/src/stores/lspStore.ts
@@ -1,0 +1,158 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+// --- Types ---
+
+export interface LSPPosition {
+  line: number;
+  character: number;
+}
+
+export interface LSPRange {
+  start: LSPPosition;
+  end: LSPPosition;
+}
+
+export interface LSPDiagnostic {
+  range: LSPRange;
+  severity?: number;
+  code?: number | string;
+  source?: string;
+  message: string;
+}
+
+export interface LSPServerStatus {
+  family: string;
+  workspace: string;
+  state: 'starting' | 'ready' | 'stopping' | 'stopped' | 'error';
+  error?: string;
+}
+
+// --- Store ---
+
+/** Build the composite key for serverStatuses. */
+export function serverStatusKey(workspace: string, family: string): string {
+  return `${workspace}::${family}`;
+}
+
+interface LSPState {
+  /** URI -> diagnostics array. Updated by publishDiagnostics notifications. */
+  diagnostics: Map<string, LSPDiagnostic[]>;
+  /** "workspace::family" -> server status. Updated by lsp:status events. */
+  serverStatuses: Map<string, LSPServerStatus>;
+}
+
+interface LSPActions {
+  setDiagnostics: (uri: string, diagnostics: LSPDiagnostic[]) => void;
+  removeDiagnostics: (uri: string) => void;
+  clearAllDiagnostics: () => void;
+
+  setServerStatus: (status: LSPServerStatus) => void;
+  removeServerStatus: (workspace: string, family: string) => void;
+  clearAllStatuses: () => void;
+
+  /** Clear server statuses for a given workspace. */
+  clearWorkspaceState: (workspace: string) => void;
+
+  /** Derived: total count of severity=1 diagnostics across all files.
+   *  Note: This is a method, not a reactive selector. Phase 4 should convert
+   *  to proper derived state when wiring StatusBar consumers. */
+  errorCount: () => number;
+  /** Derived: total count of severity=2 diagnostics across all files. */
+  warningCount: () => number;
+}
+
+type LSPStore = LSPState & LSPActions;
+
+export const useLSPStore = create<LSPStore>()(
+  devtools(
+    (set, get) => ({
+      diagnostics: new Map(),
+      serverStatuses: new Map(),
+
+      setDiagnostics: (uri, diagnostics) =>
+        set(
+          (state) => {
+            const next = new Map(state.diagnostics);
+            next.set(uri, diagnostics);
+            return { diagnostics: next };
+          },
+          false,
+          'setDiagnostics'
+        ),
+
+      removeDiagnostics: (uri) =>
+        set(
+          (state) => {
+            const next = new Map(state.diagnostics);
+            next.delete(uri);
+            return { diagnostics: next };
+          },
+          false,
+          'removeDiagnostics'
+        ),
+
+      clearAllDiagnostics: () => set({ diagnostics: new Map() }, false, 'clearAllDiagnostics'),
+
+      setServerStatus: (status) =>
+        set(
+          (state) => {
+            const next = new Map(state.serverStatuses);
+            next.set(serverStatusKey(status.workspace, status.family), status);
+            return { serverStatuses: next };
+          },
+          false,
+          'setServerStatus'
+        ),
+
+      removeServerStatus: (workspace, family) =>
+        set(
+          (state) => {
+            const next = new Map(state.serverStatuses);
+            next.delete(serverStatusKey(workspace, family));
+            return { serverStatuses: next };
+          },
+          false,
+          'removeServerStatus'
+        ),
+
+      clearAllStatuses: () => set({ serverStatuses: new Map() }, false, 'clearAllStatuses'),
+
+      clearWorkspaceState: (workspace) =>
+        set(
+          (state) => {
+            const nextStatuses = new Map(state.serverStatuses);
+            for (const [key, status] of nextStatuses) {
+              if (status.workspace === workspace) {
+                nextStatuses.delete(key);
+              }
+            }
+            return { serverStatuses: nextStatuses };
+          },
+          false,
+          'clearWorkspaceState'
+        ),
+
+      errorCount: () => {
+        let count = 0;
+        for (const diags of get().diagnostics.values()) {
+          for (const d of diags) {
+            if (d.severity === 1) count++;
+          }
+        }
+        return count;
+      },
+
+      warningCount: () => {
+        let count = 0;
+        for (const diags of get().diagnostics.values()) {
+          for (const d of diags) {
+            if (d.severity === 2) count++;
+          }
+        }
+        return count;
+      },
+    }),
+    { name: 'lsp-store' }
+  )
+);

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -576,7 +576,14 @@ func (m *Manager) handleNotification(key serverKey, method string, params json.R
 			}
 			m.mu.Unlock()
 		}
-		m.emitter("lsp:diagnostics", params)
+		// Wrap diagnostics with workspace context so the frontend can
+		// filter stale events after workspace switches.
+		m.emitter("lsp:diagnostics", map[string]any{
+			"workspace":   key.workspace,
+			"uri":         diagParams.URI,
+			"version":     diagParams.Version,
+			"diagnostics": diagParams.Diagnostics,
+		})
 	}
 }
 

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -2,7 +2,6 @@ package lsp
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"sync"
@@ -433,13 +432,18 @@ func TestManager_DiagnosticsRouting(t *testing.T) {
 		if event == "lsp:diagnostics" && len(data) > 0 {
 			diagMu.Lock()
 			defer diagMu.Unlock()
-			raw, ok := data[0].(json.RawMessage)
-			if ok {
-				var d PublishDiagnosticsParams
-				if err := json.Unmarshal(raw, &d); err == nil {
-					diagnostics = append(diagnostics, d)
-				}
+			payload, ok := data[0].(map[string]any)
+			if !ok {
+				return
 			}
+			uri, _ := payload["uri"].(string)
+			diags, _ := payload["diagnostics"].([]Diagnostic)
+			version, _ := payload["version"].(int)
+			diagnostics = append(diagnostics, PublishDiagnosticsParams{
+				URI:         uri,
+				Version:     version,
+				Diagnostics: diags,
+			})
 		}
 	}
 

--- a/internal/lsp/registry.go
+++ b/internal/lsp/registry.go
@@ -2,6 +2,7 @@ package lsp
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -100,9 +101,20 @@ func (r *Registry) resolveTypeScriptServer(workspaceRoot string) (*ServerConfig,
 		)
 	}
 
+	args := []string{"--stdio"}
+
+	// 3. If workspace has local TypeScript lib, tell the system server to use it
+	// via --tsserver-path. This ensures the server uses the project's TS version
+	// rather than whatever TypeScript the global server bundles.
+	// TODO: Gate behind workspace trust when trust system is implemented.
+	localTSLib := filepath.Join(workspaceRoot, "node_modules", "typescript", "lib")
+	if _, statErr := os.Stat(filepath.Join(localTSLib, "tsserver.js")); statErr == nil {
+		args = append(args, "--tsserver-path", localTSLib)
+	}
+
 	return &ServerConfig{
 		LanguageFamily: "typescript",
 		Command:        path,
-		Args:           []string{"--stdio"},
+		Args:           args,
 	}, nil
 }

--- a/internal/lsp/registry_test.go
+++ b/internal/lsp/registry_test.go
@@ -1,0 +1,153 @@
+package lsp
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// fakeTSLSBin creates a fake typescript-language-server executable in a temp
+// directory and returns the directory path (suitable for prepending to PATH).
+func fakeTSLSBin(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	binary := "typescript-language-server"
+	if runtime.GOOS == "windows" {
+		binary += ".cmd"
+	}
+	// Write a no-op script that's executable
+	if err := os.WriteFile(filepath.Join(dir, binary), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestResolveTypeScriptServer_MixedInstall(t *testing.T) {
+	// Workspace has local TypeScript lib but no local typescript-language-server.
+	// A fake system server is placed on PATH so the test is CI-deterministic.
+	workspace := t.TempDir()
+	tsLib := filepath.Join(workspace, "node_modules", "typescript", "lib")
+	if err := os.MkdirAll(tsLib, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tsLib, "tsserver.js"), []byte("// stub"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Prepend a fake typescript-language-server to PATH so exec.LookPath succeeds
+	fakeBinDir := fakeTSLSBin(t)
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBinDir+string(os.PathListSeparator)+origPath)
+
+	registry := NewRegistry()
+	config, err := registry.ServerConfigFor("typescript", workspace)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify --tsserver-path is present and points to the local lib
+	foundTsserverPath := false
+	for i, arg := range config.Args {
+		if arg == "--tsserver-path" && i+1 < len(config.Args) {
+			if config.Args[i+1] == tsLib {
+				foundTsserverPath = true
+			} else {
+				t.Errorf("--tsserver-path value = %q, want %q", config.Args[i+1], tsLib)
+			}
+		}
+	}
+	if !foundTsserverPath {
+		t.Error("expected --tsserver-path in args for mixed install, got:", config.Args)
+	}
+}
+
+func TestResolveTypeScriptServer_NoTsserverPathWhenLocalServerExists(t *testing.T) {
+	// When the workspace has a local typescript-language-server,
+	// --tsserver-path should NOT be added (the local server finds its own TS).
+	workspace := t.TempDir()
+	binDir := filepath.Join(workspace, "node_modules", ".bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	binary := "typescript-language-server"
+	if runtime.GOOS == "windows" {
+		binary += ".cmd"
+	}
+	binPath := filepath.Join(binDir, binary)
+	if err := os.WriteFile(binPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	registry := NewRegistry()
+	config, err := registry.ServerConfigFor("typescript", workspace)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, arg := range config.Args {
+		if arg == "--tsserver-path" {
+			t.Error("unexpected --tsserver-path for workspace-local server")
+		}
+	}
+}
+
+func TestResolveTypeScriptServer_NoLocalTS(t *testing.T) {
+	// Workspace has neither local TS lib nor local server.
+	// A fake system server is on PATH. No --tsserver-path should be added.
+	workspace := t.TempDir()
+
+	fakeBinDir := fakeTSLSBin(t)
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBinDir+string(os.PathListSeparator)+origPath)
+
+	registry := NewRegistry()
+	config, err := registry.ServerConfigFor("typescript", workspace)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, arg := range config.Args {
+		if arg == "--tsserver-path" {
+			t.Error("unexpected --tsserver-path when no local TypeScript lib exists")
+		}
+	}
+
+	// Should just be --stdio
+	if len(config.Args) != 1 || config.Args[0] != "--stdio" {
+		t.Errorf("expected args [--stdio], got %v", config.Args)
+	}
+}
+
+func TestResolveTypeScriptServer_NotFound(t *testing.T) {
+	// No server anywhere — should return an actionable error
+	workspace := t.TempDir()
+
+	// Empty PATH so nothing is found
+	t.Setenv("PATH", "")
+
+	registry := NewRegistry()
+	_, err := registry.ServerConfigFor("typescript", workspace)
+	if err == nil {
+		t.Fatal("expected error when typescript-language-server is not found")
+	}
+
+	// Error message should contain install instructions
+	if !contains(err.Error(), "npm install") {
+		t.Errorf("error message should contain install instructions, got: %s", err.Error())
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Add `--tsserver-path` flag in `registry.go` for mixed installs (workspace has `node_modules/typescript` but no local `typescript-language-server`), so the system server uses the project's TypeScript version
- Wrap `lsp:diagnostics` event payload with workspace context in `manager.go` so the frontend can filter stale events after workspace switches
- Add `lspStore` Zustand store for per-file diagnostics (URI -> diagnostics[]), server status keyed by workspace::family, derived error/warning counts, and targeted cleanup methods
- Add `useLSPEvents` hook subscribing to `lsp:diagnostics`, `lsp:status`, and `lsp:error` Wails events with workspace filtering and deduplicated Toast notifications for actionable errors
- Wire `useLSPEvents` into App.tsx alongside existing document sync

## Test plan

- [x] Go: `go test ./...` -- 8 packages pass including new registry tests (mixed install, local server, no local TS, not found)
- [x] Frontend: `npx jest --no-coverage` -- 40 suites / 393 tests pass including new lspStore (13 tests) and useLSPEvents (9 tests) suites

The following scenarios are covered by automated tests in `useLSPEvents.test.ts`:

- [x] Diagnostics from a non-active workspace are rejected (`ignores lsp:diagnostics from a different workspace`)
- [x] Duplicate Toast deduplication: repeated `lsp:status` errors for same workspace::family only show one Toast (`does not show duplicate Toast for same error`)
- [x] `lsp:error` (crash exhaustion) always shows Toast regardless of dedup state (`shows Toast on lsp:error event (crash recovery exhausted)`)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>