### PR TITLE
fix(lsp): move tsserver path from CLI flag to initializationOptions

### DIFF
--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -73,7 +73,8 @@ func NewClient(transport Transport, handler NotificationHandler) *Client {
 
 // Initialize sends the initialize request and the initialized notification.
 // rootURI should be a file:// URI for the workspace root.
-func (c *Client) Initialize(ctx context.Context, rootURI string) error {
+// initOptions, if non-nil, is sent as initializationOptions in the request.
+func (c *Client) Initialize(ctx context.Context, rootURI string, initOptions any) error {
 	c.stateMu.Lock()
 	if c.state != ClientStateUninitialized {
 		c.stateMu.Unlock()
@@ -83,9 +84,10 @@ func (c *Client) Initialize(ctx context.Context, rootURI string) error {
 	c.stateMu.Unlock()
 
 	params := InitializeParams{
-		ProcessID:    nil, // null per LSP spec — we manage server lifecycle ourselves
-		RootURI:      rootURI,
-		Capabilities: clientCapabilities,
+		ProcessID:             nil, // null per LSP spec — we manage server lifecycle ourselves
+		RootURI:               rootURI,
+		Capabilities:          clientCapabilities,
+		InitializationOptions: initOptions,
 	}
 
 	var result InitializeResult

--- a/internal/lsp/client_test.go
+++ b/internal/lsp/client_test.go
@@ -15,7 +15,7 @@ func TestClient_InitializeAndShutdown(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if err := client.Initialize(ctx, "file:///tmp/test"); err != nil {
+	if err := client.Initialize(ctx, "file:///tmp/test", nil); err != nil {
 		t.Fatalf("Initialize: %v", err)
 	}
 
@@ -48,12 +48,12 @@ func TestClient_DoubleInitialize(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if err := client.Initialize(ctx, "file:///tmp/test"); err != nil {
+	if err := client.Initialize(ctx, "file:///tmp/test", nil); err != nil {
 		t.Fatalf("Initialize: %v", err)
 	}
 
 	// Second initialize should fail
-	if err := client.Initialize(ctx, "file:///tmp/test"); err == nil {
+	if err := client.Initialize(ctx, "file:///tmp/test", nil); err == nil {
 		t.Error("expected error on double initialize")
 	}
 
@@ -67,7 +67,7 @@ func TestClient_Hover(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if err := client.Initialize(ctx, "file:///tmp/test"); err != nil {
+	if err := client.Initialize(ctx, "file:///tmp/test", nil); err != nil {
 		t.Fatalf("Initialize: %v", err)
 	}
 
@@ -92,7 +92,7 @@ func TestClient_Definition(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if err := client.Initialize(ctx, "file:///tmp/test"); err != nil {
+	if err := client.Initialize(ctx, "file:///tmp/test", nil); err != nil {
 		t.Fatalf("Initialize: %v", err)
 	}
 
@@ -117,7 +117,7 @@ func TestClient_Completion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if err := client.Initialize(ctx, "file:///tmp/test"); err != nil {
+	if err := client.Initialize(ctx, "file:///tmp/test", nil); err != nil {
 		t.Fatalf("Initialize: %v", err)
 	}
 
@@ -156,7 +156,7 @@ func TestClient_DidOpenAndDiagnostics(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if err := client.Initialize(ctx, "file:///tmp/test"); err != nil {
+	if err := client.Initialize(ctx, "file:///tmp/test", nil); err != nil {
 		t.Fatalf("Initialize: %v", err)
 	}
 
@@ -200,7 +200,7 @@ func TestClient_DidChangeThenClose(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if err := client.Initialize(ctx, "file:///tmp/test"); err != nil {
+	if err := client.Initialize(ctx, "file:///tmp/test", nil); err != nil {
 		t.Fatalf("Initialize: %v", err)
 	}
 
@@ -234,7 +234,7 @@ func TestClient_RequestTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if err := client.Initialize(ctx, "file:///tmp/test"); err != nil {
+	if err := client.Initialize(ctx, "file:///tmp/test", nil); err != nil {
 		t.Fatalf("Initialize: %v", err)
 	}
 

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -366,7 +366,7 @@ func (m *Manager) startServer(ctx context.Context, key serverKey, config *Server
 		m.emitStatus(key.family, key.workspace, "error", err.Error())
 		return nil, fmt.Errorf("invalid workspace path %q: %w", key.workspace, err)
 	}
-	if err := client.Initialize(ctx, rootURI); err != nil {
+	if err := client.Initialize(ctx, rootURI, config.InitOptions); err != nil {
 		// Include captured server stderr in the error for diagnostics.
 		errMsg := err.Error()
 		if stderr := transport.Stderr(); stderr != "" {

--- a/internal/lsp/registry.go
+++ b/internal/lsp/registry.go
@@ -20,6 +20,8 @@ type ServerConfig struct {
 	// Dir is the working directory for the spawned process.
 	// Language servers often resolve configs (tsconfig.json, etc.) relative to their cwd.
 	Dir string
+	// InitOptions, if non-nil, is sent as initializationOptions in the LSP initialize request.
+	InitOptions any
 }
 
 // Registry maps file extensions and language contexts to server configurations.
@@ -108,12 +110,18 @@ func (r *Registry) resolveTypeScriptServer(workspaceRoot string) (*ServerConfig,
 	args := []string{"--stdio"}
 
 	// 3. If workspace has local TypeScript lib, tell the system server to use it
-	// via --tsserver-path. This ensures the server uses the project's TS version
-	// rather than whatever TypeScript the global server bundles.
+	// via initializationOptions.tsserver.path. This ensures the server uses the
+	// project's TS version rather than whatever TypeScript the global server bundles.
+	// (The --tsserver-path CLI flag was removed in typescript-language-server v4+.)
 	// TODO: Gate behind workspace trust when trust system is implemented.
+	var initOpts any
 	localTSLib := filepath.Join(workspaceRoot, "node_modules", "typescript", "lib")
 	if _, statErr := os.Stat(filepath.Join(localTSLib, "tsserver.js")); statErr == nil {
-		args = append(args, "--tsserver-path", localTSLib)
+		initOpts = map[string]any{
+			"tsserver": map[string]any{
+				"path": localTSLib,
+			},
+		}
 	}
 
 	return &ServerConfig{
@@ -121,5 +129,6 @@ func (r *Registry) resolveTypeScriptServer(workspaceRoot string) (*ServerConfig,
 		Command:        path,
 		Args:           args,
 		Dir:            workspaceRoot,
+		InitOptions:    initOpts,
 	}, nil
 }

--- a/internal/lsp/registry_test.go
+++ b/internal/lsp/registry_test.go
@@ -46,19 +46,24 @@ func TestResolveTypeScriptServer_MixedInstall(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Verify --tsserver-path is present and points to the local lib
-	foundTsserverPath := false
-	for i, arg := range config.Args {
-		if arg == "--tsserver-path" && i+1 < len(config.Args) {
-			if config.Args[i+1] == tsLib {
-				foundTsserverPath = true
-			} else {
-				t.Errorf("--tsserver-path value = %q, want %q", config.Args[i+1], tsLib)
-			}
-		}
+	// Verify tsserver.path is set in InitOptions (not CLI args — v4+ removed the flag)
+	opts, ok := config.InitOptions.(map[string]any)
+	if !ok {
+		t.Fatalf("expected InitOptions to be map[string]any, got %T", config.InitOptions)
 	}
-	if !foundTsserverPath {
-		t.Error("expected --tsserver-path in args for mixed install, got:", config.Args)
+	tsserverOpts, ok := opts["tsserver"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected tsserver key in InitOptions, got %v", opts)
+	}
+	if tsserverOpts["path"] != tsLib {
+		t.Errorf("tsserver.path = %q, want %q", tsserverOpts["path"], tsLib)
+	}
+
+	// CLI args should NOT contain --tsserver-path
+	for _, arg := range config.Args {
+		if arg == "--tsserver-path" {
+			t.Error("--tsserver-path should not be in CLI args (removed in v4+)")
+		}
 	}
 }
 

--- a/internal/lsp/types.go
+++ b/internal/lsp/types.go
@@ -136,9 +136,10 @@ type Hover struct {
 
 // InitializeParams are sent as the first request from client to server.
 type InitializeParams struct {
-	ProcessID    *int            `json:"processId"`
-	RootURI      string          `json:"rootUri"`
-	Capabilities json.RawMessage `json:"capabilities"`
+	ProcessID             *int            `json:"processId"`
+	RootURI               string          `json:"rootUri"`
+	Capabilities          json.RawMessage `json:"capabilities"`
+	InitializationOptions any             `json:"initializationOptions,omitempty"`
 }
 
 // InitializeResult is the server's response to the initialize request.


### PR DESCRIPTION
## Summary
- **Root cause of "initialize: server connection closed"** -- the `--tsserver-path` CLI flag was removed in `typescript-language-server` v4+, but our registry was still passing it as a CLI arg. The server exited immediately with "unknown option '--tsserver-path'" before completing the LSP handshake.
- Move tsserver path to `initializationOptions.tsserver.path` in the LSP `initialize` request, which is the correct mechanism for v4+
- Add `InitializationOptions` field to `InitializeParams` and `ServerConfig`
- Update `Client.Initialize` signature to accept and forward `initOptions`

## Context
Depends on PR #80 (merged) which added stderr capture -- that's how we identified the actual error message. Without stderr capture, the user only saw the generic "server connection closed" toast.

## Test plan
- [x] All Go LSP tests pass (`go test ./internal/lsp/...`)
- [x] `TestResolveTypeScriptServer_MixedInstall` now verifies `InitOptions` instead of CLI args
- [x] Open a `.ts` file in a project with local TypeScript -- server should initialize without errors
- [x] Open a `.ts` file in a project without TypeScript -- server should still initialize (falls back to global TS)

Generated with [Claude Code](https://claude.com/claude-code)