### PR TITLE
[codex] Complete Phase 6 LSP hardening

### DIFF
--- a/.claude/tasks/todo.md
+++ b/.claude/tasks/todo.md
@@ -8,16 +8,14 @@
 - [x] **Phase 1 (#19): Backend LSP foundation** - JSON-RPC, stdio transport, lifecycle, crash recovery, URI normalization - merged (PR #77)
 - [x] **Phase 2 (#73): Frontend document sync** - didOpen/didChange/didSave/didClose, reconnect, flush-on-close - merged (PR #77)
 - [x] **Lint/act() warning cleanup** - merged (PR #78)
-- [x] **Phase 3 (#20): TypeScript vertical slice** - --tsserver-path for mixed installs, lspStore, useLSPEvents hook, workspace-scoped diagnostics events, Toast error notifications - merged (PR #79)
+- [x] **Phase 3 (#20): TypeScript vertical slice** - lspStore, useLSPEvents hook, workspace-scoped diagnostics events, Toast error notifications - merged (PR #79)
+- [x] **LSP server cwd fix** - set cmd.Dir to workspace root, capture stderr for crash diagnostics - merged (PR #80)
+- [x] **LSP tsserver-path fix** - move --tsserver-path from CLI flag to initializationOptions for typescript-language-server v4+ - merged (PR #82)
+- [x] **Phase 4 (#21): Diagnostics UX** - editor underlines/gutter markers, real Problems panel, lspStore reactive selectors, shared URI/navigation utilities, platform-correct path handling, URI canonicalization - merged (PR #81)
+- [x] **Phase 5 (#22): Completion, hover, and definition UX** - LSP autocomplete with SVG icons/snippets, hover tooltips with syntax highlighting/quick actions, F12/Cmd+Click go-to-definition with back/forward navigation, compartment lifecycle wiring, Firn Glacier theme styles - merged (PR #83, merge 46758a49 on 2026-05-03)
 
 ## Current Focus (Milestone 5: LSP)
-- [x] **Phase 4 (#21): Diagnostics UX** - editor underlines/gutter markers, real Problems panel, lspStore reactive selectors, ideStore diagnostic state removal, shared URI/navigation utilities — code-reviewed, on feature/diagnostics-ux branch, pending PR
-- [ ] **Phase 5 (#22): Completion, hover, and definition UX** - CodeMirror completion source, hover tooltips, F12/Cmd+Click
-- [ ] **Phase 6: Hardening** - Go/Python follow-ons, performance tuning
-
-## Detailed Strategy
-- See `docs/lsp-implementation-strategy.md`
-- Phase 4 execution plan: `docs/superpowers/plans/2026-04-03-diagnostics-ux.md`
+- [ ] **Phase 6: Hardening** - follow `docs/lsp-phase-6-hardening-plan.md`; Tasks 1-6 implementation and review gates complete, final manual smoke/final review remains before closeout
 
 ## Known Bugs
 - [ ] Issue #31: Window dragging not working on macOS
@@ -26,3 +24,4 @@
 ## Future Tickets
 - [ ] **Line number gutter too wide** - lintGutter() adds a separate gutter column for diagnostic markers, widening the left margin; investigate using a combined gutter or styling the lint gutter narrower
 - [ ] **Markdown preview** - add a split or toggle view for .md files that renders a live Markdown preview alongside the raw editor
+- [ ] **File tree loads too slowly on workspace open** - editor content appears immediately but the file explorer has a noticeable delay; investigate prefetching the directory tree in parallel with file content restoration

--- a/docs/lsp-phase-6-hardening-plan.md
+++ b/docs/lsp-phase-6-hardening-plan.md
@@ -1,0 +1,394 @@
+# Phase 6: LSP Hardening and Immediate Follow-ons
+
+> For agentic workers: implement this plan task by task. After every task, run the listed verification, then perform a code review and an adversarial review. Fix all findings, then repeat review until no findings remain.
+
+**Goal:** Finish Milestone 5 LSP work so it is reliable across Firn's workspace model, not just the TypeScript happy path.
+
+**Ticket Scope:** Milestone 5 Phase 6 covers Go/Python follow-ons, performance tuning, workspace-switching edge cases, structured failure reporting, external file/autosave interactions, and cross-platform path/binary hardening.
+
+**Non-goals for this ticket:** Find references, rename symbol, code actions, quick fixes, format document/range, semantic highlighting, and workspace trust UI. These should be separate tickets after Phase 6.
+
+**Production data rule:** Do not add fake diagnostics, fake completions, placeholder hover text, fallback language-server output, or silently successful no-ops where the user needs an actionable error. All editor intelligence must come from the current document state and real LSP servers. If a server or capability is unavailable, surface a specific status/error.
+
+**Current Branch:** `codex/milestone-5-phase-6-hardening`
+
+**Base:** `develop` at PR #83 merge `46758a49b5cf7722c2133b2a37a1f464608de203`
+
+---
+
+## Current Status
+
+- [x] Local `develop` synced to `origin/develop` after PR #83 merge.
+- [x] Stale local `feature/completion-hover-definition` branch deleted.
+- [x] Phase 6 branch created.
+- [x] Tracker updated through Phase 5 merge.
+- [x] Task 1 implementation started before this plan was written: Go/Python registry mapping plus workspace restart guard.
+- [x] Task 1 code review and adversarial review completed; test coverage gap was fixed and re-verified.
+- [x] Task 2 workspace switching and LSP lifecycle hardening completed; code review and adversarial review passed.
+- [x] Task 3 performance tuning for completion/hover async flow completed; code review and adversarial review passed.
+- [x] Task 4 external file/autosave/document version hardening completed; code review and adversarial review passed.
+- [x] Task 5 structured logging and failure clarity completed; code review and adversarial review passed.
+- [x] Task 6 cross-platform path and binary matrix completed; code review and adversarial review passed.
+
+Unrelated local changes must remain untouched unless the user explicitly scopes them into Phase 6:
+
+- `.claude/settings.local.json`
+- `.remember/`
+- `frontend/wailsjs/runtime/*` mode-only changes
+- Any Terminal changes not made by this Phase 6 task
+
+---
+
+## Task Boundaries
+
+Each task must end with:
+
+- Automated verification passing for the touched area.
+- Code review focused on correctness, maintainability, errors, tests, and security.
+- Adversarial review focused on race conditions, stale workspace state, missing binaries, unsupported capabilities, cancellation, path normalization, and performance regressions.
+- Fix/re-review loop until no issues remain.
+- Progress update in `.claude/tasks/todo.md` or this plan.
+
+Do not batch multiple tasks past a review gate.
+
+---
+
+## Task 1: Go and Python LSP Enablement
+
+**Status:** Complete; code review and adversarial review passed.
+
+**Purpose:** Make Firn start real language servers for Go and Python files using the existing workspace-scoped LSP manager.
+
+**Files:**
+
+| File | Responsibility |
+|------|----------------|
+| `internal/lsp/registry.go` | Map Go/Python extensions and resolve `gopls` / `pyright-langserver` commands |
+| `internal/lsp/manager_test.go` | Backend registry and workspace guard tests |
+| `frontend/src/utils/lspLanguageId.ts` | Frontend languageId/family mapping |
+| `frontend/src/__tests__/utils/lspLanguageId.test.ts` | Frontend mapping tests |
+
+**Acceptance criteria:**
+
+- `.go` maps to languageId `go`, family `go`.
+- `.py`, `.pyw`, and `.pyi` map to languageId `python`, family `python`.
+- Go server resolves from `gopls` on PATH and uses the workspace root as cwd.
+- Python server prefers workspace-local `node_modules/.bin/pyright-langserver`, then PATH, and uses `--stdio`.
+- Missing `gopls` and missing `pyright-langserver` produce specific actionable errors.
+- No fake diagnostics/completions/hover output is added.
+
+**Verification:**
+
+- `go test ./internal/lsp`
+- `go test ./...`
+- `cd frontend && npm test -- --runTestsByPath src/__tests__/utils/lspLanguageId.test.ts src/__tests__/hooks/useLSPDocumentSync.test.ts`
+- `cd frontend && npm test -- --watch=false`
+- `cd frontend && ./node_modules/.bin/eslint --max-warnings=0 src/utils/lspLanguageId.ts src/__tests__/utils/lspLanguageId.test.ts`
+- `cd frontend && ./node_modules/.bin/prettier --check src/utils/lspLanguageId.ts src/__tests__/utils/lspLanguageId.test.ts`
+
+**Code review checklist:**
+
+- Confirm command lookup is cross-platform and does not mask missing binaries.
+- Confirm Python local-bin preference mirrors the TypeScript local-bin pattern.
+- Confirm registry and frontend language maps stay in sync.
+- Confirm tests cover unsupported files after Go/Python become supported.
+
+**Adversarial review checklist:**
+
+- Open `.go` or `.py` without the server installed: user gets one actionable error, no fake success.
+- Open `.go` and `.py` in the same workspace: distinct server families do not collide.
+- Open uppercase extensions: backend map is case-insensitive; decide whether frontend needs case-insensitive coverage.
+- Use a workspace path with spaces: local `node_modules/.bin` lookup still works.
+
+---
+
+## Task 2: Workspace Switching and LSP Lifecycle Hardening
+
+**Purpose:** Prove workspace switches fully tear down old LSP state and do not resurrect stale servers or leak diagnostics/documents.
+
+**Files likely involved:**
+
+| File | Responsibility |
+|------|----------------|
+| `app.go` | Workspace root switching and shutdown timeout behavior |
+| `internal/lsp/manager.go` | Shutdown/restart guards, open document cleanup, stale diagnostics filtering |
+| `internal/lsp/manager_test.go` | Backend lifecycle and restart tests |
+| `frontend/src/hooks/useLSPDocumentSync.ts` | Close/reopen tracked docs on workspace changes |
+| `frontend/src/hooks/useLSPEvents.ts` | Drop stale diagnostics/status/error events |
+| `frontend/src/__tests__/hooks/useLSPDocumentSync.test.ts` | Frontend workspace-switch tests |
+| `frontend/src/__tests__/hooks/useLSPEvents.test.ts` | Stale event tests |
+
+**Acceptance criteria:**
+
+- Switching workspace closes tracked documents from the old workspace before new workspace docs are opened.
+- Old workspace diagnostics/statuses disappear immediately on switch.
+- Crash recovery does not restart an old workspace server after switch.
+- Crash recovery still works for the new workspace after switch.
+- App close shuts down LSP servers within the close deadline.
+- No pending debounced `didChange` is dropped before `didClose`.
+
+**Verification:**
+
+- `go test ./internal/lsp`
+- `go test ./...`
+- `cd frontend && npm test -- --runTestsByPath src/__tests__/hooks/useLSPDocumentSync.test.ts src/__tests__/hooks/useLSPEvents.test.ts`
+
+**Code review checklist:**
+
+- Review lock ordering and goroutine behavior in manager shutdown/restart paths.
+- Verify no data race around `workspaceRoot`, `stopped`, `servers`, or `openDocs`.
+- Verify frontend subscriptions do not double-close or reopen documents during restore.
+
+**Adversarial review checklist:**
+
+- Switch workspace while a crash backoff sleep is pending.
+- Switch workspace while `didOpen` is still in flight.
+- Switch workspace while a debounced edit is pending.
+- Receive late diagnostics from old workspace after new workspace is active.
+- Close app while a server is initializing or shutting down.
+
+---
+
+## Task 3: Performance Tuning for LSP Event Flow
+
+**Status:** Complete; code review and adversarial review passed for the completion/hover async hardening slice.
+
+**Purpose:** Keep LSP responsive without excessive React renders, Wails calls, or server requests.
+
+**Files likely involved:**
+
+| File | Responsibility |
+|------|----------------|
+| `frontend/src/stores/lspStore.ts` | Diagnostics/status storage and selectors |
+| `frontend/src/components/Terminal/Terminal.tsx` | Problems panel rendering |
+| `frontend/src/components/Editor/CodeMirrorEditor.tsx` | LSP compartment reconfiguration |
+| `frontend/src/components/Editor/codemirror/completion.ts` | Completion request behavior |
+| `frontend/src/components/Editor/codemirror/hover.ts` | Hover request behavior |
+| `frontend/src/utils/lspDocumentSync.ts` | Debounce/flush behavior |
+
+**Acceptance criteria:**
+
+- Diagnostics updates do not reconfigure completion/hover compartments.
+- Problems panel handles many diagnostics without expensive repeated URI/path conversions where avoidable.
+- Completion and hover requests are cancelled or ignored when stale.
+- Document sync sends full-content changes only when needed and coalesces edits correctly.
+- Performance changes do not weaken correctness or hide server errors.
+
+**Verification:**
+
+- Add or update focused unit tests for stale completion/hover responses if code changes are needed.
+- `cd frontend && npm test -- --runTestsByPath` for touched tests.
+- `cd frontend && npm test -- --watch=false`
+- Manual smoke, when practical: open a workspace with multiple TS/Go/Python files and verify editor interaction remains responsive.
+
+**Code review checklist:**
+
+- Check selectors and subscriptions for unnecessary full-store reactivity.
+- Check that memoization does not create stale UI.
+- Check that throttling/debounce behavior does not drop required saves or closes.
+
+**Adversarial review checklist:**
+
+- Rapid typing while completion requests are in flight.
+- Hover over symbol, switch file before response returns.
+- Large diagnostics payload from server.
+- Repeated workspace switches with cached trees and restored tabs.
+
+---
+
+## Task 4: External File, Autosave, and Document Version Hardening
+
+**Status:** Complete; code review and adversarial review passed.
+
+**Purpose:** Ensure LSP document state remains correct when files are autosaved, externally modified, restored, or closed.
+
+**Files likely involved:**
+
+| File | Responsibility |
+|------|----------------|
+| `frontend/src/hooks/useAutosave.ts` | Autosave trigger behavior |
+| `frontend/src/App.tsx` | File watcher reload behavior |
+| `frontend/src/hooks/useLSPDocumentSync.ts` | didChange/didSave/didClose sequencing |
+| `frontend/src/utils/lspDocumentSync.ts` | Version and pending-content tracking |
+| `internal/lsp/manager.go` | Version-based stale diagnostic filtering |
+
+**Acceptance criteria:**
+
+- External reload of an unmodified open file updates LSP content.
+- Autosave sends `didChange` before `didSave`.
+- Closing a file flushes pending content before `didClose`.
+- Reopening a file after close gets a fresh `didOpen`.
+- Version numbers are monotonic per document path during a session.
+
+**Verification:**
+
+- `cd frontend && npm test -- --runTestsByPath src/__tests__/utils/lspDocumentSync.test.ts src/__tests__/hooks/useLSPDocumentSync.test.ts src/__tests__/App.test.tsx`
+- `go test ./internal/lsp`
+
+**Code review checklist:**
+
+- Check save/change ordering.
+- Check pending timers are always cleared.
+- Check failed `didOpen` does not leave tracked stale documents.
+
+**Adversarial review checklist:**
+
+- Save during pending `didOpen`.
+- External file event arrives during local unsaved edit.
+- Close during pending debounced change.
+- Server crash/reconnect while local content is unsaved.
+
+---
+
+## Task 5: Structured Logging and User-Facing Failure Clarity
+
+**Status:** Complete; code review and adversarial review passed.
+
+**Purpose:** Make LSP startup/shutdown/request failures diagnosable without exposing noisy internals or hiding root causes.
+
+**Files likely involved:**
+
+| File | Responsibility |
+|------|----------------|
+| `internal/lsp/manager.go` | Startup/shutdown/request status events |
+| `internal/lsp/client.go` | Request timeout/cancellation logging |
+| `internal/lsp/transport_stdio.go` | Stderr capture and process exit detail |
+| `frontend/src/hooks/useLSPEvents.ts` | Toast/status behavior |
+| `frontend/src/stores/lspStore.ts` | Status model |
+
+**Acceptance criteria:**
+
+- Startup failures include server family, workspace, command, and actionable install guidance.
+- Initialization failures include bounded stderr.
+- Request failures are logged with method/family/workspace but do not spam user toasts.
+- Crash exhaustion emits a clear terminal error.
+- StatusBar/Problems state does not imply LSP is ready when server startup failed.
+
+**Verification:**
+
+- Backend tests for missing binaries and init stderr behavior.
+- Frontend tests for toast deduplication and stale workspace filtering.
+- Manual smoke with missing `gopls` or `pyright-langserver` when practical.
+
+**Code review checklist:**
+
+- Confirm logs are structured enough to debug but do not leak document content.
+- Confirm user-facing errors are actionable.
+- Confirm repeated transient errors are deduplicated.
+
+**Adversarial review checklist:**
+
+- Server writes very large stderr.
+- Server exits before initialize response.
+- Request times out after workspace switch.
+- Repeated crash loop across two language families.
+
+---
+
+## Task 6: Cross-Platform Path and Binary Matrix
+
+**Status:** Complete; code review and adversarial review passed.
+
+**Purpose:** Validate behavior on macOS/Linux/Windows path forms before Phase 6 closes.
+
+**Files likely involved:**
+
+| File | Responsibility |
+|------|----------------|
+| `internal/lsp/uri.go` | File URI conversion |
+| `internal/lsp/uri_test.go` | URI/path matrix |
+| `internal/lsp/registry.go` | Binary lookup |
+| `frontend/src/utils/lspUri.ts` | Frontend URI conversion |
+| `frontend/src/__tests__/utils/lspUri.test.ts` | Frontend URI/path matrix |
+
+**Acceptance criteria:**
+
+- Spaces, `#`, `%`, and Unicode paths round-trip correctly.
+- Windows drive-letter paths canonicalize consistently.
+- Workspace-local node binaries resolve on Windows using `.cmd`.
+- Diagnostics URI keys match editor URI keys for all supported platforms.
+
+**Verification:**
+
+- `go test ./internal/lsp`
+- `cd frontend && npm test -- --runTestsByPath src/__tests__/utils/lspUri.test.ts src/__tests__/hooks/useLSPDocumentSync.test.ts`
+
+**Code review checklist:**
+
+- Check canonicalization between backend and frontend.
+- Check path comparison code does not rely on lossy string operations.
+
+**Adversarial review checklist:**
+
+- Path with encoded slash-like characters.
+- Windows lower-case drive in URI vs upper-case local path.
+- UNC-like path behavior if supported by existing utilities.
+
+---
+
+## Final Phase 6 Exit Gate
+
+Do not mark Phase 6 complete until:
+
+- [ ] Every task above is complete.
+- [ ] Each task has passed code review and adversarial review after fixes.
+- [ ] `go test ./...` passes.
+- [ ] `cd frontend && npm test -- --watch=false` passes.
+- [ ] Touched frontend files pass direct ESLint and Prettier checks.
+- [ ] Any remaining full-lint warnings are documented as pre-existing or fixed.
+- [ ] Manual smoke notes exist for TypeScript plus at least one Go or Python path.
+- [ ] `.claude/tasks/todo.md` is updated with Phase 6 results and follow-on tickets.
+
+---
+
+## Review Log
+
+Use this section after each task.
+
+### Task 1 Review
+
+- Implementation: complete.
+- Verification: `go test ./internal/lsp`, `go test ./...`, targeted frontend tests, full frontend tests, direct ESLint/Prettier on touched frontend files.
+- Code review: completed. Finding: missing tests for actionable `gopls` and `pyright-langserver` not-found errors.
+- Adversarial review: completed. Finding: frontend case-insensitive extension behavior was implicit but not covered for Go/Python.
+- Fix/re-review: completed. Added missing-server tests and uppercase `.GO` / `.PY` mapping coverage; all Task 1 checks pass.
+
+### Task 2 Review
+
+- Implementation: complete.
+- Verification: `go test ./internal/lsp`, `go test -race ./internal/lsp`, `go test ./...`, targeted frontend LSP sync/events tests, full frontend test suite, direct ESLint/Prettier on touched frontend files, `git diff --check`.
+- Code review: completed. No open findings after formatting fix.
+- Adversarial review: completed. Covered delayed server initialization during workspace switch, stale backend diagnostics after workspace switch, stale frontend reconnect events, pending `didChange` flush before workspace switch close, and race-enabled backend lifecycle tests.
+- Fix/re-review: completed. Formatted updated frontend test; all Task 2 checks pass.
+
+### Task 3 Review
+
+- Implementation: complete for completion/hover async performance hardening without touching unrelated Terminal or store files.
+- Verification: targeted completion/hover tests, full frontend test suite, production frontend build, direct ESLint/Prettier on touched completion/hover files, `git diff --check`.
+- Code review: completed. Finding: stale hover document guard initially lacked direct test coverage.
+- Adversarial review: completed. Finding: hover test initially used a loose plain-object cast instead of the generated Wails `lsp.Hover` model shape.
+- Fix/re-review: completed. Added direct stale-hover tests for flush-time and in-flight document changes, switched test data to `lsp.Hover.createFrom(...)`, and re-ran verification; all Task 3 checks pass.
+
+### Task 4 Review
+
+- Implementation: complete.
+- Verification: targeted document-sync/App tests, full frontend test suite, production frontend build, direct ESLint/Prettier on touched Task 4 files, `git diff --check`.
+- Code review: completed. Finding: close/reopen of the same path could send a fresh `didOpen` before the old async `didClose` reached the server.
+- Adversarial review: completed. Finding: a flush waiting on slow `didOpen` could lose edits made while it was awaiting the open.
+- Fix/re-review: completed. Added per-path close barriers, tracked successful opens before sending change/save/close, re-read pending content after `didOpen`, preserved newer pending content during explicit flushes, and added tests for external reload, save/close ordering, failed `didOpen`, close/reopen ordering, and slow-open edit coalescing.
+
+### Task 5 Review
+
+- Implementation: complete.
+- Verification: `go test ./internal/lsp`, `go test -race ./internal/lsp`, `go test ./...`, targeted frontend LSP event/store tests, full frontend test suite, production frontend build, direct ESLint/Prettier on touched frontend files, `git diff --check`.
+- Code review: completed. Finding: missing-binary startup status had install guidance but did not carry the expected command as structured status data.
+- Adversarial review: completed. Finding: bounded stderr writes reported the truncated byte count, and stderr capture lacked explicit synchronization for read/write overlap.
+- Fix/re-review: completed. Added `command` to LSP status payloads and frontend status type, added command hints for config-resolution failures, included bounded stderr in initialize status and returned errors, added request-failure logs with method/family/workspace only, fixed and synchronized the bounded stderr buffer, and added backend/frontend tests.
+
+### Task 6 Review
+
+- Implementation: complete.
+- Verification: `go test ./internal/lsp`, `go test ./...`, targeted frontend URI/document-sync tests, full frontend test suite, production frontend build, direct ESLint/Prettier on touched frontend files, `git diff --check`.
+- Code review: completed. Finding: frontend URI encoding used `URL.pathname`, which left literal `%` unescaped in file names.
+- Adversarial review: completed. Finding: backend `URIToFile` double-unescaped `url.Parse().Path`, causing valid literal `%` file names to fail, and frontend diagnostics keys did not canonicalize uppercase Windows drive URI forms to the editor key.
+- Fix/re-review: completed. Backend now unescapes `EscapedPath()`, frontend path-to-URI now percent-encodes path segments explicitly, canonicalization normalizes file URI scheme/localhost/drive case through the shared path helpers, and tests cover spaces, `#`, `%`, Unicode, Windows drive case, and workspace-local `.cmd` binary suffix behavior.

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -8,11 +8,16 @@
 import { act, render, screen } from '@testing-library/react';
 import App from '../App';
 import { useIDEStore } from '../stores/ideStore';
+import { resetLSPDocumentSyncState } from '../utils/lspDocumentSync';
 import type { FileEvent } from '../types/watcher';
 
 const mockReadDirectory = jest.fn();
 const mockReadFile = jest.fn();
 const mockUseFileWatcher = jest.fn();
+const mockDidOpen = jest.fn().mockResolvedValue(undefined);
+const mockDidChange = jest.fn().mockResolvedValue(undefined);
+const mockDidSave = jest.fn().mockResolvedValue(undefined);
+const mockDidClose = jest.fn().mockResolvedValue(undefined);
 
 // Mock Wails bindings
 jest.mock('../../wailsjs/go/main/App', () => ({
@@ -32,6 +37,10 @@ jest.mock('../../wailsjs/go/main/App', () => ({
   ListRecentWorkspaces: jest.fn(() => Promise.resolve([])),
   LoadRunProfiles: jest.fn(() => Promise.resolve()),
   GetAllRunProfiles: jest.fn(() => Promise.resolve([])),
+  LSPDidOpen: (...args: unknown[]) => mockDidOpen(...args),
+  LSPDidChange: (...args: unknown[]) => mockDidChange(...args),
+  LSPDidSave: (...args: unknown[]) => mockDidSave(...args),
+  LSPDidClose: (...args: unknown[]) => mockDidClose(...args),
 }));
 
 jest.mock('../../wailsjs/runtime/runtime', () => ({
@@ -41,6 +50,10 @@ jest.mock('../../wailsjs/runtime/runtime', () => ({
 
 jest.mock('../hooks/useFileWatcher', () => ({
   useFileWatcher: (...args: unknown[]) => mockUseFileWatcher(...args),
+}));
+
+jest.mock('../components/Editor', () => ({
+  Editor: () => null,
 }));
 
 // Mock useDirectoryTree to prevent automatic fetching
@@ -54,6 +67,11 @@ describe('App Component', () => {
     mockReadDirectory.mockReset();
     mockReadFile.mockReset();
     mockUseFileWatcher.mockReset();
+    mockDidOpen.mockClear();
+    mockDidChange.mockClear();
+    mockDidSave.mockClear();
+    mockDidClose.mockClear();
+    resetLSPDocumentSyncState();
     useIDEStore.setState({
       workspace: null,
       openFiles: [],
@@ -123,4 +141,69 @@ describe('App Component', () => {
       ]);
     }
   );
+
+  it('should sync LSP content when an unmodified open file is externally reloaded', async () => {
+    useIDEStore.setState({
+      workspace: { name: 'workspace', path: '/test/workspace' },
+    });
+
+    mockReadFile.mockResolvedValueOnce({
+      content: 'const x = 2;',
+      encoding: 'utf-8',
+      lineEndings: 'LF',
+    });
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    act(() => {
+      useIDEStore.getState().openFile({
+        id: '/test/workspace/main.ts',
+        name: 'main.ts',
+        path: '/test/workspace/main.ts',
+        language: 'typescript',
+        encoding: 'utf-8',
+        lineEndings: 'LF',
+        content: 'const x = 1;',
+        isModified: false,
+      });
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const watcherCallback = mockUseFileWatcher.mock.calls[0]?.[1] as
+      | ((event: FileEvent) => void)
+      | undefined;
+    expect(watcherCallback).toBeDefined();
+
+    await act(async () => {
+      watcherCallback!({
+        type: 'modified',
+        path: '/test/workspace/main.ts',
+        isDir: false,
+        time: new Date().toISOString(),
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(useIDEStore.getState().openFiles[0]).toEqual(
+      expect.objectContaining({
+        content: 'const x = 2;',
+        isModified: false,
+      })
+    );
+    expect(mockDidChange).toHaveBeenCalledWith(
+      '/test/workspace/main.ts',
+      2,
+      expect.arrayContaining([expect.objectContaining({ text: 'const x = 2;' })])
+    );
+    expect(mockDidSave).toHaveBeenCalledWith('/test/workspace/main.ts');
+    expect(mockDidChange.mock.invocationCallOrder[0]).toBeLessThan(
+      mockDidSave.mock.invocationCallOrder[0]
+    );
+  });
 });

--- a/frontend/src/__tests__/components/Editor/codemirror/completion.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/completion.test.ts
@@ -1,13 +1,23 @@
 import { acceptCompletion } from '@codemirror/autocomplete';
 import { indentWithTab } from '@codemirror/commands';
+import { EditorState } from '@codemirror/state';
 
 jest.mock('../../../../../wailsjs/go/main/App', () => ({
   LSPComplete: jest.fn(),
   LSPResolveCompletionItem: jest.fn(),
 }));
 
-import { LSPResolveCompletionItem } from '../../../../../wailsjs/go/main/App';
+jest.mock('../../../../utils/lspDocumentSync', () => ({
+  flushLSPDocumentChange: jest.fn(() => Promise.resolve(false)),
+}));
+
+import { LSPComplete, LSPResolveCompletionItem } from '../../../../../wailsjs/go/main/App';
+import { flushLSPDocumentChange } from '../../../../utils/lspDocumentSync';
 import {
+  COMPLETION_RESOLVE_CACHE_LIMIT,
+  clearCompletionResolveCache,
+  completionResolveCacheSize,
+  createLSPCompletionSource,
   parseResolvedCompletionDetail,
   positionCompletionInfo,
   resolveCompletionItem,
@@ -17,6 +27,11 @@ import {
   editorKeybindings,
   editorTooltipSpace,
 } from '../../../../components/Editor/codemirror/extensions';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clearCompletionResolveCache();
+});
 
 describe('sortLSPCompletionItems', () => {
   it('preserves server ordering while demoting internal-style names', () => {
@@ -40,10 +55,6 @@ describe('resolveCompletionItem', () => {
   const mockResolve = LSPResolveCompletionItem as jest.MockedFunction<
     typeof LSPResolveCompletionItem
   >;
-
-  beforeEach(() => {
-    mockResolve.mockReset();
-  });
 
   it('decodes RawMessage byte arrays before sending resolve requests', async () => {
     const data = encodeRawJSON({ entryId: 7, source: 'tsserver' });
@@ -73,6 +84,90 @@ describe('resolveCompletionItem', () => {
         },
       })
     );
+  });
+
+  it('caps the resolve cache to avoid unbounded workspace growth', async () => {
+    mockResolve.mockImplementation(async (_path, item) => item);
+
+    for (let i = 0; i < COMPLETION_RESOLVE_CACHE_LIMIT + 1; i += 1) {
+      await resolveCompletionItem('/project/src/file.ts', {
+        label: `item${i}`,
+        data: { i },
+      });
+    }
+
+    expect(completionResolveCacheSize()).toBe(COMPLETION_RESOLVE_CACHE_LIMIT);
+  });
+});
+
+describe('createLSPCompletionSource', () => {
+  const mockComplete = LSPComplete as jest.MockedFunction<typeof LSPComplete>;
+  const mockFlush = flushLSPDocumentChange as jest.MockedFunction<typeof flushLSPDocumentChange>;
+
+  it('does not send backend requests after CodeMirror aborts the query', async () => {
+    const state = EditorState.create({ doc: 'con' });
+    const source = createLSPCompletionSource('/project/src/file.ts', new Set());
+
+    const result = await source({
+      state,
+      pos: 3,
+      explicit: false,
+      aborted: true,
+      addEventListener: jest.fn(),
+      matchBefore: (expr: RegExp) => {
+        const text = state.sliceDoc(0, 3);
+        const match = text.match(expr);
+        return match ? { from: 0, to: 3, text: match[0] } : null;
+      },
+    } as never);
+
+    expect(result).toBeNull();
+    expect(mockFlush).not.toHaveBeenCalled();
+    expect(mockComplete).not.toHaveBeenCalled();
+  });
+
+  it('drops backend results when CodeMirror aborts an in-flight query', async () => {
+    const state = EditorState.create({ doc: 'con' });
+    const source = createLSPCompletionSource('/project/src/file.ts', new Set());
+    let aborted = false;
+    let abortListener = () => {};
+    let resolveComplete: (value: Awaited<ReturnType<typeof LSPComplete>>) => void = () => {};
+
+    mockComplete.mockReturnValue(
+      new Promise((resolve) => {
+        resolveComplete = resolve;
+      })
+    );
+
+    const pending = source({
+      state,
+      pos: 3,
+      explicit: false,
+      get aborted() {
+        return aborted;
+      },
+      addEventListener: (_type: 'abort', listener: () => void) => {
+        abortListener = listener;
+      },
+      matchBefore: (expr: RegExp) => {
+        const text = state.sliceDoc(0, 3);
+        const match = text.match(expr);
+        return match ? { from: 0, to: 3, text: match[0] } : null;
+      },
+    } as never);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockComplete).toHaveBeenCalledTimes(1);
+
+    aborted = true;
+    abortListener();
+    resolveComplete({
+      isIncomplete: false,
+      items: [{ label: 'console' }],
+    } as Awaited<ReturnType<typeof LSPComplete>>);
+
+    await expect(pending).resolves.toBeNull();
   });
 });
 

--- a/frontend/src/__tests__/components/Editor/codemirror/hover.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/hover.test.ts
@@ -1,3 +1,6 @@
+import { EditorState } from '@codemirror/state';
+import type { EditorView } from '@codemirror/view';
+
 jest.mock('../../../../../wailsjs/go/main/App', () => ({
   LSPHover: jest.fn(),
   LSPDefinition: jest.fn(),
@@ -11,11 +14,62 @@ jest.mock('../../../../utils/lspDocumentSync', () => ({
   flushLSPDocumentChange: jest.fn(() => Promise.resolve(false)),
 }));
 
+import { LSPHover } from '../../../../../wailsjs/go/main/App';
+import { lsp } from '../../../../../wailsjs/go/models';
+import { flushLSPDocumentChange } from '../../../../utils/lspDocumentSync';
 import {
+  createLSPHoverSource,
   highlightSignatureParts,
   hoverRequestPos,
   hoverTargetRange,
 } from '../../../../components/Editor/codemirror/hover';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('createLSPHoverSource', () => {
+  const mockHover = LSPHover as jest.MockedFunction<typeof LSPHover>;
+  const mockFlush = flushLSPDocumentChange as jest.MockedFunction<typeof flushLSPDocumentChange>;
+
+  it('drops hover requests when the document changes while flushing', async () => {
+    const { view, setDoc } = createMutableEditorView('const value = 1');
+    mockFlush.mockImplementation(async () => {
+      setDoc('const other = 1');
+      return false;
+    });
+
+    const result = await createLSPHoverSource('/project/src/file.ts')(view, 7);
+
+    expect(result).toBeNull();
+    expect(mockHover).not.toHaveBeenCalled();
+  });
+
+  it('drops hover results when the document changes while the request is in flight', async () => {
+    const { view, setDoc } = createMutableEditorView('const value = 1');
+    let resolveHover: (value: Awaited<ReturnType<typeof LSPHover>>) => void = () => {};
+
+    mockHover.mockReturnValue(
+      new Promise((resolve) => {
+        resolveHover = resolve;
+      })
+    );
+
+    const pending = createLSPHoverSource('/project/src/file.ts')(view, 7);
+    await Promise.resolve();
+
+    expect(mockHover).toHaveBeenCalledTimes(1);
+
+    setDoc('const other = 1');
+    resolveHover(
+      lsp.Hover.createFrom({
+        contents: encodeRawJSON({ kind: 'markdown', value: 'value docs' }),
+      })
+    );
+
+    await expect(pending).resolves.toBeNull();
+  });
+});
 
 describe('hoverTargetRange', () => {
   it('returns null when there is no word under the cursor', () => {
@@ -54,3 +108,24 @@ describe('highlightSignatureParts', () => {
     ]);
   });
 });
+
+function createMutableEditorView(doc: string): {
+  view: EditorView;
+  setDoc: (nextDoc: string) => void;
+} {
+  let currentState = EditorState.create({ doc });
+  return {
+    view: {
+      get state() {
+        return currentState;
+      },
+    } as EditorView,
+    setDoc: (nextDoc: string) => {
+      currentState = EditorState.create({ doc: nextDoc });
+    },
+  };
+}
+
+function encodeRawJSON(value: unknown): number[] {
+  return Array.from(new TextEncoder().encode(JSON.stringify(value)));
+}

--- a/frontend/src/__tests__/hooks/useLSPDocumentSync.test.ts
+++ b/frontend/src/__tests__/hooks/useLSPDocumentSync.test.ts
@@ -384,7 +384,9 @@ describe('useLSPDocumentSync', () => {
 
   describe('lsp:reconnect', () => {
     function captureReconnectHandler() {
-      let reconnectHandler: ((payload: { documents?: string[] }) => void) | null = null;
+      let reconnectHandler:
+        | ((payload: { workspace?: string; documents?: string[] }) => void)
+        | null = null;
       mockEventsOn.mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
         if (event === 'lsp:reconnect') {
           reconnectHandler = handler as typeof reconnectHandler;
@@ -414,6 +416,7 @@ describe('useLSPDocumentSync', () => {
       expect(reconnectHandler).not.toBeNull();
       act(() => {
         reconnectHandler!({
+          workspace: '/test/workspace',
           documents: ['file:///test/workspace/main.ts'],
         });
       });
@@ -460,6 +463,36 @@ describe('useLSPDocumentSync', () => {
       });
 
       expect(mockDidOpen).toHaveBeenCalledTimes(1); // no additional didOpen
+    });
+
+    it('should ignore reconnect events from a non-active workspace', async () => {
+      const getReconnectHandler = captureReconnectHandler();
+
+      renderHook(() => useLSPDocumentSync());
+
+      act(() => {
+        openTestFile();
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockDidOpen).toHaveBeenCalledTimes(1);
+
+      const reconnectHandler = getReconnectHandler();
+      act(() => {
+        reconnectHandler!({
+          workspace: '/other/workspace',
+          documents: ['file:///test/workspace/main.ts'],
+        });
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockDidOpen).toHaveBeenCalledTimes(1);
     });
 
     it('should match reconnect URIs with percent-encoded Unix paths', async () => {

--- a/frontend/src/__tests__/hooks/useLSPDocumentSync.test.ts
+++ b/frontend/src/__tests__/hooks/useLSPDocumentSync.test.ts
@@ -534,6 +534,45 @@ describe('useLSPDocumentSync', () => {
       );
     });
 
+    it('should match backend reconnect URIs with PathEscape-preserved characters', async () => {
+      const getReconnectHandler = captureReconnectHandler();
+
+      renderHook(() => useLSPDocumentSync());
+
+      act(() => {
+        openTestFile({
+          id: '/test/workspace/a&b+c=d$e@f:main.ts',
+          name: 'a&b+c=d$e@f:main.ts',
+          path: '/test/workspace/a&b+c=d$e@f:main.ts',
+        });
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockDidOpen).toHaveBeenCalledTimes(1);
+
+      const reconnectHandler = getReconnectHandler();
+      act(() => {
+        reconnectHandler!({
+          documents: ['file:///test/workspace/a&b+c=d$e@f:main.ts'],
+        });
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockDidOpen).toHaveBeenCalledTimes(2);
+      expect(mockDidOpen).toHaveBeenLastCalledWith(
+        '/test/workspace/a&b+c=d$e@f:main.ts',
+        'typescript',
+        expect.any(Number),
+        'const x = 1;'
+      );
+    });
+
     it('should match reconnect URIs with Windows-style file paths', async () => {
       const getReconnectHandler = captureReconnectHandler();
 

--- a/frontend/src/__tests__/hooks/useLSPEvents.test.ts
+++ b/frontend/src/__tests__/hooks/useLSPEvents.test.ts
@@ -125,12 +125,14 @@ describe('useLSPEvents', () => {
       handlers['lsp:status']({
         family: 'typescript',
         workspace: '/project',
+        command: '/project/node_modules/.bin/typescript-language-server',
         state: 'ready',
       });
     });
 
     const status = useLSPStore.getState().serverStatuses.get('/project::typescript');
     expect(status?.state).toBe('ready');
+    expect(status?.command).toBe('/project/node_modules/.bin/typescript-language-server');
   });
 
   it('ignores lsp:status from a different workspace', () => {

--- a/frontend/src/__tests__/utils/lspDocumentSync.test.ts
+++ b/frontend/src/__tests__/utils/lspDocumentSync.test.ts
@@ -87,6 +87,19 @@ describe('lspDocumentSync', () => {
     expect(mockDidChange).toHaveBeenCalledTimes(1);
   });
 
+  it('clears stale pending content when an explicit flush is already synced', async () => {
+    await openLSPDocument('/test/workspace/main.ts', 'typescript', 'const x = 1;');
+
+    scheduleLSPDocumentChange('/test/workspace/main.ts', 'const x = 2;');
+
+    await expect(flushLSPDocumentChange('/test/workspace/main.ts', 'const x = 1;')).resolves.toBe(
+      false
+    );
+    await expect(flushLSPDocumentChange('/test/workspace/main.ts')).resolves.toBe(false);
+
+    expect(mockDidChange).not.toHaveBeenCalled();
+  });
+
   it('flushes the latest pending content when didOpen is still in flight', async () => {
     let resolveOpen: () => void = () => {};
     mockDidOpen.mockReturnValueOnce(

--- a/frontend/src/__tests__/utils/lspDocumentSync.test.ts
+++ b/frontend/src/__tests__/utils/lspDocumentSync.test.ts
@@ -30,6 +30,7 @@ import {
   resetLSPDocumentSyncState,
   scheduleLSPDocumentChange,
   saveLSPDocument,
+  trackedLSPDocumentPaths,
 } from '../../utils/lspDocumentSync';
 
 beforeEach(() => {
@@ -86,6 +87,68 @@ describe('lspDocumentSync', () => {
     expect(mockDidChange).toHaveBeenCalledTimes(1);
   });
 
+  it('flushes the latest pending content when didOpen is still in flight', async () => {
+    let resolveOpen: () => void = () => {};
+    mockDidOpen.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveOpen = resolve;
+      })
+    );
+
+    const openPromise = openLSPDocument('/test/workspace/main.ts', 'typescript', 'const x = 1;');
+    await Promise.resolve();
+
+    scheduleLSPDocumentChange('/test/workspace/main.ts', 'const x = 2;');
+    const flushPromise = flushLSPDocumentChange('/test/workspace/main.ts');
+    scheduleLSPDocumentChange('/test/workspace/main.ts', 'const x = 3;');
+
+    resolveOpen();
+    await openPromise;
+    await flushPromise;
+
+    expect(mockDidChange).toHaveBeenCalledTimes(1);
+    expect(mockDidChange).toHaveBeenCalledWith(
+      '/test/workspace/main.ts',
+      2,
+      expect.arrayContaining([expect.objectContaining({ text: 'const x = 3;' })])
+    );
+  });
+
+  it('keeps newer pending content when an explicit flush waits for didOpen', async () => {
+    let resolveOpen: () => void = () => {};
+    mockDidOpen.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveOpen = resolve;
+      })
+    );
+
+    const openPromise = openLSPDocument('/test/workspace/main.ts', 'typescript', 'const x = 1;');
+    await Promise.resolve();
+
+    const flushPromise = flushLSPDocumentChange('/test/workspace/main.ts', 'const x = 2;');
+    scheduleLSPDocumentChange('/test/workspace/main.ts', 'const x = 3;');
+
+    resolveOpen();
+    await openPromise;
+    await flushPromise;
+
+    expect(mockDidChange).toHaveBeenCalledWith(
+      '/test/workspace/main.ts',
+      2,
+      expect.arrayContaining([expect.objectContaining({ text: 'const x = 2;' })])
+    );
+
+    jest.advanceTimersByTime(200);
+    await Promise.resolve();
+
+    expect(mockDidChange).toHaveBeenCalledTimes(2);
+    expect(mockDidChange).toHaveBeenLastCalledWith(
+      '/test/workspace/main.ts',
+      3,
+      expect.arrayContaining([expect.objectContaining({ text: 'const x = 3;' })])
+    );
+  });
+
   it('sends didSave after syncing unsent content', async () => {
     await openLSPDocument('/test/workspace/main.ts', 'typescript', 'const x = 1;');
 
@@ -94,6 +157,9 @@ describe('lspDocumentSync', () => {
 
     expect(mockDidChange).toHaveBeenCalledTimes(1);
     expect(mockDidSave).toHaveBeenCalledWith('/test/workspace/main.ts');
+    expect(mockDidChange.mock.invocationCallOrder[0]).toBeLessThan(
+      mockDidSave.mock.invocationCallOrder[0]
+    );
   });
 
   it('sends didClose with the latest content on close', async () => {
@@ -104,5 +170,84 @@ describe('lspDocumentSync', () => {
 
     expect(mockDidChange).toHaveBeenCalledTimes(1);
     expect(mockDidClose).toHaveBeenCalledWith('/test/workspace/main.ts');
+    expect(mockDidChange.mock.invocationCallOrder[0]).toBeLessThan(
+      mockDidClose.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('waits for an in-flight close before reopening the same path', async () => {
+    let resolveClose: () => void = () => {};
+    mockDidClose.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveClose = resolve;
+      })
+    );
+
+    await openLSPDocument('/test/workspace/main.ts', 'typescript', 'const x = 1;');
+
+    const closePromise = closeLSPDocument('/test/workspace/main.ts');
+    const reopenPromise = openLSPDocument('/test/workspace/main.ts', 'typescript', 'const x = 2;');
+
+    await Promise.resolve();
+
+    expect(mockDidClose).toHaveBeenCalledTimes(1);
+    expect(mockDidOpen).toHaveBeenCalledTimes(1);
+
+    resolveClose();
+    await closePromise;
+    await reopenPromise;
+
+    expect(mockDidOpen).toHaveBeenCalledTimes(2);
+    expect(mockDidClose.mock.invocationCallOrder[0]).toBeLessThan(
+      mockDidOpen.mock.invocationCallOrder[1]
+    );
+    expect(mockDidOpen).toHaveBeenLastCalledWith(
+      '/test/workspace/main.ts',
+      'typescript',
+      2,
+      'const x = 2;'
+    );
+  });
+
+  it('does not save a reopened document from a stale in-flight save', async () => {
+    let resolveOpen: () => void = () => {};
+    mockDidOpen.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveOpen = resolve;
+      })
+    );
+
+    const openPromise = openLSPDocument('/test/workspace/main.ts', 'typescript', 'const x = 1;');
+    await Promise.resolve();
+
+    const savePromise = saveLSPDocument('/test/workspace/main.ts', 'const x = 2;');
+    const closePromise = closeLSPDocument('/test/workspace/main.ts', 'const x = 2;');
+    const reopenPromise = openLSPDocument('/test/workspace/main.ts', 'typescript', 'const y = 1;');
+
+    resolveOpen();
+    await openPromise;
+    await closePromise;
+    await reopenPromise;
+    await savePromise;
+
+    expect(mockDidOpen).toHaveBeenCalledTimes(2);
+    expect(mockDidClose).toHaveBeenCalledTimes(1);
+    expect(mockDidSave).not.toHaveBeenCalled();
+  });
+
+  it('does not leave a tracked document after didOpen fails', async () => {
+    mockDidOpen.mockRejectedValueOnce(new Error('server unavailable'));
+
+    await expect(
+      openLSPDocument('/test/workspace/main.ts', 'typescript', 'const x = 1;')
+    ).rejects.toThrow('server unavailable');
+
+    expect(trackedLSPDocumentPaths()).toEqual([]);
+
+    await closeLSPDocument('/test/workspace/main.ts');
+    expect(mockDidClose).not.toHaveBeenCalled();
+
+    await openLSPDocument('/test/workspace/main.ts', 'typescript', 'const x = 2;');
+    expect(mockDidOpen).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/__tests__/utils/lspLanguageId.test.ts
+++ b/frontend/src/__tests__/utils/lspLanguageId.test.ts
@@ -1,0 +1,24 @@
+import { languageIdForFile, lspFamilyForFile } from '../../utils/lspLanguageId';
+
+describe('lspLanguageId', () => {
+  it.each([
+    ['main.ts', 'typescript', 'typescript'],
+    ['component.tsx', 'typescriptreact', 'typescript'],
+    ['script.js', 'javascript', 'typescript'],
+    ['view.jsx', 'javascriptreact', 'typescript'],
+    ['main.go', 'go', 'go'],
+    ['MAIN.GO', 'go', 'go'],
+    ['app.py', 'python', 'python'],
+    ['APP.PY', 'python', 'python'],
+    ['app.pyw', 'python', 'python'],
+    ['types.pyi', 'python', 'python'],
+  ])('maps %s to language=%s family=%s', (filename, languageId, family) => {
+    expect(languageIdForFile(filename)).toBe(languageId);
+    expect(lspFamilyForFile(filename)).toBe(family);
+  });
+
+  it('returns empty strings for unsupported files', () => {
+    expect(languageIdForFile('README.md')).toBe('');
+    expect(lspFamilyForFile('README.md')).toBe('');
+  });
+});

--- a/frontend/src/__tests__/utils/lspUri.test.ts
+++ b/frontend/src/__tests__/utils/lspUri.test.ts
@@ -1,4 +1,5 @@
 import {
+  canonicalizeFileURI,
   filePathToURI,
   fileURIToPath,
   pathsReferToSameFile,
@@ -19,6 +20,12 @@ describe('filePathToURI', () => {
     const uri = filePathToURI('/home/user/my project/test.ts');
     expect(uri).toContain('my%20project');
   });
+
+  it('encodes special characters and Unicode path segments', () => {
+    expect(filePathToURI('/tmp/Firn #1/100%/café.ts')).toBe(
+      'file:///tmp/Firn%20%231/100%25/caf%C3%A9.ts'
+    );
+  });
 });
 
 describe('fileURIToPath', () => {
@@ -37,6 +44,12 @@ describe('fileURIToPath', () => {
   it('decodes percent-encoded characters', () => {
     expect(fileURIToPath('file:///home/user/my%20project/test.ts')).toBe(
       '/home/user/my project/test.ts'
+    );
+  });
+
+  it('decodes encoded special characters and Unicode path segments', () => {
+    expect(fileURIToPath('file:///tmp/Firn%20%231/100%25/caf%C3%A9.ts')).toBe(
+      '/tmp/Firn #1/100%/café.ts'
     );
   });
 
@@ -61,9 +74,35 @@ describe('fileURIToPath', () => {
   });
 });
 
+describe('canonicalizeFileURI', () => {
+  it('normalizes localhost authority and encoded characters to the editor URI key', () => {
+    expect(canonicalizeFileURI('file://localhost/tmp/Firn%20%231/100%25/caf%C3%A9.ts')).toBe(
+      filePathToURI('/tmp/Firn #1/100%/café.ts')
+    );
+  });
+
+  it('normalizes Windows drive-letter case to match editor URI keys', () => {
+    expect(canonicalizeFileURI('file:///C:/Users/dev/My%20Project/main.ts')).toBe(
+      filePathToURI('C:\\Users\\dev\\My Project\\main.ts')
+    );
+  });
+
+  it('normalizes uppercase file URI schemes', () => {
+    expect(canonicalizeFileURI('FILE:///tmp/Firn%20%231.ts')).toBe(
+      filePathToURI('/tmp/Firn #1.ts')
+    );
+  });
+});
+
 describe('path helpers', () => {
   it('matches equivalent Windows paths regardless of slash style', () => {
     expect(pathsReferToSameFile('C:\\Users\\dev\\test.ts', 'c:/Users/dev/test.ts')).toBe(true);
+  });
+
+  it('matches diagnostics URI paths against editor paths for Windows drive case differences', () => {
+    const diagnosticPath = fileURIToPath(canonicalizeFileURI('file:///C:/Users/dev/test.ts'));
+    expect(diagnosticPath).not.toBeNull();
+    expect(pathsReferToSameFile(diagnosticPath!, 'c:/Users/dev/test.ts')).toBe(true);
   });
 
   it('extracts the basename from Windows paths', () => {

--- a/frontend/src/__tests__/utils/lspUri.test.ts
+++ b/frontend/src/__tests__/utils/lspUri.test.ts
@@ -26,6 +26,10 @@ describe('filePathToURI', () => {
       'file:///tmp/Firn%20%231/100%25/caf%C3%A9.ts'
     );
   });
+
+  it('matches backend PathEscape encoding for reconnect-sensitive path characters', () => {
+    expect(filePathToURI('/tmp/a&b+c=d$e@f:main.ts')).toBe('file:///tmp/a&b+c=d$e@f:main.ts');
+  });
 });
 
 describe('fileURIToPath', () => {

--- a/frontend/src/components/Editor/codemirror/completion.ts
+++ b/frontend/src/components/Editor/codemirror/completion.ts
@@ -69,6 +69,7 @@ type ParsedCompletionDetail = {
 };
 
 const completionResolveCache = new Map<string, Promise<LSPCompletionItem>>();
+export const COMPLETION_RESOLVE_CACHE_LIMIT = 500;
 const PROPERTY_ACCESS_RESOLVE_LIMIT = 12;
 const SCOPE_RESOLVE_LIMIT = 6;
 
@@ -94,6 +95,7 @@ export function completionExtensions() {
 
 /** Returns the default completion configuration with language-mode fallbacks. */
 export function resetCompletion() {
+  clearCompletionResolveCache();
   return createCompletionExtension();
 }
 
@@ -175,10 +177,23 @@ export function positionCompletionInfo(
 
 // --- Completion Source ---
 
-function createLSPCompletionSource(filePath: string, triggerChars: Set<string>): CompletionSource {
+export function createLSPCompletionSource(
+  filePath: string,
+  triggerChars: Set<string>
+): CompletionSource {
   return async function lspCompletionSource(
     ctx: CompletionContext
   ): Promise<CompletionResult | null> {
+    let aborted = ctx.aborted;
+    ctx.addEventListener(
+      'abort',
+      () => {
+        aborted = true;
+      },
+      { onDocChange: true }
+    );
+    const isAborted = () => aborted || ctx.aborted;
+
     const { pos, explicit } = ctx;
     const lineText = ctx.state.doc.lineAt(pos);
     const charBefore = pos > lineText.from ? ctx.state.sliceDoc(pos - 1, pos) : '';
@@ -198,10 +213,14 @@ function createLSPCompletionSource(filePath: string, triggerChars: Set<string>):
     const line = lineText.number - 1;
     const character = pos - lineText.from;
 
+    if (isAborted()) return null;
+
     let result;
     try {
       await flushLSPDocumentChange(filePath, ctx.state.doc.toString());
+      if (isAborted()) return null;
       result = await LSPComplete(filePath, line, character, triggerCharacter);
+      if (isAborted()) return null;
     } catch {
       return null;
     }
@@ -210,6 +229,7 @@ function createLSPCompletionSource(filePath: string, triggerChars: Set<string>):
 
     const sortedItems = sortLSPCompletionItems(result.items as LSPCompletionItem[]);
     const resolvedItems = await resolveCompletionItems(filePath, sortedItems, isPropertyAccess);
+    if (isAborted()) return null;
 
     const completions: Completion[] = resolvedItems.map((item) => {
       const presentation = completionPresentation(item, isPropertyAccess);
@@ -333,7 +353,24 @@ export async function resolveCompletionItem(
     });
 
   completionResolveCache.set(key, pending);
+  trimCompletionResolveCache();
   return pending;
+}
+
+export function clearCompletionResolveCache(): void {
+  completionResolveCache.clear();
+}
+
+export function completionResolveCacheSize(): number {
+  return completionResolveCache.size;
+}
+
+function trimCompletionResolveCache(): void {
+  while (completionResolveCache.size > COMPLETION_RESOLVE_CACHE_LIMIT) {
+    const oldestKey = completionResolveCache.keys().next().value;
+    if (oldestKey === undefined) return;
+    completionResolveCache.delete(oldestKey);
+  }
 }
 
 function completionItemForResolve(item: LSPCompletionItem): LSPCompletionItem {

--- a/frontend/src/components/Editor/codemirror/hover.ts
+++ b/frontend/src/components/Editor/codemirror/hover.ts
@@ -1,5 +1,5 @@
 import { Compartment } from '@codemirror/state';
-import { hoverTooltip, type Tooltip } from '@codemirror/view';
+import { hoverTooltip, type EditorView, type Tooltip } from '@codemirror/view';
 import { LSPHover, LSPDefinition } from '../../../../wailsjs/go/main/App';
 import { ClipboardSetText } from '../../../../wailsjs/runtime/runtime';
 import { decodeLSPContent } from '../../../utils/lspContent';
@@ -16,45 +16,49 @@ export function hoverExtensions() {
 }
 
 export function reconfigureHover(filePath: string) {
-  return hoverTooltip(
-    async (view, pos): Promise<Tooltip | null> => {
-      const wordRange = view.state.wordAt(pos) ?? (pos > 0 ? view.state.wordAt(pos - 1) : null);
-      const targetRange = hoverTargetRange(wordRange, pos);
-      if (!targetRange) return null;
-      const requestPos = hoverRequestPos(targetRange, pos);
+  return hoverTooltip(createLSPHoverSource(filePath), {
+    hideOn: (tr) => tr.docChanged,
+    hoverTime: 180,
+  });
+}
 
-      const line = view.state.doc.lineAt(requestPos);
-      const lspLine = line.number - 1;
-      const lspChar = requestPos - line.from;
+export function createLSPHoverSource(filePath: string) {
+  return async (view: EditorView, pos: number): Promise<Tooltip | null> => {
+    const requestDoc = view.state.doc;
+    const wordRange = view.state.wordAt(pos) ?? (pos > 0 ? view.state.wordAt(pos - 1) : null);
+    const targetRange = hoverTargetRange(wordRange, pos);
+    if (!targetRange) return null;
+    const requestPos = hoverRequestPos(targetRange, pos);
 
-      let result;
-      try {
-        await flushLSPDocumentChange(filePath);
-        result = await LSPHover(filePath, lspLine, lspChar);
-      } catch {
-        return null;
-      }
+    const line = view.state.doc.lineAt(requestPos);
+    const lspLine = line.number - 1;
+    const lspChar = requestPos - line.from;
 
-      if (!result || !result.contents) return null;
-
-      const content = decodeLSPContent(result.contents);
-      if (!content) return null;
-
-      return {
-        pos: targetRange.from,
-        end: targetRange.to,
-        above: true,
-        create: () => {
-          const dom = createHoverTooltipDOM(content.value, filePath, lspLine, lspChar);
-          return { dom };
-        },
-      };
-    },
-    {
-      hideOn: (tr) => tr.docChanged,
-      hoverTime: 180,
+    let result;
+    try {
+      await flushLSPDocumentChange(filePath);
+      if (view.state.doc !== requestDoc) return null;
+      result = await LSPHover(filePath, lspLine, lspChar);
+      if (view.state.doc !== requestDoc) return null;
+    } catch {
+      return null;
     }
-  );
+
+    if (!result || !result.contents) return null;
+
+    const content = decodeLSPContent(result.contents);
+    if (!content) return null;
+
+    return {
+      pos: targetRange.from,
+      end: targetRange.to,
+      above: true,
+      create: () => {
+        const dom = createHoverTooltipDOM(content.value, filePath, lspLine, lspChar);
+        return { dom };
+      },
+    };
+  };
 }
 
 export function hoverTargetRange(

--- a/frontend/src/hooks/useLSPDocumentSync.ts
+++ b/frontend/src/hooks/useLSPDocumentSync.ts
@@ -13,6 +13,11 @@ import {
   trackedLSPDocumentPaths,
 } from '../utils/lspDocumentSync';
 
+interface LSPReconnectPayload {
+  workspace?: string;
+  documents?: string[];
+}
+
 /**
  * useLSPDocumentSync wires the editor's document lifecycle to the backend LSP manager.
  *
@@ -128,9 +133,14 @@ export function useLSPDocumentSync() {
 
   // --- Listen for lsp:reconnect after server crash recovery ---
   useEffect(() => {
-    const cancel = EventsOn('lsp:reconnect', (payload: { documents?: string[] }) => {
+    const cancel = EventsOn('lsp:reconnect', (payload: LSPReconnectPayload) => {
       const reconnectedURIs = payload?.documents;
       if (!reconnectedURIs || reconnectedURIs.length === 0) return;
+
+      const activeWorkspace = useIDEStore.getState().workspace?.path;
+      if (payload.workspace && payload.workspace !== activeWorkspace) {
+        return;
+      }
 
       const reconnectSet = new Set(reconnectedURIs);
 

--- a/frontend/src/stores/lspStore.ts
+++ b/frontend/src/stores/lspStore.ts
@@ -25,6 +25,7 @@ export interface LSPDiagnostic {
 export interface LSPServerStatus {
   family: string;
   workspace: string;
+  command?: string;
   state: 'starting' | 'ready' | 'stopping' | 'stopped' | 'error';
   error?: string;
   completionTriggerCharacters?: string[];

--- a/frontend/src/utils/lspDocumentSync.ts
+++ b/frontend/src/utils/lspDocumentSync.ts
@@ -92,11 +92,10 @@ export async function flushLSPDocumentChange(path: string, content?: string): Pr
   clearChangeTimer(doc);
 
   const hasExplicitContent = content !== undefined;
+  const pendingContentAtFlushStart = doc.pendingContent;
   let nextContent = content ?? doc.pendingContent;
   if (nextContent === undefined || nextContent === doc.syncedContent) {
-    if (!hasExplicitContent || doc.pendingContent === nextContent) {
-      doc.pendingContent = undefined;
-    }
+    doc.pendingContent = undefined;
     return false;
   }
 
@@ -115,7 +114,11 @@ export async function flushLSPDocumentChange(path: string, content?: string): Pr
   }
 
   if (nextContent === undefined || nextContent === current.syncedContent) {
-    if (!hasExplicitContent || current.pendingContent === nextContent) {
+    if (
+      !hasExplicitContent ||
+      current.pendingContent === pendingContentAtFlushStart ||
+      current.pendingContent === nextContent
+    ) {
       current.pendingContent = undefined;
     }
     return false;

--- a/frontend/src/utils/lspDocumentSync.ts
+++ b/frontend/src/utils/lspDocumentSync.ts
@@ -8,10 +8,12 @@ type TrackedDocument = {
   pendingContent?: string;
   changeTimer?: ReturnType<typeof setTimeout>;
   openPromise?: Promise<void>;
+  opened?: boolean;
 };
 
 const versions = new Map<string, number>();
 const documents = new Map<string, TrackedDocument>();
+const closeBarriers = new Map<string, Promise<void>>();
 
 function nextVersion(path: string): number {
   const current = versions.get(path) ?? 0;
@@ -38,7 +40,13 @@ export function openLSPDocument(
   };
   documents.set(path, doc);
 
-  const openPromise = LSPDidOpen(path, languageID, nextVersion(path), content)
+  const closeBarrier = closeBarriers.get(path) ?? Promise.resolve();
+  const openPromise = closeBarrier
+    .then(async () => {
+      if (documents.get(path) !== doc) return;
+      await LSPDidOpen(path, languageID, nextVersion(path), content);
+      doc.opened = true;
+    })
     .catch((err) => {
       if (documents.get(path) === doc) {
         clearChangeTimer(doc);
@@ -83,9 +91,12 @@ export async function flushLSPDocumentChange(path: string, content?: string): Pr
 
   clearChangeTimer(doc);
 
-  const nextContent = content ?? doc.pendingContent;
+  const hasExplicitContent = content !== undefined;
+  let nextContent = content ?? doc.pendingContent;
   if (nextContent === undefined || nextContent === doc.syncedContent) {
-    doc.pendingContent = undefined;
+    if (!hasExplicitContent || doc.pendingContent === nextContent) {
+      doc.pendingContent = undefined;
+    }
     return false;
   }
 
@@ -94,9 +105,26 @@ export async function flushLSPDocumentChange(path: string, content?: string): Pr
   }
 
   const current = documents.get(path);
-  if (!current) return false;
+  if (current !== doc || !current.opened) return false;
 
-  current.pendingContent = undefined;
+  if (hasExplicitContent) {
+    nextContent = content;
+  } else {
+    clearChangeTimer(current);
+    nextContent = current.pendingContent;
+  }
+
+  if (nextContent === undefined || nextContent === current.syncedContent) {
+    if (!hasExplicitContent || current.pendingContent === nextContent) {
+      current.pendingContent = undefined;
+    }
+    return false;
+  }
+
+  if (!hasExplicitContent || current.pendingContent === nextContent) {
+    current.pendingContent = undefined;
+  }
+
   const change = new lsp.TextDocumentContentChangeEvent({ text: nextContent });
   await LSPDidChange(path, nextVersion(path), [change]);
   current.syncedContent = nextContent;
@@ -110,23 +138,33 @@ export async function saveLSPDocument(path: string, content: string): Promise<vo
   await flushLSPDocumentChange(path, content);
 
   const current = documents.get(path);
-  if (!current) return;
+  if (current !== doc) return;
 
   if (current.openPromise) {
     await current.openPromise;
   }
-  if (!documents.has(path)) return;
+  if (documents.get(path) !== current || !current.opened) return;
 
   await LSPDidSave(path);
 }
 
-export async function closeLSPDocument(path: string, lastContent?: string): Promise<void> {
+export function closeLSPDocument(path: string, lastContent?: string): Promise<void> {
   const doc = documents.get(path);
-  if (!doc) return;
+  if (!doc) return closeBarriers.get(path) ?? Promise.resolve();
 
   clearChangeTimer(doc);
   documents.delete(path);
 
+  const closePromise = closeTrackedDocument(path, doc, lastContent);
+  trackCloseBarrier(path, closePromise);
+  return closePromise;
+}
+
+async function closeTrackedDocument(
+  path: string,
+  doc: TrackedDocument,
+  lastContent?: string
+): Promise<void> {
   try {
     if (doc.openPromise) {
       await doc.openPromise;
@@ -135,6 +173,8 @@ export async function closeLSPDocument(path: string, lastContent?: string): Prom
     return;
   }
 
+  if (!doc.opened) return;
+
   const nextContent = lastContent ?? doc.pendingContent;
   if (nextContent !== undefined && nextContent !== doc.syncedContent) {
     const change = new lsp.TextDocumentContentChangeEvent({ text: nextContent });
@@ -142,6 +182,20 @@ export async function closeLSPDocument(path: string, lastContent?: string): Prom
   }
 
   await LSPDidClose(path);
+}
+
+function trackCloseBarrier(path: string, closePromise: Promise<void>): void {
+  const barrier = closePromise
+    .catch(() => {
+      // The caller still observes the close failure; the barrier only keeps later
+      // opens ordered after the attempted close.
+    })
+    .then(() => {
+      if (closeBarriers.get(path) === barrier) {
+        closeBarriers.delete(path);
+      }
+    });
+  closeBarriers.set(path, barrier);
 }
 
 export function forgetLSPDocument(path: string): void {
@@ -161,4 +215,5 @@ export function resetLSPDocumentSyncState(): void {
   }
   documents.clear();
   versions.clear();
+  closeBarriers.clear();
 }

--- a/frontend/src/utils/lspLanguageId.ts
+++ b/frontend/src/utils/lspLanguageId.ts
@@ -16,6 +16,10 @@ const extensionToLSPInfo: Record<string, LSPFileInfo> = {
   cts: { languageId: 'typescript', family: 'typescript' },
   mjs: { languageId: 'javascript', family: 'typescript' },
   cjs: { languageId: 'javascript', family: 'typescript' },
+  go: { languageId: 'go', family: 'go' },
+  py: { languageId: 'python', family: 'python' },
+  pyw: { languageId: 'python', family: 'python' },
+  pyi: { languageId: 'python', family: 'python' },
 };
 
 function lspInfoForFile(filename: string): LSPFileInfo | undefined {

--- a/frontend/src/utils/lspUri.ts
+++ b/frontend/src/utils/lspUri.ts
@@ -14,10 +14,18 @@ function normalizeWindowsDrivePath(path: string): string {
   return /^\/[A-Za-z]:\//.test(normalized) ? normalized.slice(1) : normalized;
 }
 
+function encodeGoPathSegment(segment: string): string {
+  return encodeURIComponent(segment)
+    .replace(/[!'()*]/g, (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`)
+    .replace(/%(24|26|2B|3A|3D|40)/gi, (match) =>
+      String.fromCharCode(Number.parseInt(match.slice(1), 16))
+    );
+}
+
 function encodeFileURIPath(path: string): string {
   return path
     .split('/')
-    .map((segment) => (/^[A-Za-z]:$/.test(segment) ? segment : encodeURIComponent(segment)))
+    .map((segment) => (/^[A-Za-z]:$/.test(segment) ? segment : encodeGoPathSegment(segment)))
     .join('/');
 }
 

--- a/frontend/src/utils/lspUri.ts
+++ b/frontend/src/utils/lspUri.ts
@@ -14,21 +14,25 @@ function normalizeWindowsDrivePath(path: string): string {
   return /^\/[A-Za-z]:\//.test(normalized) ? normalized.slice(1) : normalized;
 }
 
+function encodeFileURIPath(path: string): string {
+  return path
+    .split('/')
+    .map((segment) => (/^[A-Za-z]:$/.test(segment) ? segment : encodeURIComponent(segment)))
+    .join('/');
+}
+
 /**
  * Normalizes a file URI to a canonical form for use as a map key.
  * Strips localhost authority and lowercases the scheme.
  * Returns the input unchanged for non-file or unparseable URIs.
  */
 export function canonicalizeFileURI(uri: string): string {
-  if (!uri.startsWith('file:')) return uri;
+  if (!/^file:/i.test(uri)) return uri;
   try {
     const parsed = new URL(uri);
     if (parsed.protocol !== 'file:') return uri;
-    // Strip localhost authority: file://localhost/... -> file:///...
-    if (parsed.host === 'localhost') {
-      return `file://${parsed.pathname}${parsed.search}${parsed.hash}`;
-    }
-    return uri;
+    const path = fileURIToPath(uri);
+    return path ? filePathToURI(path) : uri;
   } catch {
     return uri;
   }
@@ -47,9 +51,7 @@ export function filePathToURI(path: string): string {
     normalized = `/${normalized[0].toLowerCase()}${normalized.slice(1)}`;
   }
 
-  const uri = new URL('file://');
-  uri.pathname = normalized;
-  return uri.toString();
+  return `file://${encodeFileURIPath(normalized)}`;
 }
 
 /**

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -26,6 +26,7 @@ const (
 type ServerStatus struct {
 	Family                      string   `json:"family"`
 	Workspace                   string   `json:"workspace"`
+	Command                     string   `json:"command,omitempty"`
 	State                       string   `json:"state"` // "starting", "ready", "stopping", "stopped", "error"
 	Error                       string   `json:"error,omitempty"`
 	CompletionTriggerCharacters []string `json:"completionTriggerCharacters,omitempty"`
@@ -87,6 +88,7 @@ func (m *Manager) SetWorkspaceRoot(root string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.workspaceRoot = root
+	m.stopped = false
 }
 
 // WorkspaceRoot returns the current workspace root path.
@@ -148,7 +150,7 @@ func (m *Manager) DidOpen(ctx context.Context, path, languageID string, version 
 // Returns early if the document has not been opened via DidOpen (e.g., during
 // the gap between crash recovery and frontend reconnect).
 func (m *Manager) DidChange(path string, version int, changes []TextDocumentContentChangeEvent) error {
-	entry, uri := m.serverForPath(path)
+	entry, uri, _ := m.serverForPath(path)
 	if entry == nil {
 		return nil
 	}
@@ -168,7 +170,7 @@ func (m *Manager) DidChange(path string, version int, changes []TextDocumentCont
 // DidSave forwards save notification to the appropriate server.
 // Returns early if the document has not been opened via DidOpen.
 func (m *Manager) DidSave(path string) error {
-	entry, uri := m.serverForPath(path)
+	entry, uri, _ := m.serverForPath(path)
 	if entry == nil {
 		return nil
 	}
@@ -239,38 +241,54 @@ func (m *Manager) DidClose(ctx context.Context, path string) error {
 
 // Hover sends a hover request for the given file position.
 func (m *Manager) Hover(ctx context.Context, path string, line, character int) (*Hover, error) {
-	entry, uri := m.serverForPath(path)
+	entry, uri, key := m.serverForPath(path)
 	if entry == nil {
 		return nil, nil
 	}
-	return entry.client.Hover(ctx, uri, line, character)
+	result, err := entry.client.Hover(ctx, uri, line, character)
+	if err != nil {
+		m.logRequestFailure(key, "textDocument/hover", err)
+	}
+	return result, err
 }
 
 // Definition sends a go-to-definition request for the given file position.
 func (m *Manager) Definition(ctx context.Context, path string, line, character int) ([]Location, error) {
-	entry, uri := m.serverForPath(path)
+	entry, uri, key := m.serverForPath(path)
 	if entry == nil {
 		return nil, nil
 	}
-	return entry.client.Definition(ctx, uri, line, character)
+	result, err := entry.client.Definition(ctx, uri, line, character)
+	if err != nil {
+		m.logRequestFailure(key, "textDocument/definition", err)
+	}
+	return result, err
 }
 
 // Complete sends a completion request for the given file position.
 func (m *Manager) Complete(ctx context.Context, path string, line, character int, triggerChar string) (*CompletionList, error) {
-	entry, uri := m.serverForPath(path)
+	entry, uri, key := m.serverForPath(path)
 	if entry == nil {
 		return nil, nil
 	}
-	return entry.client.Complete(ctx, uri, line, character, triggerChar)
+	result, err := entry.client.Complete(ctx, uri, line, character, triggerChar)
+	if err != nil {
+		m.logRequestFailure(key, "textDocument/completion", err)
+	}
+	return result, err
 }
 
 // ResolveCompletionItem resolves additional metadata for a completion item.
 func (m *Manager) ResolveCompletionItem(ctx context.Context, path string, item CompletionItem) (*CompletionItem, error) {
-	entry, _ := m.serverForPath(path)
+	entry, _, key := m.serverForPath(path)
 	if entry == nil {
 		return nil, nil
 	}
-	return entry.client.ResolveCompletionItem(ctx, item)
+	result, err := entry.client.ResolveCompletionItem(ctx, item)
+	if err != nil {
+		m.logRequestFailure(key, "completionItem/resolve", err)
+	}
+	return result, err
 }
 
 // GetStatus returns the status of all running language servers.
@@ -296,6 +314,7 @@ func (m *Manager) GetStatus() []ServerStatus {
 		status := ServerStatus{
 			Family:    key.family,
 			Workspace: key.workspace,
+			Command:   entry.config.Command,
 			State:     state,
 		}
 		if state == "ready" {
@@ -347,7 +366,7 @@ func (m *Manager) ensureServer(ctx context.Context, family, workspace string) (*
 	// Resolve server config
 	config, err := m.registry.ServerConfigFor(family, workspace)
 	if err != nil {
-		m.emitStatus(family, workspace, "error", err.Error())
+		m.emitStatus(family, workspace, "error", err.Error(), defaultServerCommand(family))
 		return nil, err
 	}
 
@@ -356,11 +375,11 @@ func (m *Manager) ensureServer(ctx context.Context, family, workspace string) (*
 
 // startServer launches a new language server process and initializes it.
 func (m *Manager) startServer(ctx context.Context, key serverKey, config *ServerConfig) (*serverEntry, error) {
-	m.emitStatus(key.family, key.workspace, "starting", "")
+	m.emitStatus(key.family, key.workspace, "starting", "", config.Command)
 
 	transport, err := NewStdioTransport(config.Command, config.Dir, config.Args...)
 	if err != nil {
-		m.emitStatus(key.family, key.workspace, "error", err.Error())
+		m.emitStatus(key.family, key.workspace, "error", err.Error(), config.Command)
 		return nil, fmt.Errorf("start server %s: %w", config.Command, err)
 	}
 
@@ -377,7 +396,7 @@ func (m *Manager) startServer(ctx context.Context, key serverKey, config *Server
 	rootURI, err := FileToURI(key.workspace)
 	if err != nil {
 		transport.Close()
-		m.emitStatus(key.family, key.workspace, "error", err.Error())
+		m.emitStatus(key.family, key.workspace, "error", err.Error(), config.Command)
 		return nil, fmt.Errorf("invalid workspace path %q: %w", key.workspace, err)
 	}
 	if err := client.Initialize(ctx, rootURI, config.InitOptions); err != nil {
@@ -387,11 +406,18 @@ func (m *Manager) startServer(ctx context.Context, key serverKey, config *Server
 			errMsg = fmt.Sprintf("%s (server stderr: %s)", errMsg, strings.TrimSpace(stderr))
 		}
 		transport.Close()
-		m.emitStatus(key.family, key.workspace, "error", errMsg)
-		return nil, fmt.Errorf("initialize %s: %w", config.Command, err)
+		m.emitStatus(key.family, key.workspace, "error", errMsg, config.Command)
+		return nil, fmt.Errorf("initialize %s: %s", config.Command, errMsg)
 	}
 
 	m.mu.Lock()
+	if m.stopped || m.workspaceRoot != key.workspace {
+		m.mu.Unlock()
+		shutCtx, cancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
+		defer cancel()
+		m.doShutdown(shutCtx, key, entry)
+		return nil, fmt.Errorf("server start abandoned for %s/%s: workspace changed or manager stopped", key.family, key.workspace)
+	}
 	// Double-check: another goroutine may have started the server while we were initializing
 	if existing, ok := m.servers[key]; ok {
 		m.mu.Unlock()
@@ -403,7 +429,7 @@ func (m *Manager) startServer(ctx context.Context, key serverKey, config *Server
 	m.servers[key] = entry
 	m.mu.Unlock()
 
-	m.emitStatus(key.family, key.workspace, "ready", "")
+	m.emitStatus(key.family, key.workspace, "ready", "", config.Command)
 
 	// Monitor for unexpected server exit
 	go m.monitorServer(key, entry)
@@ -451,13 +477,13 @@ func (m *Manager) shutdownServer(ctx context.Context, key serverKey) {
 // doShutdown performs the actual client shutdown and emits status events.
 func (m *Manager) doShutdown(ctx context.Context, key serverKey, entry *serverEntry) {
 
-	m.emitStatus(key.family, key.workspace, "stopping", "")
+	m.emitStatus(key.family, key.workspace, "stopping", "", entry.config.Command)
 
 	if err := entry.client.Shutdown(ctx); err != nil {
 		log.Printf("lsp: shutdown %s/%s failed: %v", key.family, key.workspace, err)
 	}
 
-	m.emitStatus(key.family, key.workspace, "stopped", "")
+	m.emitStatus(key.family, key.workspace, "stopped", "", entry.config.Command)
 }
 
 // monitorServer watches for unexpected server process exit and attempts restart.
@@ -479,7 +505,7 @@ func (m *Manager) monitorServer(key serverKey, entry *serverEntry) {
 		delete(m.servers, key)
 		m.mu.Unlock()
 		m.emitStatus(key.family, key.workspace, "error",
-			fmt.Sprintf("server crashed %d times, giving up", entry.crashCount))
+			fmt.Sprintf("server crashed %d times, giving up", entry.crashCount), entry.config.Command)
 		m.emitError(key.family, key.workspace,
 			fmt.Sprintf("Language server for %s crashed repeatedly. Check that %s is installed correctly.",
 				key.family, entry.config.Command))
@@ -505,7 +531,7 @@ func (m *Manager) monitorServer(key serverKey, entry *serverEntry) {
 
 	log.Printf("lsp: %s server crashed (attempt %d), restarting in %v", key.family, crashCount, backoff)
 	m.emitStatus(key.family, key.workspace, "error",
-		fmt.Sprintf("server crashed, restarting in %v (attempt %d/%d)", backoff, crashCount, maxCrashRetries))
+		fmt.Sprintf("server crashed, restarting in %v (attempt %d/%d)", backoff, crashCount, maxCrashRetries), config.Command)
 
 	time.Sleep(backoff)
 
@@ -548,16 +574,16 @@ func (m *Manager) monitorServer(key serverKey, entry *serverEntry) {
 }
 
 // serverForPath finds the server entry responsible for the given file path.
-func (m *Manager) serverForPath(path string) (*serverEntry, string) {
+func (m *Manager) serverForPath(path string) (*serverEntry, string, serverKey) {
 	ext := filepath.Ext(path)
 	family := m.registry.FamilyForExtension(ext)
 	if family == "" {
-		return nil, ""
+		return nil, "", serverKey{}
 	}
 
 	uri, err := FileToURI(path)
 	if err != nil {
-		return nil, ""
+		return nil, "", serverKey{}
 	}
 
 	m.mu.Lock()
@@ -566,9 +592,26 @@ func (m *Manager) serverForPath(path string) (*serverEntry, string) {
 	key := serverKey{family: family, workspace: m.workspaceRoot}
 	entry, ok := m.servers[key]
 	if !ok {
-		return nil, ""
+		return nil, "", key
 	}
-	return entry, uri
+	return entry, uri, key
+}
+
+func (m *Manager) logRequestFailure(key serverKey, method string, err error) {
+	log.Printf("lsp: request failed method=%s family=%s workspace=%q error=%v", method, key.family, key.workspace, err)
+}
+
+func defaultServerCommand(family string) string {
+	switch family {
+	case "typescript":
+		return "typescript-language-server"
+	case "go":
+		return "gopls"
+	case "python":
+		return "pyright-langserver"
+	default:
+		return ""
+	}
 }
 
 // handleNotification processes server notifications and emits events.
@@ -585,6 +628,14 @@ func (m *Manager) handleNotification(key serverKey, method string, params json.R
 			log.Printf("lsp: failed to parse diagnostics: %v", err)
 			return
 		}
+
+		m.mu.Lock()
+		if m.stopped || m.workspaceRoot != key.workspace {
+			m.mu.Unlock()
+			return
+		}
+		m.mu.Unlock()
+
 		if diagParams.Version > 0 {
 			m.mu.Lock()
 			entry, ok := m.servers[key]
@@ -608,7 +659,7 @@ func (m *Manager) handleNotification(key serverKey, method string, params json.R
 }
 
 // emitStatus emits an lsp:status event.
-func (m *Manager) emitStatus(family, workspace, state, errMsg string) {
+func (m *Manager) emitStatus(family, workspace, state, errMsg string, command ...string) {
 	if m.emitter == nil {
 		return
 	}
@@ -617,6 +668,9 @@ func (m *Manager) emitStatus(family, workspace, state, errMsg string) {
 		Workspace: workspace,
 		State:     state,
 		Error:     errMsg,
+	}
+	if len(command) > 0 {
+		status.Command = command[0]
 	}
 	if state == "ready" {
 		m.mu.Lock()

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -2,8 +2,11 @@ package lsp
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -60,6 +63,25 @@ func (ec *eventCollector) hasDiagnostics() bool {
 	return false
 }
 
+func writeTestExecutable(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	if runtime.GOOS == "windows" && filepath.Ext(name) == "" {
+		name += ".cmd"
+	}
+
+	path := filepath.Join(dir, name)
+	content := []byte("#!/bin/sh\nexit 0\n")
+	if runtime.GOOS == "windows" {
+		content = []byte("@echo off\r\nexit /b 0\r\n")
+	}
+
+	if err := os.WriteFile(path, content, 0755); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+	return path
+}
+
 func TestRegistry_LanguageIDMapping(t *testing.T) {
 	r := NewRegistry()
 
@@ -76,8 +98,10 @@ func TestRegistry_LanguageIDMapping(t *testing.T) {
 		{".cts", "typescript", "typescript"},
 		{".mjs", "javascript", "typescript"},
 		{".cjs", "javascript", "typescript"},
-		{".go", "", ""},
-		{".py", "", ""},
+		{".go", "go", "go"},
+		{".py", "python", "python"},
+		{".pyw", "python", "python"},
+		{".pyi", "python", "python"},
 		{".rs", "", ""},
 	}
 
@@ -88,6 +112,87 @@ func TestRegistry_LanguageIDMapping(t *testing.T) {
 		if got := r.FamilyForExtension(tt.ext); got != tt.family {
 			t.Errorf("FamilyForExtension(%q) = %q, want %q", tt.ext, got, tt.family)
 		}
+	}
+}
+
+func TestRegistry_GoServerConfigUsesGoplsFromPath(t *testing.T) {
+	r := NewRegistry()
+	binDir := t.TempDir()
+	goplsPath := writeTestExecutable(t, binDir, "gopls")
+	t.Setenv("PATH", binDir)
+
+	workspace := t.TempDir()
+	config, err := r.ServerConfigFor("go", workspace)
+	if err != nil {
+		t.Fatalf("ServerConfigFor(go): %v", err)
+	}
+
+	if config.LanguageFamily != "go" {
+		t.Errorf("LanguageFamily = %q, want go", config.LanguageFamily)
+	}
+	if config.Command != goplsPath {
+		t.Errorf("Command = %q, want %q", config.Command, goplsPath)
+	}
+	if len(config.Args) != 0 {
+		t.Errorf("Args = %v, want none", config.Args)
+	}
+	if config.Dir != workspace {
+		t.Errorf("Dir = %q, want %q", config.Dir, workspace)
+	}
+}
+
+func TestRegistry_GoServerConfigReportsMissingGopls(t *testing.T) {
+	r := NewRegistry()
+	t.Setenv("PATH", "")
+
+	_, err := r.ServerConfigFor("go", t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when gopls is not found")
+	}
+	if !contains(err.Error(), "go install golang.org/x/tools/gopls@latest") {
+		t.Errorf("error should include install instructions, got: %s", err.Error())
+	}
+}
+
+func TestRegistry_PythonServerConfigPrefersWorkspaceLocalPyright(t *testing.T) {
+	r := NewRegistry()
+	workspace := t.TempDir()
+	localBin := filepath.Join(workspace, "node_modules", ".bin")
+	if err := os.MkdirAll(localBin, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	pyrightPath := writeTestExecutable(t, localBin, "pyright-langserver")
+	t.Setenv("PATH", "")
+
+	config, err := r.ServerConfigFor("python", workspace)
+	if err != nil {
+		t.Fatalf("ServerConfigFor(python): %v", err)
+	}
+
+	if config.LanguageFamily != "python" {
+		t.Errorf("LanguageFamily = %q, want python", config.LanguageFamily)
+	}
+	if config.Command != pyrightPath {
+		t.Errorf("Command = %q, want %q", config.Command, pyrightPath)
+	}
+	if len(config.Args) != 1 || config.Args[0] != "--stdio" {
+		t.Errorf("Args = %v, want [--stdio]", config.Args)
+	}
+	if config.Dir != workspace {
+		t.Errorf("Dir = %q, want %q", config.Dir, workspace)
+	}
+}
+
+func TestRegistry_PythonServerConfigReportsMissingPyright(t *testing.T) {
+	r := NewRegistry()
+	t.Setenv("PATH", "")
+
+	_, err := r.ServerConfigFor("python", t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when pyright-langserver is not found")
+	}
+	if !contains(err.Error(), "npm install -g pyright") {
+		t.Errorf("error should include install instructions, got: %s", err.Error())
 	}
 }
 
@@ -103,9 +208,237 @@ func TestManager_DidOpenUnsupported(t *testing.T) {
 	mgr.SetWorkspaceRoot("/tmp/test")
 
 	ctx := context.Background()
-	err := mgr.DidOpen(ctx, "/tmp/test/main.go", "", 1, "package main")
+	err := mgr.DidOpen(ctx, "/tmp/test/main.rs", "", 1, "fn main() {}")
 	if err != nil {
 		t.Errorf("DidOpen unsupported file should be no-op, got: %v", err)
+	}
+}
+
+func TestManager_SetWorkspaceRootClearsStoppedFlag(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mgr.SetWorkspaceRoot("/tmp/old")
+	mgr.ShutdownAll(time.Millisecond)
+
+	mgr.mu.Lock()
+	stoppedAfterShutdown := mgr.stopped
+	mgr.mu.Unlock()
+	if !stoppedAfterShutdown {
+		t.Fatal("stopped should be true after ShutdownAll")
+	}
+
+	mgr.SetWorkspaceRoot("/tmp/new")
+
+	mgr.mu.Lock()
+	stoppedAfterSwitch := mgr.stopped
+	mgr.mu.Unlock()
+	if stoppedAfterSwitch {
+		t.Fatal("stopped should be false after setting a new workspace root")
+	}
+}
+
+func TestManager_InitializingServerAbandonedAfterWorkspaceSwitch(t *testing.T) {
+	if os.Getenv("FIRN_MOCK_LSP") == "1" {
+		t.Skip("running as mock server")
+	}
+
+	oldWorkspace := t.TempDir()
+	newWorkspace := t.TempDir()
+	collector := &eventCollector{}
+	mgr := &Manager{
+		registry: NewRegistry(),
+		emitter:  collector.emit,
+		servers:  make(map[serverKey]*serverEntry),
+	}
+	mgr.SetWorkspaceRoot(oldWorkspace)
+
+	config := &ServerConfig{
+		LanguageFamily: "typescript",
+		Command:        os.Args[0],
+		Args:           []string{"-test.run=^TestMockServerProcess$"},
+	}
+
+	t.Setenv("FIRN_MOCK_LSP", "1")
+	t.Setenv("FIRN_MOCK_LSP_INITIALIZE_DELAY_MS", "200")
+
+	key := serverKey{family: "typescript", workspace: oldWorkspace}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	type startResult struct {
+		entry *serverEntry
+		err   error
+	}
+	resultCh := make(chan startResult, 1)
+	go func() {
+		entry, err := mgr.startServer(ctx, key, config)
+		resultCh <- startResult{entry: entry, err: err}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	mgr.ShutdownAll(time.Second)
+	mgr.SetWorkspaceRoot(newWorkspace)
+
+	var result startResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for delayed startServer")
+	}
+
+	if result.err == nil {
+		t.Fatal("expected stale initializing server to return an error")
+	}
+	if result.entry != nil {
+		t.Fatal("expected stale initializing server not to return an entry")
+	}
+
+	mgr.mu.Lock()
+	_, oldExists := mgr.servers[key]
+	serverCount := len(mgr.servers)
+	mgr.mu.Unlock()
+	if oldExists || serverCount != 0 {
+		t.Fatalf("stale server remained registered: oldExists=%v serverCount=%d", oldExists, serverCount)
+	}
+
+	for _, event := range collector.eventsByName("lsp:status") {
+		if len(event.data) == 0 {
+			continue
+		}
+		status, ok := event.data[0].(ServerStatus)
+		if ok && status.Workspace == oldWorkspace && status.State == "ready" {
+			t.Fatal("stale initializing server emitted ready after workspace switch")
+		}
+	}
+}
+
+func TestManager_InitializeFailureStatusIncludesBoundedStderrAndCommand(t *testing.T) {
+	if os.Getenv("FIRN_MOCK_LSP") == "1" {
+		t.Skip("running as mock server")
+	}
+
+	workspace := t.TempDir()
+	mgr, collector := newTestManager(t)
+	mgr.SetWorkspaceRoot(workspace)
+
+	stderrPrefix := "mock initialize failed: "
+	stderrBody := strings.Repeat("x", maxStderrCapture+256) + "UNCAPTURED_TAIL"
+	t.Setenv("FIRN_MOCK_LSP", "1")
+	t.Setenv("FIRN_MOCK_LSP_INITIALIZE_STDERR", stderrPrefix+stderrBody)
+
+	key := serverKey{family: "typescript", workspace: workspace}
+	config := &ServerConfig{
+		LanguageFamily: "typescript",
+		Command:        os.Args[0],
+		Args:           []string{"-test.run=^TestMockServerProcess$"},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := mgr.startServer(ctx, key, config)
+	if err == nil {
+		t.Fatal("expected initialize failure")
+	}
+	if !strings.Contains(err.Error(), stderrPrefix) {
+		t.Fatalf("returned error should include stderr prefix, got: %s", err)
+	}
+	if strings.Contains(err.Error(), "UNCAPTURED_TAIL") {
+		t.Fatalf("returned error should include bounded stderr, got tail in: %s", err)
+	}
+
+	var errorStatus *ServerStatus
+	for _, event := range collector.eventsByName("lsp:status") {
+		if len(event.data) == 0 {
+			continue
+		}
+		status, ok := event.data[0].(ServerStatus)
+		if ok && status.State == "error" && status.Family == key.family && status.Workspace == key.workspace {
+			errorStatus = &status
+		}
+	}
+	if errorStatus == nil {
+		t.Fatal("expected error status event")
+	}
+	if errorStatus.Command != os.Args[0] {
+		t.Fatalf("status command = %q, want %q", errorStatus.Command, os.Args[0])
+	}
+	if !strings.Contains(errorStatus.Error, stderrPrefix) {
+		t.Fatalf("status error should include stderr prefix, got: %s", errorStatus.Error)
+	}
+	if strings.Contains(errorStatus.Error, "UNCAPTURED_TAIL") {
+		t.Fatalf("status error should include bounded stderr, got tail in: %s", errorStatus.Error)
+	}
+}
+
+func TestManager_DropsDiagnosticsAfterWorkspaceSwitch(t *testing.T) {
+	oldWorkspace := t.TempDir()
+	newWorkspace := t.TempDir()
+	mgr, collector := newTestManager(t)
+	mgr.SetWorkspaceRoot(oldWorkspace)
+	mgr.SetWorkspaceRoot(newWorkspace)
+
+	uri, err := FileToURI(filepath.Join(oldWorkspace, "main.ts"))
+	if err != nil {
+		t.Fatalf("FileToURI: %v", err)
+	}
+	paramsJSON, err := json.Marshal(PublishDiagnosticsParams{
+		URI: uri,
+		Diagnostics: []Diagnostic{
+			{
+				Range:   Range{Start: Position{Line: 0, Character: 0}, End: Position{Line: 0, Character: 1}},
+				Message: "stale diagnostic",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	mgr.handleNotification(serverKey{family: "typescript", workspace: oldWorkspace}, "textDocument/publishDiagnostics", paramsJSON)
+
+	if diagnostics := collector.eventsByName("lsp:diagnostics"); len(diagnostics) != 0 {
+		t.Fatalf("expected stale diagnostics to be dropped, got %d events", len(diagnostics))
+	}
+}
+
+func TestManager_StartupFailureStatusIncludesCommandAndInstallHint(t *testing.T) {
+	workspace := t.TempDir()
+	mgr, collector := newTestManager(t)
+	mgr.SetWorkspaceRoot(workspace)
+	t.Setenv("PATH", "")
+
+	err := mgr.DidOpen(context.Background(), filepath.Join(workspace, "main.go"), "go", 1, "package main")
+	if err == nil {
+		t.Fatal("expected missing gopls error")
+	}
+
+	statusEvents := collector.eventsByName("lsp:status")
+	if len(statusEvents) == 0 {
+		t.Fatal("expected lsp:status event")
+	}
+
+	last := statusEvents[len(statusEvents)-1]
+	if len(last.data) != 1 {
+		t.Fatalf("status event data len = %d, want 1", len(last.data))
+	}
+	status, ok := last.data[0].(ServerStatus)
+	if !ok {
+		t.Fatalf("status payload type = %T, want ServerStatus", last.data[0])
+	}
+	if status.Family != "go" {
+		t.Fatalf("status family = %q, want go", status.Family)
+	}
+	if status.Workspace != workspace {
+		t.Fatalf("status workspace = %q, want %q", status.Workspace, workspace)
+	}
+	if status.Command != "gopls" {
+		t.Fatalf("status command = %q, want gopls", status.Command)
+	}
+	if status.State != "error" {
+		t.Fatalf("status state = %q, want error", status.State)
+	}
+	if !strings.Contains(status.Error, "go install golang.org/x/tools/gopls@latest") {
+		t.Fatalf("status error should include install guidance, got: %s", status.Error)
 	}
 }
 

--- a/internal/lsp/mockserver_test.go
+++ b/internal/lsp/mockserver_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // mockServerMain is the entry point for the mock LSP server subprocess.
@@ -62,6 +64,16 @@ func handleMockNotification(msg *JSONRPCMessage, initialized *bool) {
 func handleMockRequest(msg *JSONRPCMessage, initialized bool) *JSONRPCMessage {
 	switch msg.Method {
 	case "initialize":
+		if stderr := os.Getenv("FIRN_MOCK_LSP_INITIALIZE_STDERR"); stderr != "" {
+			fmt.Fprint(os.Stderr, stderr)
+			os.Exit(2)
+		}
+		if delay := os.Getenv("FIRN_MOCK_LSP_INITIALIZE_DELAY_MS"); delay != "" {
+			ms, err := strconv.Atoi(delay)
+			if err == nil && ms > 0 {
+				time.Sleep(time.Duration(ms) * time.Millisecond)
+			}
+		}
 		return respondWithResult(msg.ID, InitializeResult{
 			Capabilities: ServerCapabilities{
 				TextDocumentSync:   mustJSON(TextDocumentSyncOptions{OpenClose: true, Change: TextDocumentSyncFull}),
@@ -92,7 +104,7 @@ func handleMockRequest(msg *JSONRPCMessage, initialized bool) *JSONRPCMessage {
 			IsIncomplete: false,
 			Items: []CompletionItem{
 				{Label: "mockFunction", Kind: 3, Data: json.RawMessage(`{"id":1}`)}, // Function
-				{Label: "mockVariable", Kind: 6, Detail: "mock var"},               // Variable
+				{Label: "mockVariable", Kind: 6, Detail: "mock var"},                // Variable
 			},
 		})
 

--- a/internal/lsp/registry.go
+++ b/internal/lsp/registry.go
@@ -48,6 +48,10 @@ var extensionMap = map[string]langInfo{
 	".cts": {"typescript", "typescript"},
 	".mjs": {"javascript", "typescript"},
 	".cjs": {"javascript", "typescript"},
+	".go":  {"go", "go"},
+	".py":  {"python", "python"},
+	".pyw": {"python", "python"},
+	".pyi": {"python", "python"},
 }
 
 // LanguageIDForExtension returns the LSP languageId for the given file extension.
@@ -74,9 +78,21 @@ func (r *Registry) ServerConfigFor(family, workspaceRoot string) (*ServerConfig,
 	switch family {
 	case "typescript":
 		return r.resolveTypeScriptServer(workspaceRoot)
+	case "go":
+		return r.resolveGoServer(workspaceRoot)
+	case "python":
+		return r.resolvePythonServer(workspaceRoot)
 	default:
 		return nil, fmt.Errorf("no language server configured for %q", family)
 	}
+}
+
+func workspaceLocalNodeBin(workspaceRoot, binary string) string {
+	localBin := filepath.Join(workspaceRoot, "node_modules", ".bin", binary)
+	if runtime.GOOS == "windows" {
+		localBin += ".cmd"
+	}
+	return localBin
 }
 
 // resolveTypeScriptServer finds and configures typescript-language-server.
@@ -84,11 +100,7 @@ func (r *Registry) resolveTypeScriptServer(workspaceRoot string) (*ServerConfig,
 	binary := "typescript-language-server"
 
 	// 1. Check workspace-local node_modules/.bin/
-	localBin := filepath.Join(workspaceRoot, "node_modules", ".bin", binary)
-	if runtime.GOOS == "windows" {
-		localBin += ".cmd"
-	}
-	if path, err := exec.LookPath(localBin); err == nil {
+	if path, err := exec.LookPath(workspaceLocalNodeBin(workspaceRoot, binary)); err == nil {
 		return &ServerConfig{
 			LanguageFamily: "typescript",
 			Command:        path,
@@ -101,8 +113,8 @@ func (r *Registry) resolveTypeScriptServer(workspaceRoot string) (*ServerConfig,
 	path, err := exec.LookPath(binary)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"typescript-language-server not found: install it with "+
-				"\"npm install -g typescript-language-server typescript\" "+
+			"typescript-language-server not found: install it with " +
+				"\"npm install -g typescript-language-server typescript\" " +
 				"or add it as a project dependency",
 		)
 	}
@@ -130,5 +142,53 @@ func (r *Registry) resolveTypeScriptServer(workspaceRoot string) (*ServerConfig,
 		Args:           args,
 		Dir:            workspaceRoot,
 		InitOptions:    initOpts,
+	}, nil
+}
+
+// resolveGoServer finds and configures gopls.
+func (r *Registry) resolveGoServer(workspaceRoot string) (*ServerConfig, error) {
+	path, err := exec.LookPath("gopls")
+	if err != nil {
+		return nil, fmt.Errorf(
+			"gopls not found: install it with " +
+				"\"go install golang.org/x/tools/gopls@latest\" " +
+				"or add it to PATH",
+		)
+	}
+
+	return &ServerConfig{
+		LanguageFamily: "go",
+		Command:        path,
+		Dir:            workspaceRoot,
+	}, nil
+}
+
+// resolvePythonServer finds and configures pyright-langserver.
+func (r *Registry) resolvePythonServer(workspaceRoot string) (*ServerConfig, error) {
+	binary := "pyright-langserver"
+
+	if path, err := exec.LookPath(workspaceLocalNodeBin(workspaceRoot, binary)); err == nil {
+		return &ServerConfig{
+			LanguageFamily: "python",
+			Command:        path,
+			Args:           []string{"--stdio"},
+			Dir:            workspaceRoot,
+		}, nil
+	}
+
+	path, err := exec.LookPath(binary)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"pyright-langserver not found: install it with " +
+				"\"npm install -g pyright\" " +
+				"or add pyright as a project dependency",
+		)
+	}
+
+	return &ServerConfig{
+		LanguageFamily: "python",
+		Command:        path,
+		Args:           []string{"--stdio"},
+		Dir:            workspaceRoot,
 	}, nil
 }

--- a/internal/lsp/transport_stdio.go
+++ b/internal/lsp/transport_stdio.go
@@ -157,11 +157,16 @@ func (t *StdioTransport) ExitErr() error {
 // limitedBuffer is a bytes.Buffer that silently discards writes beyond max bytes.
 // This prevents a chatty server from consuming unbounded memory via stderr.
 type limitedBuffer struct {
+	mu  sync.Mutex
 	buf bytes.Buffer
 	max int
 }
 
 func (b *limitedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	written := len(p)
 	remaining := b.max - b.buf.Len()
 	if remaining <= 0 {
 		return len(p), nil // discard but report success so the writer doesn't block
@@ -170,9 +175,11 @@ func (b *limitedBuffer) Write(p []byte) (int, error) {
 		p = p[:remaining]
 	}
 	b.buf.Write(p)
-	return len(p), nil
+	return written, nil
 }
 
 func (b *limitedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	return b.buf.String()
 }

--- a/internal/lsp/transport_test.go
+++ b/internal/lsp/transport_test.go
@@ -174,6 +174,32 @@ func TestJSONRPCMessage_Classification(t *testing.T) {
 	}
 }
 
+func TestLimitedBufferCapsCaptureAndReportsFullWrite(t *testing.T) {
+	buf := &limitedBuffer{max: 5}
+
+	n, err := buf.Write([]byte("abcdef"))
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if n != 6 {
+		t.Fatalf("Write reported %d bytes, want 6", n)
+	}
+	if got := buf.String(); got != "abcde" {
+		t.Fatalf("captured stderr = %q, want abcde", got)
+	}
+
+	n, err = buf.Write([]byte("gh"))
+	if err != nil {
+		t.Fatalf("second Write: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("second Write reported %d bytes, want 2", n)
+	}
+	if got := buf.String(); got != "abcde" {
+		t.Fatalf("captured stderr after overflow = %q, want abcde", got)
+	}
+}
+
 // --- helpers ---
 
 type slowReader struct {

--- a/internal/lsp/uri.go
+++ b/internal/lsp/uri.go
@@ -53,14 +53,16 @@ func URIToFile(uri string) (string, error) {
 		return "", fmt.Errorf("file URI with host %q not supported", parsed.Host)
 	}
 
-	path := parsed.Path
+	path := parsed.EscapedPath()
 
 	// On Windows, the path will be /C:/... — strip the leading slash
 	if runtime.GOOS == "windows" && len(path) >= 3 && path[0] == '/' && path[2] == ':' {
 		path = path[1:]
 	}
 
-	// Unescape percent-encoded characters
+	// Unescape percent-encoded characters. Use EscapedPath instead of Path:
+	// url.Parse decodes Path eagerly, which would make literal '%' characters
+	// from file names look like malformed escape sequences during a second pass.
 	path, err = url.PathUnescape(path)
 	if err != nil {
 		return "", fmt.Errorf("failed to unescape URI path %q: %w", parsed.Path, err)

--- a/internal/lsp/uri_test.go
+++ b/internal/lsp/uri_test.go
@@ -1,7 +1,9 @@
 package lsp
 
 import (
+	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -16,6 +18,7 @@ func TestFileToURI_Unix(t *testing.T) {
 	}{
 		{"/home/user/project/main.go", "file:///home/user/project/main.go"},
 		{"/tmp/file with spaces.ts", "file:///tmp/file%20with%20spaces.ts"},
+		{"/tmp/Firn #1/100%/café.ts", "file:///tmp/Firn%20%231/100%25/caf%C3%A9.ts"},
 		{"/usr/local/bin/test", "file:///usr/local/bin/test"},
 	}
 
@@ -49,6 +52,7 @@ func TestURIToFile_Unix(t *testing.T) {
 	}{
 		{"file:///home/user/project/main.go", "/home/user/project/main.go"},
 		{"file:///tmp/file%20with%20spaces.ts", "/tmp/file with spaces.ts"},
+		{"file:///tmp/Firn%20%231/100%25/caf%C3%A9.ts", "/tmp/Firn #1/100%/café.ts"},
 	}
 
 	for _, tt := range tests {
@@ -96,6 +100,7 @@ func TestURIToFile_Roundtrip(t *testing.T) {
 	paths := []string{
 		"/home/user/project/main.go",
 		"/tmp/test file.ts",
+		"/tmp/Firn #1/100%/café.ts",
 		"/var/data/café.txt",
 	}
 
@@ -120,5 +125,21 @@ func TestURIToFile_InvalidScheme(t *testing.T) {
 	_, err := URIToFile("https://example.com/file.ts")
 	if err == nil {
 		t.Error("expected error for non-file URI scheme")
+	}
+}
+
+func TestWorkspaceLocalNodeBinPlatformSuffix(t *testing.T) {
+	got := workspaceLocalNodeBin("/workspace", "pyright-langserver")
+	wantSuffix := filepath.Join("node_modules", ".bin", "pyright-langserver")
+	if runtime.GOOS == "windows" {
+		wantSuffix += ".cmd"
+		if !strings.HasSuffix(got, wantSuffix) {
+			t.Fatalf("workspaceLocalNodeBin on Windows = %q, want .cmd suffix", got)
+		}
+		return
+	}
+
+	if !strings.HasSuffix(got, wantSuffix) {
+		t.Fatalf("workspaceLocalNodeBin = %q, want Unix-style local bin path", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Add Go and Python LSP family support with real `gopls` and `pyright-langserver` resolution.
- Harden workspace switching, shutdown, crash recovery, stale diagnostics, and reconnect handling.
- Improve completion and hover behavior under cancellation, stale document state, and high request volume.
- Tighten LSP document sync ordering for didOpen/didChange/didSave/didClose, including close/reopen races.
- Improve URI/path normalization, stderr-safe transport behavior, and status events with server command context.
- Add the Phase 6 implementation plan and update the tracker through the completed review gates.

## Root Cause / Motivation
Phase 5 delivered the TypeScript LSP vertical slice, but the follow-on hardening work was needed before treating the milestone as reliable across Firn's workspace model. The main risks were stale workspace state after switches, language-server resurrection after shutdown, missing Go/Python support, stale completion/hover responses, and document lifecycle races around autosave, external reloads, and close/reopen sequences.

## Final Review Notes
- Code review and adversarial review covered manager lock ordering, crash-restart guards, frontend stale-result handling, URI conversion edge cases, missing server binaries, and document sync sequencing.
- During final adversarial review, I found and fixed a stale save race where an old in-flight save could target a newly reopened document at the same path. Regression coverage was added in `lspDocumentSync.test.ts`.
- Remaining lint output is the existing repo warning set in unrelated FileExplorer/RunOutput/RunProfiles files; no lint errors were introduced.

## Validation
- `go test ./...`
- `go test -race ./internal/lsp` (rerun with normal macOS Go build cache access after sandbox cache denial)
- `npm test -- --watch=false --runTestsByPath src/__tests__/utils/lspDocumentSync.test.ts src/__tests__/hooks/useLSPDocumentSync.test.ts`
- `npm test -- --watch=false`
- `npm run build`
- `npm run lint` passed with existing repo warnings only
- `npm run format:check -- src/utils/lspDocumentSync.ts src/__tests__/utils/lspDocumentSync.test.ts`
- `npm run format:check -- src/__tests__/App.test.tsx src/__tests__/components/Editor/codemirror/completion.test.ts src/__tests__/components/Editor/codemirror/hover.test.ts src/__tests__/hooks/useLSPDocumentSync.test.ts src/__tests__/hooks/useLSPEvents.test.ts src/__tests__/utils/lspDocumentSync.test.ts src/__tests__/utils/lspLanguageId.test.ts src/__tests__/utils/lspUri.test.ts src/components/Editor/codemirror/completion.ts src/components/Editor/codemirror/hover.ts src/hooks/useLSPDocumentSync.ts src/stores/lspStore.ts src/utils/lspDocumentSync.ts src/utils/lspLanguageId.ts src/utils/lspUri.ts`
- `git diff --check`