### PR TITLE
fix(lsp): set server working directory to workspace root and capture stderr

### DIFF
--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -343,7 +344,7 @@ func (m *Manager) ensureServer(ctx context.Context, family, workspace string) (*
 func (m *Manager) startServer(ctx context.Context, key serverKey, config *ServerConfig) (*serverEntry, error) {
 	m.emitStatus(key.family, key.workspace, "starting", "")
 
-	transport, err := NewStdioTransport(config.Command, config.Args...)
+	transport, err := NewStdioTransport(config.Command, config.Dir, config.Args...)
 	if err != nil {
 		m.emitStatus(key.family, key.workspace, "error", err.Error())
 		return nil, fmt.Errorf("start server %s: %w", config.Command, err)
@@ -366,8 +367,13 @@ func (m *Manager) startServer(ctx context.Context, key serverKey, config *Server
 		return nil, fmt.Errorf("invalid workspace path %q: %w", key.workspace, err)
 	}
 	if err := client.Initialize(ctx, rootURI); err != nil {
+		// Include captured server stderr in the error for diagnostics.
+		errMsg := err.Error()
+		if stderr := transport.Stderr(); stderr != "" {
+			errMsg = fmt.Sprintf("%s (server stderr: %s)", errMsg, strings.TrimSpace(stderr))
+		}
 		transport.Close()
-		m.emitStatus(key.family, key.workspace, "error", err.Error())
+		m.emitStatus(key.family, key.workspace, "error", errMsg)
 		return nil, fmt.Errorf("initialize %s: %w", config.Command, err)
 	}
 

--- a/internal/lsp/registry.go
+++ b/internal/lsp/registry.go
@@ -17,6 +17,9 @@ type ServerConfig struct {
 	Command string
 	// Args are the command-line arguments.
 	Args []string
+	// Dir is the working directory for the spawned process.
+	// Language servers often resolve configs (tsconfig.json, etc.) relative to their cwd.
+	Dir string
 }
 
 // Registry maps file extensions and language contexts to server configurations.
@@ -88,6 +91,7 @@ func (r *Registry) resolveTypeScriptServer(workspaceRoot string) (*ServerConfig,
 			LanguageFamily: "typescript",
 			Command:        path,
 			Args:           []string{"--stdio"},
+			Dir:            workspaceRoot,
 		}, nil
 	}
 
@@ -116,5 +120,6 @@ func (r *Registry) resolveTypeScriptServer(workspaceRoot string) (*ServerConfig,
 		LanguageFamily: "typescript",
 		Command:        path,
 		Args:           args,
+		Dir:            workspaceRoot,
 	}, nil
 }

--- a/internal/lsp/transport_stdio.go
+++ b/internal/lsp/transport_stdio.go
@@ -1,6 +1,7 @@
 package lsp
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os/exec"
@@ -11,12 +12,16 @@ import (
 // processExitTimeout is the time to wait for a server process to exit gracefully before killing it.
 const processExitTimeout = 5 * time.Second
 
+// maxStderrCapture is the maximum number of stderr bytes to retain for diagnostics.
+const maxStderrCapture = 4096
+
 // StdioTransport implements Transport over a child process's stdin/stdout.
 type StdioTransport struct {
 	cmd    *exec.Cmd
 	codec  *Codec
 	stdin  io.WriteCloser
 	stdout io.ReadCloser
+	stderr *limitedBuffer
 
 	closeOnce sync.Once
 	done      chan struct{}
@@ -25,8 +30,12 @@ type StdioTransport struct {
 }
 
 // NewStdioTransport starts the given command and wraps its stdin/stdout as an LSP transport.
-func NewStdioTransport(name string, args ...string) (*StdioTransport, error) {
+// dir sets the working directory for the spawned process; if empty, the parent's cwd is used.
+func NewStdioTransport(name string, dir string, args ...string) (*StdioTransport, error) {
 	cmd := exec.Command(name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -39,8 +48,9 @@ func NewStdioTransport(name string, args ...string) (*StdioTransport, error) {
 		return nil, fmt.Errorf("stdout pipe: %w", err)
 	}
 
-	// Discard stderr to avoid blocking the server process
-	cmd.Stderr = io.Discard
+	// Capture stderr so crash diagnostics can be included in error messages.
+	stderrBuf := &limitedBuffer{max: maxStderrCapture}
+	cmd.Stderr = stderrBuf
 
 	if err := cmd.Start(); err != nil {
 		stdin.Close()
@@ -52,6 +62,7 @@ func NewStdioTransport(name string, args ...string) (*StdioTransport, error) {
 		codec:  NewCodec(stdout, stdin),
 		stdin:  stdin,
 		stdout: stdout,
+		stderr: stderrBuf,
 		done:   make(chan struct{}),
 	}
 
@@ -65,6 +76,11 @@ func NewStdioTransport(name string, args ...string) (*StdioTransport, error) {
 	}()
 
 	return t, nil
+}
+
+// Stderr returns the captured stderr output from the server process.
+func (t *StdioTransport) Stderr() string {
+	return t.stderr.String()
 }
 
 // Send writes a JSON-RPC message to the server's stdin.
@@ -136,4 +152,27 @@ func (t *StdioTransport) ExitErr() error {
 	default:
 		return nil
 	}
+}
+
+// limitedBuffer is a bytes.Buffer that silently discards writes beyond max bytes.
+// This prevents a chatty server from consuming unbounded memory via stderr.
+type limitedBuffer struct {
+	buf bytes.Buffer
+	max int
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	remaining := b.max - b.buf.Len()
+	if remaining <= 0 {
+		return len(p), nil // discard but report success so the writer doesn't block
+	}
+	if len(p) > remaining {
+		p = p[:remaining]
+	}
+	b.buf.Write(p)
+	return len(p), nil
+}
+
+func (b *limitedBuffer) String() string {
+	return b.buf.String()
 }


### PR DESCRIPTION
## Summary
- **Set `cmd.Dir` to workspace root** when spawning language server processes -- previously inherited Firn IDE's cwd, causing `typescript-language-server` to crash when it couldn't find `tsconfig.json`/`node_modules` relative to its working directory
- **Capture server stderr** (capped at 4KB) instead of discarding it, so crash diagnostics are included in the error toast shown to the user
- **Add `Dir` field to `ServerConfig`** -- registry now sets it to `workspaceRoot` for all config paths

## Context
When opening a `.ts` file, the user saw a brief error toast: "initialize: server connection closed while waiting for initialize". The server was found and launched, but crashed before completing the LSP handshake because it was running in the wrong directory.

## Test plan
- [x] All Go LSP tests pass (`go test ./internal/lsp/...`)
- [x] Open a `.ts` file in a TypeScript project -- server should initialize without errors
- [x] Open a `.ts` file in a non-TS project -- error toast should now include stderr output explaining why the server failed
- [x] Crash recovery still works (kill the server process, verify it restarts)

Generated with [Claude Code](https://claude.com/claude-code)