### PR TITLE
[codex] Fix terminal close-all session behavior

### DIFF
--- a/frontend/src/__tests__/components/Terminal.test.tsx
+++ b/frontend/src/__tests__/components/Terminal.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Terminal } from '../../components/Terminal';
 import { useIDEStore } from '../../stores/ideStore';
 
@@ -28,6 +28,7 @@ describe('Terminal component', () => {
       hasAutoCreatedInitialTerminalSession: false,
       runOutputs: {},
       activeRunOutputId: null,
+      toast: null,
     });
   });
 
@@ -51,5 +52,30 @@ describe('Terminal component', () => {
     expect(await screen.findByText('Terminal 1')).toBeInTheDocument();
     expect(screen.queryByText('Terminal 2')).not.toBeInTheDocument();
     expect(mockCreateTerminal).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries initial auto-create after a failed terminal spawn', async () => {
+    mockCreateTerminal.mockReset();
+    mockCreateTerminal.mockRejectedValueOnce(new Error('pty unavailable'));
+    mockCreateTerminal.mockResolvedValueOnce('term-1');
+
+    render(<Terminal />);
+
+    await waitFor(() => {
+      expect(useIDEStore.getState().toast?.message).toContain('pty unavailable');
+    });
+    expect(mockCreateTerminal).toHaveBeenCalledTimes(1);
+    expect(useIDEStore.getState().hasAutoCreatedInitialTerminalSession).toBe(false);
+
+    act(() => {
+      useIDEStore.getState().setTerminalTab('output');
+    });
+    act(() => {
+      useIDEStore.getState().setTerminalTab('terminal');
+    });
+
+    expect(await screen.findByText('Terminal 1')).toBeInTheDocument();
+    expect(mockCreateTerminal).toHaveBeenCalledTimes(2);
+    expect(useIDEStore.getState().hasAutoCreatedInitialTerminalSession).toBe(true);
   });
 });

--- a/frontend/src/__tests__/components/Terminal.test.tsx
+++ b/frontend/src/__tests__/components/Terminal.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Terminal } from '../../components/Terminal';
+import { useIDEStore } from '../../stores/ideStore';
+
+const mockCreateTerminal = jest.fn();
+const mockCloseTerminal = jest.fn();
+
+jest.mock('../../../wailsjs/go/main/App', () => ({
+  CreateTerminal: (...args: unknown[]) => mockCreateTerminal(...args),
+  WriteTerminal: jest.fn(),
+  CloseTerminal: (...args: unknown[]) => mockCloseTerminal(...args),
+  ResizeTerminal: jest.fn(),
+}));
+
+jest.mock('../../../wailsjs/runtime', () => ({
+  EventsOn: jest.fn(() => jest.fn()),
+}));
+
+describe('Terminal component', () => {
+  beforeEach(() => {
+    mockCreateTerminal.mockReset();
+    mockCloseTerminal.mockReset();
+    mockCreateTerminal.mockResolvedValueOnce('term-1').mockResolvedValueOnce('term-2');
+    useIDEStore.setState({
+      activeTerminalTab: 'terminal',
+      terminalSessions: [],
+      activeTerminalSessionId: null,
+      hasAutoCreatedInitialTerminalSession: false,
+      runOutputs: {},
+      activeRunOutputId: null,
+    });
+  });
+
+  it('leaves the terminal panel empty after closing the last session and resets the next default title', async () => {
+    render(<Terminal />);
+
+    expect(await screen.findByText('Terminal 1')).toBeInTheDocument();
+    expect(mockCreateTerminal).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByLabelText('Close Terminal 1'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Terminal 1')).not.toBeInTheDocument();
+    });
+    expect(mockCloseTerminal).toHaveBeenCalledWith('term-1');
+    expect(mockCreateTerminal).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText('New terminal session')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('New terminal session'));
+
+    expect(await screen.findByText('Terminal 1')).toBeInTheDocument();
+    expect(screen.queryByText('Terminal 2')).not.toBeInTheDocument();
+    expect(mockCreateTerminal).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/__tests__/stores/ideStore.test.ts
+++ b/frontend/src/__tests__/stores/ideStore.test.ts
@@ -12,6 +12,7 @@ beforeEach(() => {
     panelSizes: { left: 260, right: 280, bottom: 200 },
     terminalSessions: [],
     activeTerminalSessionId: null,
+    hasAutoCreatedInitialTerminalSession: false,
   });
 });
 
@@ -283,6 +284,14 @@ describe('ideStore - terminal sessions', () => {
 
     const sessions = useIDEStore.getState().terminalSessions;
     expect(sessions.map((s) => s.id)).toEqual(['term-1', 'term-2']);
+  });
+
+  it('should track when the initial terminal session has been created', () => {
+    const { markInitialTerminalSessionCreated } = useIDEStore.getState();
+
+    markInitialTerminalSessionCreated();
+
+    expect(useIDEStore.getState().hasAutoCreatedInitialTerminalSession).toBe(true);
   });
 });
 

--- a/frontend/src/components/Terminal/Terminal.tsx
+++ b/frontend/src/components/Terminal/Terminal.tsx
@@ -114,6 +114,24 @@ function cleanupSessionBuffers(sessionId: string) {
   outputListeners.delete(sessionId);
 }
 
+function getNextTerminalTitle(sessions: Array<{ title: string }>) {
+  const usedNumbers = new Set<number>();
+
+  for (const session of sessions) {
+    const match = /^Terminal (\d+)$/.exec(session.title);
+    if (match) {
+      usedNumbers.add(Number(match[1]));
+    }
+  }
+
+  let nextNumber = 1;
+  while (usedNumbers.has(nextNumber)) {
+    nextNumber += 1;
+  }
+
+  return `Terminal ${nextNumber}`;
+}
+
 export function Terminal() {
   const activeTab = useIDEStore((state) => state.activeTerminalTab);
   const setTerminalTab = useIDEStore((state) => state.setTerminalTab);
@@ -125,6 +143,10 @@ export function Terminal() {
   const setActiveSession = useIDEStore((state) => state.setActiveTerminalSession);
   const renameSession = useIDEStore((state) => state.renameTerminalSession);
   const reorderSessions = useIDEStore((state) => state.reorderTerminalSessions);
+  const hasAutoCreatedInitialSession = useIDEStore(
+    (state) => state.hasAutoCreatedInitialTerminalSession
+  );
+  const markInitialSessionCreated = useIDEStore((state) => state.markInitialTerminalSessionCreated);
   const showToast = useIDEStore((state) => state.showToast);
 
   useRunOutputListener();
@@ -135,7 +157,6 @@ export function Terminal() {
   const setViewMode = useIDEStore((s) => s.setRunOutputViewMode);
   const outputIds = Object.keys(runOutputs);
 
-  const sessionCountRef = useRef(0);
   const isCreatingRef = useRef(false);
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
@@ -158,8 +179,8 @@ export function Terminal() {
       // Register global listener before creating the PTY so early output is buffered
       ensureGlobalOutputListener();
       const id = await CreateTerminal();
-      sessionCountRef.current += 1;
-      addSession({ id, title: `Terminal ${sessionCountRef.current}` });
+      const title = getNextTerminalTitle(useIDEStore.getState().terminalSessions);
+      addSession({ id, title });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error';
       showToast(`Failed to create terminal: ${message}`, 'error');
@@ -168,12 +189,23 @@ export function Terminal() {
     }
   }, [addSession, showToast]);
 
-  // Auto-create a session when switching to the terminal tab with no sessions
+  // Auto-create the first terminal once, but honor an explicit close-all state.
   useEffect(() => {
-    if (activeTab === 'terminal' && terminalSessions.length === 0) {
+    if (
+      activeTab === 'terminal' &&
+      terminalSessions.length === 0 &&
+      !hasAutoCreatedInitialSession
+    ) {
+      markInitialSessionCreated();
       createNewSession();
     }
-  }, [activeTab, terminalSessions.length, createNewSession]);
+  }, [
+    activeTab,
+    createNewSession,
+    hasAutoCreatedInitialSession,
+    markInitialSessionCreated,
+    terminalSessions.length,
+  ]);
 
   const handleCloseSession = useCallback(
     (e: React.MouseEvent, sessionId: string) => {
@@ -268,7 +300,7 @@ export function Terminal() {
             </button>
           );
         })}
-        {activeTab === 'terminal' && terminalSessions.length > 0 && (
+        {activeTab === 'terminal' && (
           <>
             <div className={styles.divider} />
             {terminalSessions.map((session, index) => {

--- a/frontend/src/components/Terminal/Terminal.tsx
+++ b/frontend/src/components/Terminal/Terminal.tsx
@@ -172,22 +172,28 @@ export function Terminal() {
     ensureGlobalOutputListener();
   }, []);
 
-  const createNewSession = useCallback(async () => {
-    if (isCreatingRef.current) return;
-    isCreatingRef.current = true;
-    try {
-      // Register global listener before creating the PTY so early output is buffered
-      ensureGlobalOutputListener();
-      const id = await CreateTerminal();
-      const title = getNextTerminalTitle(useIDEStore.getState().terminalSessions);
-      addSession({ id, title });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      showToast(`Failed to create terminal: ${message}`, 'error');
-    } finally {
-      isCreatingRef.current = false;
-    }
-  }, [addSession, showToast]);
+  const createNewSession = useCallback(
+    async (options?: { markInitialCreated?: boolean }) => {
+      if (isCreatingRef.current) return;
+      isCreatingRef.current = true;
+      try {
+        // Register global listener before creating the PTY so early output is buffered
+        ensureGlobalOutputListener();
+        const id = await CreateTerminal();
+        const title = getNextTerminalTitle(useIDEStore.getState().terminalSessions);
+        addSession({ id, title });
+        if (options?.markInitialCreated) {
+          markInitialSessionCreated();
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        showToast(`Failed to create terminal: ${message}`, 'error');
+      } finally {
+        isCreatingRef.current = false;
+      }
+    },
+    [addSession, markInitialSessionCreated, showToast]
+  );
 
   // Auto-create the first terminal once, but honor an explicit close-all state.
   useEffect(() => {
@@ -196,16 +202,9 @@ export function Terminal() {
       terminalSessions.length === 0 &&
       !hasAutoCreatedInitialSession
     ) {
-      markInitialSessionCreated();
-      createNewSession();
+      createNewSession({ markInitialCreated: true });
     }
-  }, [
-    activeTab,
-    createNewSession,
-    hasAutoCreatedInitialSession,
-    markInitialSessionCreated,
-    terminalSessions.length,
-  ]);
+  }, [activeTab, createNewSession, hasAutoCreatedInitialSession, terminalSessions.length]);
 
   const handleCloseSession = useCallback(
     (e: React.MouseEvent, sessionId: string) => {
@@ -361,7 +360,9 @@ export function Terminal() {
             })}
             <button
               className={styles.newSessionButton}
-              onClick={createNewSession}
+              onClick={() => {
+                void createNewSession();
+              }}
               aria-label="New terminal session"
               title="New Terminal"
             >

--- a/frontend/src/stores/ideStore.ts
+++ b/frontend/src/stores/ideStore.ts
@@ -119,6 +119,7 @@ interface IDEState {
   activeTerminalTab: TerminalTab;
   terminalSessions: TerminalSession[];
   activeTerminalSessionId: string | null;
+  hasAutoCreatedInitialTerminalSession: boolean;
   workingDirectory: string;
 
   // Run Profiles
@@ -204,6 +205,7 @@ interface IDEActions {
   setActiveTerminalSession: (sessionId: string) => void;
   renameTerminalSession: (sessionId: string, title: string) => void;
   reorderTerminalSessions: (fromIndex: number, toIndex: number) => void;
+  markInitialTerminalSessionCreated: () => void;
   setWorkingDirectory: (path: string) => void;
 
   // Run Profile actions
@@ -303,6 +305,7 @@ export const useIDEStore = create<IDEStore>()(
       activeTerminalTab: 'terminal',
       terminalSessions: [],
       activeTerminalSessionId: null,
+      hasAutoCreatedInitialTerminalSession: false,
       workingDirectory: '',
       runProfiles: [],
       isLoadingProfiles: false,
@@ -520,6 +523,13 @@ export const useIDEStore = create<IDEStore>()(
           },
           false,
           'reorderTerminalSessions'
+        ),
+
+      markInitialTerminalSessionCreated: () =>
+        set(
+          { hasAutoCreatedInitialTerminalSession: true },
+          false,
+          'markInitialTerminalSessionCreated'
         ),
 
       setWorkingDirectory: (workingDirectory) =>


### PR DESCRIPTION
## Summary
- Prevent the Terminal panel from immediately auto-creating a new session after the user closes the last terminal.
- Keep the new-session button available in the empty terminal state.
- Reset default terminal naming based on currently open sessions so a manual session after close-all can be named `Terminal 1`.

## Root Cause
The Terminal component auto-created a session any time the terminal tab had zero sessions. Closing the final session therefore removed it and immediately recreated another one, making an explicit close-all state impossible.

## Validation
- `npm test -- --watch=false --runTestsByPath src/__tests__/components/Terminal.test.tsx src/__tests__/stores/ideStore.test.ts`
- `npm test -- --watch=false`
- `npm run build`
- `npm run lint` passed with existing repo warnings only
- `npm run format:check -- src/components/Terminal/Terminal.tsx src/stores/ideStore.ts src/__tests__/components/Terminal.test.tsx src/__tests__/stores/ideStore.test.ts`
- `git diff --check`