### PR TITLE
Milestone 6 Task 2: frontend search store + ripgrep client

### DIFF
--- a/frontend/src/__tests__/hooks/useWorkspaceSearch.test.ts
+++ b/frontend/src/__tests__/hooks/useWorkspaceSearch.test.ts
@@ -1,0 +1,384 @@
+import { renderHook, act } from '@testing-library/react';
+import { useIDEStore } from '../../stores/ideStore';
+import { useSearchStore } from '../../stores/searchStore';
+
+// --- Wails App mocks ---
+const mockSearchWorkspace = jest.fn();
+const mockCancelSearch = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../../wailsjs/go/main/App', () => ({
+  SearchWorkspace: (...args: unknown[]) => mockSearchWorkspace(...args),
+  CancelSearch: (...args: unknown[]) => mockCancelSearch(...args),
+}));
+
+// --- Wails models mock: only the search namespace is used by the hook ---
+jest.mock('../../../wailsjs/go/models', () => ({
+  search: {
+    SearchRequest: class {
+      requestId: string;
+      root: string;
+      query: string;
+      options: { regex: boolean; caseSensitive: boolean; wholeWord: boolean };
+      constructor(source: {
+        requestId: string;
+        root: string;
+        query: string;
+        options: { regex: boolean; caseSensitive: boolean; wholeWord: boolean };
+      }) {
+        this.requestId = source.requestId;
+        this.root = source.root;
+        this.query = source.query;
+        this.options = source.options;
+      }
+    },
+  },
+}));
+
+// Imported after mocks so the hook closes over the mocks above.
+import { SEARCH_DEBOUNCE_MS, useWorkspaceSearch } from '../../hooks/useWorkspaceSearch';
+import type { SearchResponse } from '../../types/search';
+
+function buildResponse(overrides: Partial<SearchResponse> = {}): SearchResponse {
+  return {
+    requestId: 'unset',
+    status: 'success',
+    message: '',
+    files: [],
+    totalFiles: 0,
+    totalLines: 0,
+    truncated: false,
+    matchCap: 1000,
+    durationMs: 4,
+    ...overrides,
+  };
+}
+
+function setWorkspace(path: string | null) {
+  if (path === null) {
+    useIDEStore.setState({ workspace: null });
+  } else {
+    useIDEStore.setState({ workspace: { name: 'ws', path } });
+  }
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockSearchWorkspace.mockReset();
+  mockCancelSearch.mockClear();
+  mockSearchWorkspace.mockImplementation(async (req: { requestId: string }) =>
+    buildResponse({ requestId: req.requestId })
+  );
+  useSearchStore.setState(useSearchStore.getInitialState());
+  setWorkspace(null);
+});
+
+afterEach(() => {
+  // Drain any pending timers so they don't leak into the next test.
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
+  jest.useRealTimers();
+});
+
+async function flushMicrotasks(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+/**
+ * Type a query and advance past the debounce window in two separate acts so
+ * React commits the re-render (scheduling the new effect's timer) before the
+ * timer is advanced. Then flush microtasks so the SearchWorkspace promise
+ * resolves and the store updates land before assertions run.
+ */
+async function typeAndDebounce(query: string, ms = SEARCH_DEBOUNCE_MS): Promise<void> {
+  act(() => {
+    useSearchStore.getState().setQuery(query);
+  });
+  act(() => {
+    jest.advanceTimersByTime(ms);
+  });
+  await flushMicrotasks();
+}
+
+async function toggleOption(
+  option: 'regex' | 'caseSensitive' | 'wholeWord',
+  value: boolean,
+  ms = SEARCH_DEBOUNCE_MS
+): Promise<void> {
+  act(() => {
+    useSearchStore.getState().setOption(option, value);
+  });
+  act(() => {
+    jest.advanceTimersByTime(ms);
+  });
+  await flushMicrotasks();
+}
+
+describe('useWorkspaceSearch', () => {
+  it('does not call SearchWorkspace when no workspace is open', async () => {
+    renderHook(() => useWorkspaceSearch());
+
+    await typeAndDebounce('alpha');
+
+    expect(mockSearchWorkspace).not.toHaveBeenCalled();
+    expect(useSearchStore.getState().uiState).toEqual({ kind: 'no-workspace' });
+  });
+
+  it('does not call SearchWorkspace when query is empty or whitespace', async () => {
+    setWorkspace('/workspace');
+    renderHook(() => useWorkspaceSearch());
+
+    await typeAndDebounce('   ');
+
+    expect(mockSearchWorkspace).not.toHaveBeenCalled();
+    expect(useSearchStore.getState().uiState).toEqual({ kind: 'empty-query' });
+  });
+
+  it('calls SearchWorkspace once after the debounce window with the typed query and root', async () => {
+    setWorkspace('/workspace');
+    renderHook(() => useWorkspaceSearch());
+
+    act(() => {
+      useSearchStore.getState().setQuery('alpha');
+    });
+    expect(mockSearchWorkspace).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+    });
+    await flushMicrotasks();
+
+    expect(mockSearchWorkspace).toHaveBeenCalledTimes(1);
+    const arg = mockSearchWorkspace.mock.calls[0][0];
+    expect(arg.root).toBe('/workspace');
+    expect(arg.query).toBe('alpha');
+    expect(arg.options).toEqual({ regex: false, caseSensitive: false, wholeWord: false });
+    expect(typeof arg.requestId).toBe('string');
+    expect(arg.requestId.length).toBeGreaterThan(0);
+  });
+
+  it('coalesces rapid typing into one backend call with the latest query', async () => {
+    setWorkspace('/workspace');
+    renderHook(() => useWorkspaceSearch());
+
+    act(() => useSearchStore.getState().setQuery('a'));
+    act(() => jest.advanceTimersByTime(50));
+    act(() => useSearchStore.getState().setQuery('al'));
+    act(() => jest.advanceTimersByTime(50));
+    act(() => useSearchStore.getState().setQuery('alpha'));
+    act(() => jest.advanceTimersByTime(SEARCH_DEBOUNCE_MS));
+    await flushMicrotasks();
+
+    expect(mockSearchWorkspace).toHaveBeenCalledTimes(1);
+    expect(mockSearchWorkspace.mock.calls[0][0].query).toBe('alpha');
+  });
+
+  it('applies a successful response to the store with results state', async () => {
+    setWorkspace('/workspace');
+    mockSearchWorkspace.mockImplementation(async (req: { requestId: string }) =>
+      buildResponse({
+        requestId: req.requestId,
+        totalFiles: 1,
+        totalLines: 1,
+        files: [
+          {
+            path: '/workspace/a.ts',
+            relativePath: 'a.ts',
+            matches: [{ line: 1, column: 1, text: 'match', submatches: [] }],
+          },
+        ],
+      })
+    );
+    renderHook(() => useWorkspaceSearch());
+
+    await typeAndDebounce('alpha');
+
+    expect(useSearchStore.getState().uiState.kind).toBe('results');
+  });
+
+  it('drops a stale response that arrives after a newer one has been applied', async () => {
+    setWorkspace('/workspace');
+    // First request: never resolves until we manually resolve it.
+    let resolveFirst!: (response: SearchResponse) => void;
+    mockSearchWorkspace.mockImplementationOnce(
+      () => new Promise<SearchResponse>((resolve) => (resolveFirst = resolve))
+    );
+    // Second request: resolves immediately with no_matches.
+    mockSearchWorkspace.mockImplementationOnce(async (req: { requestId: string }) =>
+      buildResponse({ requestId: req.requestId, status: 'no_matches' })
+    );
+    renderHook(() => useWorkspaceSearch());
+
+    await typeAndDebounce('alpha');
+    const firstRequestId = mockSearchWorkspace.mock.calls[0][0].requestId as string;
+    expect(useSearchStore.getState().activeRequestId).toBe(firstRequestId);
+
+    // User changes query while first request is still in flight. The second
+    // request resolves immediately with no_matches and applies, clearing
+    // activeRequestId to null and setting uiState to no-matches.
+    await typeAndDebounce('beta');
+    expect(mockSearchWorkspace).toHaveBeenCalledTimes(2);
+    expect(useSearchStore.getState().uiState.kind).toBe('no-matches');
+    expect(useSearchStore.getState().activeRequestId).toBeNull();
+
+    // First request finally resolves with its (now-stale) id and would-be
+    // results. Because activeRequestId is null (or any value other than
+    // firstRequestId), the response is dropped and uiState stays no-matches.
+    await act(async () => {
+      resolveFirst(
+        buildResponse({
+          requestId: firstRequestId,
+          totalFiles: 999,
+          files: [
+            {
+              path: '/workspace/stale.ts',
+              relativePath: 'stale.ts',
+              matches: [{ line: 1, column: 1, text: 'stale', submatches: [] }],
+            },
+          ],
+        })
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(useSearchStore.getState().uiState.kind).toBe('no-matches');
+  });
+
+  it('cancels the in-flight request when the workspace switches', async () => {
+    setWorkspace('/workspace-a');
+    mockSearchWorkspace.mockImplementation(
+      () => new Promise<SearchResponse>(() => {}) // never resolves
+    );
+    renderHook(() => useWorkspaceSearch());
+
+    await typeAndDebounce('alpha');
+    const inflightRequestId = useSearchStore.getState().activeRequestId;
+    expect(inflightRequestId).not.toBeNull();
+
+    act(() => {
+      setWorkspace('/workspace-b');
+    });
+    await flushMicrotasks();
+
+    expect(mockCancelSearch).toHaveBeenCalledWith(inflightRequestId);
+    expect(useSearchStore.getState().query).toBe('');
+    expect(useSearchStore.getState().activeRequestId).toBeNull();
+  });
+
+  it('cancels the in-flight request on unmount', async () => {
+    setWorkspace('/workspace');
+    mockSearchWorkspace.mockImplementation(() => new Promise<SearchResponse>(() => {}));
+    const { unmount } = renderHook(() => useWorkspaceSearch());
+
+    await typeAndDebounce('alpha');
+    const inflightRequestId = useSearchStore.getState().activeRequestId;
+    expect(inflightRequestId).not.toBeNull();
+
+    unmount();
+
+    expect(mockCancelSearch).toHaveBeenCalledWith(inflightRequestId);
+  });
+
+  it('does not call SearchWorkspace if the user clears the query during the debounce window', async () => {
+    setWorkspace('/workspace');
+    renderHook(() => useWorkspaceSearch());
+
+    act(() => useSearchStore.getState().setQuery('alpha'));
+    act(() => jest.advanceTimersByTime(SEARCH_DEBOUNCE_MS - 50));
+    act(() => useSearchStore.getState().setQuery(''));
+    act(() => jest.advanceTimersByTime(SEARCH_DEBOUNCE_MS));
+    await flushMicrotasks();
+
+    expect(mockSearchWorkspace).not.toHaveBeenCalled();
+    expect(useSearchStore.getState().uiState).toEqual({ kind: 'empty-query' });
+  });
+
+  it('routes a SearchWorkspace rejection to failSearch with the error message', async () => {
+    setWorkspace('/workspace');
+    mockSearchWorkspace.mockImplementation(async () => {
+      throw new Error('rg crashed');
+    });
+    renderHook(() => useWorkspaceSearch());
+
+    await typeAndDebounce('alpha');
+
+    expect(useSearchStore.getState().uiState).toEqual({
+      kind: 'failed',
+      message: 'rg crashed',
+    });
+    expect(useSearchStore.getState().activeRequestId).toBeNull();
+  });
+
+  it('retriggers a search when an option toggles', async () => {
+    setWorkspace('/workspace');
+    renderHook(() => useWorkspaceSearch());
+
+    await typeAndDebounce('alpha');
+    expect(mockSearchWorkspace).toHaveBeenCalledTimes(1);
+
+    await toggleOption('regex', true);
+
+    expect(mockSearchWorkspace).toHaveBeenCalledTimes(2);
+    expect(mockSearchWorkspace.mock.calls[1][0].options.regex).toBe(true);
+  });
+
+  it('maps a missing_tool response to the missing-tool UI state', async () => {
+    setWorkspace('/workspace');
+    mockSearchWorkspace.mockImplementation(async (req: { requestId: string }) =>
+      buildResponse({ requestId: req.requestId, status: 'missing_tool', message: 'install rg' })
+    );
+    renderHook(() => useWorkspaceSearch());
+
+    await typeAndDebounce('alpha');
+
+    expect(useSearchStore.getState().uiState).toEqual({
+      kind: 'missing-tool',
+      message: 'install rg',
+    });
+  });
+
+  it('maps an invalid_regex response to the invalid-regex UI state', async () => {
+    setWorkspace('/workspace');
+    mockSearchWorkspace.mockImplementation(async (req: { requestId: string }) =>
+      buildResponse({
+        requestId: req.requestId,
+        status: 'invalid_regex',
+        message: 'unclosed group',
+      })
+    );
+    renderHook(() => useWorkspaceSearch());
+
+    act(() => {
+      useSearchStore.getState().setOption('regex', true);
+    });
+    await typeAndDebounce('(unclosed');
+
+    expect(useSearchStore.getState().uiState).toEqual({
+      kind: 'invalid-regex',
+      message: 'unclosed group',
+    });
+  });
+
+  it('narrows an unknown status to failed so the UI surfaces the issue', async () => {
+    setWorkspace('/workspace');
+    mockSearchWorkspace.mockImplementation(async (req: { requestId: string }) => ({
+      ...buildResponse({ requestId: req.requestId }),
+      // Cast through unknown so TS lets us inject a status the union doesn't model.
+      status: 'mystery_state' as unknown as SearchResponse['status'],
+      message: '',
+    }));
+    renderHook(() => useWorkspaceSearch());
+
+    await typeAndDebounce('alpha');
+
+    const state = useSearchStore.getState().uiState;
+    expect(state.kind).toBe('failed');
+    if (state.kind === 'failed') {
+      expect(state.message).toContain('mystery_state');
+    }
+  });
+});

--- a/frontend/src/__tests__/stores/searchStore.test.ts
+++ b/frontend/src/__tests__/stores/searchStore.test.ts
@@ -1,0 +1,385 @@
+import { DEFAULT_EXPAND_FILE_LIMIT, useSearchStore } from '../../stores/searchStore';
+import type { FileResult, SearchResponse } from '../../types/search';
+
+function fileResult(path: string, lines: number[] = [1]): FileResult {
+  return {
+    path,
+    relativePath: path.replace(/^\/workspace\//, ''),
+    matches: lines.map((line) => ({
+      line,
+      column: 1,
+      text: `match on line ${line}`,
+      submatches: [],
+    })),
+  };
+}
+
+function response(overrides: Partial<SearchResponse> = {}): SearchResponse {
+  return {
+    requestId: 'request-1',
+    status: 'success',
+    message: '',
+    files: [],
+    totalFiles: 0,
+    totalLines: 0,
+    truncated: false,
+    matchCap: 1000,
+    durationMs: 4,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useSearchStore.setState(useSearchStore.getInitialState());
+});
+
+describe('searchStore', () => {
+  describe('initial state', () => {
+    it('starts in no-workspace with empty query and default options', () => {
+      const state = useSearchStore.getState();
+      expect(state.uiState).toEqual({ kind: 'no-workspace' });
+      expect(state.query).toBe('');
+      expect(state.options).toEqual({ regex: false, caseSensitive: false, wholeWord: false });
+      expect(state.expandedFiles.size).toBe(0);
+      expect(state.activeRequestId).toBeNull();
+    });
+  });
+
+  describe('setQuery', () => {
+    it('updates the query and leaves uiState alone', () => {
+      useSearchStore.getState().setQuery('alpha');
+      expect(useSearchStore.getState().query).toBe('alpha');
+      expect(useSearchStore.getState().uiState.kind).toBe('no-workspace');
+    });
+  });
+
+  describe('setOption', () => {
+    it.each(['regex', 'caseSensitive', 'wholeWord'] as const)(
+      'toggles %s independently',
+      (option) => {
+        useSearchStore.getState().setOption(option, true);
+        expect(useSearchStore.getState().options[option]).toBe(true);
+
+        useSearchStore.getState().setOption(option, false);
+        expect(useSearchStore.getState().options[option]).toBe(false);
+      }
+    );
+  });
+
+  describe('beginSearch', () => {
+    it('sets activeRequestId and transitions to loading', () => {
+      useSearchStore.getState().beginSearch('request-1');
+      const state = useSearchStore.getState();
+      expect(state.activeRequestId).toBe('request-1');
+      expect(state.uiState).toEqual({ kind: 'loading', requestId: 'request-1' });
+    });
+  });
+
+  describe('applyResponse', () => {
+    it('drops responses whose requestId does not match activeRequestId', () => {
+      useSearchStore.getState().beginSearch('request-2');
+      useSearchStore.getState().applyResponse(response({ requestId: 'request-1' }));
+
+      expect(useSearchStore.getState().uiState).toEqual({
+        kind: 'loading',
+        requestId: 'request-2',
+      });
+      expect(useSearchStore.getState().activeRequestId).toBe('request-2');
+    });
+
+    it('maps a successful response with files to results state', () => {
+      useSearchStore.getState().beginSearch('request-1');
+      useSearchStore.getState().applyResponse(
+        response({
+          totalFiles: 1,
+          totalLines: 1,
+          files: [fileResult('/workspace/src/App.tsx')],
+        })
+      );
+
+      const state = useSearchStore.getState();
+      expect(state.uiState).toEqual({
+        kind: 'results',
+        files: [fileResult('/workspace/src/App.tsx')],
+        totalFiles: 1,
+        totalLines: 1,
+        truncated: false,
+        matchCap: 1000,
+        durationMs: 4,
+      });
+      expect(state.activeRequestId).toBeNull();
+    });
+
+    it('expands all result files when count is at or below the default limit', () => {
+      const files = Array.from({ length: DEFAULT_EXPAND_FILE_LIMIT }, (_, i) =>
+        fileResult(`/workspace/file${i}.ts`)
+      );
+      useSearchStore.getState().beginSearch('request-1');
+      useSearchStore
+        .getState()
+        .applyResponse(response({ totalFiles: files.length, totalLines: files.length, files }));
+
+      const state = useSearchStore.getState();
+      expect(state.expandedFiles.size).toBe(DEFAULT_EXPAND_FILE_LIMIT);
+      for (const file of files) {
+        expect(state.expandedFiles.has(file.path)).toBe(true);
+      }
+    });
+
+    it('caps default expansion when result count exceeds the limit', () => {
+      const files = Array.from({ length: DEFAULT_EXPAND_FILE_LIMIT + 5 }, (_, i) =>
+        fileResult(`/workspace/file${i}.ts`)
+      );
+      useSearchStore.getState().beginSearch('request-1');
+      useSearchStore
+        .getState()
+        .applyResponse(response({ totalFiles: files.length, totalLines: files.length, files }));
+
+      const state = useSearchStore.getState();
+      expect(state.expandedFiles.size).toBe(DEFAULT_EXPAND_FILE_LIMIT);
+      // First N expanded; tail collapsed.
+      for (let i = 0; i < DEFAULT_EXPAND_FILE_LIMIT; i++) {
+        expect(state.expandedFiles.has(files[i].path)).toBe(true);
+      }
+      for (let i = DEFAULT_EXPAND_FILE_LIMIT; i < files.length; i++) {
+        expect(state.expandedFiles.has(files[i].path)).toBe(false);
+      }
+    });
+
+    it('preserves truncation flag and matchCap in results state', () => {
+      useSearchStore.getState().beginSearch('request-1');
+      useSearchStore.getState().applyResponse(
+        response({
+          truncated: true,
+          matchCap: 5000,
+          totalFiles: 100,
+          totalLines: 5000,
+          files: [fileResult('/workspace/big.log')],
+        })
+      );
+
+      const state = useSearchStore.getState();
+      expect(state.uiState.kind).toBe('results');
+      if (state.uiState.kind === 'results') {
+        expect(state.uiState.truncated).toBe(true);
+        expect(state.uiState.matchCap).toBe(5000);
+        expect(state.uiState.totalFiles).toBe(100);
+        expect(state.uiState.totalLines).toBe(5000);
+      }
+    });
+
+    it('maps a successful response with zero files to no-matches', () => {
+      useSearchStore.getState().beginSearch('request-1');
+      useSearchStore.getState().applyResponse(response({ status: 'success', files: [] }));
+
+      expect(useSearchStore.getState().uiState).toEqual({
+        kind: 'no-matches',
+        durationMs: 4,
+      });
+    });
+
+    it('maps a no_matches response to no-matches', () => {
+      useSearchStore.getState().beginSearch('request-1');
+      useSearchStore.getState().applyResponse(response({ status: 'no_matches' }));
+
+      expect(useSearchStore.getState().uiState).toEqual({
+        kind: 'no-matches',
+        durationMs: 4,
+      });
+    });
+
+    it('maps a missing_tool response to missing-tool with the backend message', () => {
+      useSearchStore.getState().beginSearch('request-1');
+      useSearchStore
+        .getState()
+        .applyResponse(response({ status: 'missing_tool', message: 'install rg' }));
+
+      expect(useSearchStore.getState().uiState).toEqual({
+        kind: 'missing-tool',
+        message: 'install rg',
+      });
+    });
+
+    it('uses a fallback message when the backend missing_tool message is empty', () => {
+      useSearchStore.getState().beginSearch('request-1');
+      useSearchStore.getState().applyResponse(response({ status: 'missing_tool', message: '' }));
+
+      expect(useSearchStore.getState().uiState).toEqual({
+        kind: 'missing-tool',
+        message: 'ripgrep is not available on PATH.',
+      });
+    });
+
+    it('maps an invalid_regex response to invalid-regex with the backend message', () => {
+      useSearchStore.getState().beginSearch('request-1');
+      useSearchStore
+        .getState()
+        .applyResponse(response({ status: 'invalid_regex', message: 'unclosed group' }));
+
+      expect(useSearchStore.getState().uiState).toEqual({
+        kind: 'invalid-regex',
+        message: 'unclosed group',
+      });
+    });
+
+    it('maps a canceled response to canceled', () => {
+      useSearchStore.getState().beginSearch('request-1');
+      useSearchStore.getState().applyResponse(response({ status: 'canceled' }));
+
+      expect(useSearchStore.getState().uiState).toEqual({ kind: 'canceled' });
+    });
+
+    it('maps a failed response to failed with the backend message', () => {
+      useSearchStore.getState().beginSearch('request-1');
+      useSearchStore
+        .getState()
+        .applyResponse(response({ status: 'failed', message: 'rg exited with 2' }));
+
+      expect(useSearchStore.getState().uiState).toEqual({
+        kind: 'failed',
+        message: 'rg exited with 2',
+      });
+    });
+
+    it('clears expandedFiles on non-result terminal states', () => {
+      useSearchStore.getState().toggleFileExpanded('/workspace/keep.ts');
+      useSearchStore.getState().beginSearch('request-1');
+      useSearchStore.getState().applyResponse(response({ status: 'failed', message: 'boom' }));
+
+      expect(useSearchStore.getState().expandedFiles.size).toBe(0);
+    });
+  });
+
+  describe('failSearch', () => {
+    it('transitions to failed when requestId matches', () => {
+      useSearchStore.getState().beginSearch('request-1');
+      useSearchStore.getState().failSearch('request-1', 'IPC error');
+
+      const state = useSearchStore.getState();
+      expect(state.uiState).toEqual({ kind: 'failed', message: 'IPC error' });
+      expect(state.activeRequestId).toBeNull();
+    });
+
+    it('ignores stale failures from superseded requests', () => {
+      useSearchStore.getState().beginSearch('request-2');
+      useSearchStore.getState().failSearch('request-1', 'late failure');
+
+      expect(useSearchStore.getState().uiState).toEqual({
+        kind: 'loading',
+        requestId: 'request-2',
+      });
+    });
+  });
+
+  describe('setNoWorkspace', () => {
+    it('clears uiState, activeRequestId, and expandedFiles', () => {
+      useSearchStore.getState().beginSearch('request-1');
+      useSearchStore.getState().toggleFileExpanded('/workspace/x.ts');
+      useSearchStore.getState().setNoWorkspace();
+
+      const state = useSearchStore.getState();
+      expect(state.uiState).toEqual({ kind: 'no-workspace' });
+      expect(state.activeRequestId).toBeNull();
+      expect(state.expandedFiles.size).toBe(0);
+    });
+
+    it('is a no-op when already in clean no-workspace state (preserves identity)', () => {
+      const before = useSearchStore.getState();
+      useSearchStore.getState().setNoWorkspace();
+      const after = useSearchStore.getState();
+      expect(after.uiState).toBe(before.uiState);
+      expect(after.expandedFiles).toBe(before.expandedFiles);
+    });
+  });
+
+  describe('setEmptyQuery', () => {
+    it('transitions to empty-query and clears active request', () => {
+      useSearchStore.getState().beginSearch('request-1');
+      useSearchStore.getState().setEmptyQuery();
+
+      const state = useSearchStore.getState();
+      expect(state.uiState).toEqual({ kind: 'empty-query' });
+      expect(state.activeRequestId).toBeNull();
+    });
+
+    it('is a no-op when already in clean empty-query state', () => {
+      useSearchStore.getState().setEmptyQuery();
+      const before = useSearchStore.getState();
+      useSearchStore.getState().setEmptyQuery();
+      const after = useSearchStore.getState();
+      expect(after.uiState).toBe(before.uiState);
+    });
+  });
+
+  describe('resetForWorkspace', () => {
+    it('resets to empty-query when given a non-null path', () => {
+      useSearchStore.getState().setQuery('alpha');
+      useSearchStore.getState().setOption('regex', true);
+      useSearchStore.getState().beginSearch('request-1');
+      useSearchStore.getState().resetForWorkspace('/workspace');
+
+      const state = useSearchStore.getState();
+      expect(state.query).toBe('');
+      expect(state.options).toEqual({ regex: false, caseSensitive: false, wholeWord: false });
+      expect(state.uiState).toEqual({ kind: 'empty-query' });
+      expect(state.activeRequestId).toBeNull();
+      expect(state.expandedFiles.size).toBe(0);
+    });
+
+    it('resets to no-workspace when given null', () => {
+      useSearchStore.getState().setQuery('alpha');
+      useSearchStore.getState().resetForWorkspace(null);
+
+      expect(useSearchStore.getState().uiState).toEqual({ kind: 'no-workspace' });
+      expect(useSearchStore.getState().query).toBe('');
+    });
+
+    it('resets to no-workspace when given undefined', () => {
+      useSearchStore.getState().resetForWorkspace(undefined);
+      expect(useSearchStore.getState().uiState).toEqual({ kind: 'no-workspace' });
+    });
+  });
+
+  describe('toggleFileExpanded', () => {
+    it('adds the path when not present', () => {
+      useSearchStore.getState().toggleFileExpanded('/workspace/a.ts');
+      expect(useSearchStore.getState().expandedFiles.has('/workspace/a.ts')).toBe(true);
+    });
+
+    it('removes the path when already present', () => {
+      useSearchStore.getState().toggleFileExpanded('/workspace/a.ts');
+      useSearchStore.getState().toggleFileExpanded('/workspace/a.ts');
+      expect(useSearchStore.getState().expandedFiles.has('/workspace/a.ts')).toBe(false);
+    });
+
+    it('preserves other expansions', () => {
+      useSearchStore.getState().toggleFileExpanded('/workspace/a.ts');
+      useSearchStore.getState().toggleFileExpanded('/workspace/b.ts');
+      useSearchStore.getState().toggleFileExpanded('/workspace/a.ts');
+
+      const expanded = useSearchStore.getState().expandedFiles;
+      expect(expanded.has('/workspace/a.ts')).toBe(false);
+      expect(expanded.has('/workspace/b.ts')).toBe(true);
+    });
+
+    it('returns a fresh Set instance to support shallow equality re-render checks', () => {
+      const before = useSearchStore.getState().expandedFiles;
+      useSearchStore.getState().toggleFileExpanded('/workspace/a.ts');
+      const after = useSearchStore.getState().expandedFiles;
+      expect(after).not.toBe(before);
+    });
+  });
+
+  describe('clearResults', () => {
+    it('returns the store to empty-query and drops expansions and active id', () => {
+      useSearchStore.getState().beginSearch('request-1');
+      useSearchStore.getState().toggleFileExpanded('/workspace/a.ts');
+      useSearchStore.getState().clearResults();
+
+      const state = useSearchStore.getState();
+      expect(state.uiState).toEqual({ kind: 'empty-query' });
+      expect(state.activeRequestId).toBeNull();
+      expect(state.expandedFiles.size).toBe(0);
+    });
+  });
+});

--- a/frontend/src/__tests__/utils/searchRanges.test.ts
+++ b/frontend/src/__tests__/utils/searchRanges.test.ts
@@ -1,0 +1,228 @@
+import {
+  byteColumnToCharColumn,
+  byteOffsetToCharIndex,
+  splitLineByByteRanges,
+} from '../../utils/searchRanges';
+
+describe('byteOffsetToCharIndex', () => {
+  it('keeps ASCII byte offsets aligned with string indexes', () => {
+    expect(byteOffsetToCharIndex('abcdef', 0)).toBe(0);
+    expect(byteOffsetToCharIndex('abcdef', 3)).toBe(3);
+    expect(byteOffsetToCharIndex('abcdef', 6)).toBe(6);
+  });
+
+  it('clamps offsets past the end of text to text.length', () => {
+    expect(byteOffsetToCharIndex('abcdef', 99)).toBe(6);
+    expect(byteOffsetToCharIndex('', 0)).toBe(0);
+    expect(byteOffsetToCharIndex('', 99)).toBe(0);
+  });
+
+  it('treats negative offsets as 0', () => {
+    expect(byteOffsetToCharIndex('abcdef', -1)).toBe(0);
+    expect(byteOffsetToCharIndex('abcdef', -100)).toBe(0);
+  });
+
+  it('rounds non-integer byte offsets toward zero', () => {
+    expect(byteOffsetToCharIndex('abcdef', 2.9)).toBe(2);
+    expect(byteOffsetToCharIndex('abcdef', 0.4)).toBe(0);
+  });
+
+  it('handles 2-byte UTF-8 (Latin-1 supplement)', () => {
+    // 'é' = U+00E9 = 0xC3 0xA9 (2 UTF-8 bytes)
+    const text = 'café';
+    expect(byteOffsetToCharIndex(text, 0)).toBe(0);
+    expect(byteOffsetToCharIndex(text, 3)).toBe(3); // start of 'é'
+    expect(byteOffsetToCharIndex(text, 5)).toBe(4); // end of 'é'
+  });
+
+  it('handles 3-byte UTF-8 (CJK)', () => {
+    // '日' = U+65E5 = 0xE6 0x97 0xA5 (3 UTF-8 bytes)
+    const text = 'a日b';
+    expect(byteOffsetToCharIndex(text, 0)).toBe(0);
+    expect(byteOffsetToCharIndex(text, 1)).toBe(1); // start of '日'
+    expect(byteOffsetToCharIndex(text, 4)).toBe(2); // end of '日'
+    expect(byteOffsetToCharIndex(text, 5)).toBe(3); // end of 'b'
+  });
+
+  it('handles 4-byte UTF-8 emoji as a UTF-16 surrogate pair', () => {
+    // '😀' = U+1F600 = 0xF0 0x9F 0x98 0x80 (4 UTF-8 bytes), 2 UTF-16 code units
+    const text = 'a😀z';
+    expect(byteOffsetToCharIndex(text, 0)).toBe(0);
+    expect(byteOffsetToCharIndex(text, 1)).toBe(1); // start of emoji
+    expect(byteOffsetToCharIndex(text, 5)).toBe(3); // end of emoji
+    expect(byteOffsetToCharIndex(text, 6)).toBe(4); // end of 'z'
+  });
+
+  it('never lands inside a UTF-16 surrogate pair when given a mid-emoji byte offset', () => {
+    const text = 'a😀z';
+    // Bytes 2, 3, 4 are inside the 4-byte emoji. The function should return
+    // either before the emoji (1) or after it (3), never the high-surrogate
+    // index (would be 2 — the low surrogate).
+    for (const byte of [2, 3, 4]) {
+      const idx = byteOffsetToCharIndex(text, byte);
+      expect(idx === 1 || idx === 3).toBe(true);
+    }
+  });
+
+  it('handles combining marks as separate codepoints', () => {
+    // 'é' decomposed: 'e' + U+0301 = 1 + 2 UTF-8 bytes = 3 bytes total
+    const text = 'éz';
+    expect(byteOffsetToCharIndex(text, 0)).toBe(0);
+    expect(byteOffsetToCharIndex(text, 1)).toBe(1); // start of combining mark
+    expect(byteOffsetToCharIndex(text, 3)).toBe(2); // end of combining mark
+    expect(byteOffsetToCharIndex(text, 4)).toBe(3); // end of 'z'
+  });
+
+  it('handles ZWJ emoji sequences', () => {
+    // 👨‍👩‍👧 = man + ZWJ + woman + ZWJ + girl
+    // U+1F468 (4B) + U+200D (3B) + U+1F469 (4B) + U+200D (3B) + U+1F467 (4B) = 18 bytes
+    // UTF-16 code units: 2 + 1 + 2 + 1 + 2 = 8
+    const text = '\u{1F468}‍\u{1F469}‍\u{1F467}';
+    expect(byteOffsetToCharIndex(text, 0)).toBe(0);
+    expect(byteOffsetToCharIndex(text, 18)).toBe(8); // end of full sequence
+    expect(byteOffsetToCharIndex(text, 4)).toBe(2); // after first man
+    expect(byteOffsetToCharIndex(text, 7)).toBe(3); // after first ZWJ
+  });
+});
+
+describe('byteColumnToCharColumn', () => {
+  it('converts 1-based ripgrep byte columns to 1-based editor columns', () => {
+    // 'aé😀z': bytes [a=1][é=1-2][😀=3-6][z=7] (1-based)
+    // chars (UTF-16): [a][é][😀hi][😀lo][z] → 1-based 1,2,3,5
+    expect(byteColumnToCharColumn('aé😀z', 1)).toBe(1); // 'a'
+    expect(byteColumnToCharColumn('aé😀z', 2)).toBe(2); // 'é'
+    expect(byteColumnToCharColumn('aé😀z', 4)).toBe(3); // start of '😀'
+    expect(byteColumnToCharColumn('aé😀z', 8)).toBe(5); // 'z'
+  });
+
+  it('clamps byte columns past line end to one past last char', () => {
+    expect(byteColumnToCharColumn('abc', 99)).toBe(4);
+  });
+
+  it('treats column 0 or negative as column 1', () => {
+    expect(byteColumnToCharColumn('abc', 0)).toBe(1);
+    expect(byteColumnToCharColumn('abc', -5)).toBe(1);
+  });
+});
+
+describe('splitLineByByteRanges', () => {
+  it('returns the whole text as a non-match segment when ranges is empty', () => {
+    expect(splitLineByByteRanges('alpha beta', [])).toEqual([
+      { text: 'alpha beta', isMatch: false },
+    ]);
+  });
+
+  it('splits a single ASCII range', () => {
+    expect(splitLineByByteRanges('alpha beta gamma', [{ start: 6, end: 10 }])).toEqual([
+      { text: 'alpha ', isMatch: false },
+      { text: 'beta', isMatch: true },
+      { text: ' gamma', isMatch: false },
+    ]);
+  });
+
+  it('emits no leading non-match segment when range starts at byte 0', () => {
+    expect(splitLineByByteRanges('alpha beta', [{ start: 0, end: 5 }])).toEqual([
+      { text: 'alpha', isMatch: true },
+      { text: ' beta', isMatch: false },
+    ]);
+  });
+
+  it('emits no trailing non-match segment when range ends at text byte length', () => {
+    expect(splitLineByByteRanges('alpha beta', [{ start: 6, end: 10 }])).toEqual([
+      { text: 'alpha ', isMatch: false },
+      { text: 'beta', isMatch: true },
+    ]);
+  });
+
+  it('emits a single match segment when a range covers the entire text', () => {
+    expect(splitLineByByteRanges('alpha', [{ start: 0, end: 5 }])).toEqual([
+      { text: 'alpha', isMatch: true },
+    ]);
+  });
+
+  it('emits multiple match segments separated by gaps', () => {
+    expect(
+      splitLineByByteRanges('alpha beta gamma', [
+        { start: 0, end: 5 },
+        { start: 11, end: 16 },
+      ])
+    ).toEqual([
+      { text: 'alpha', isMatch: true },
+      { text: ' beta ', isMatch: false },
+      { text: 'gamma', isMatch: true },
+    ]);
+  });
+
+  it('joins adjacent match segments with no gap between them', () => {
+    expect(
+      splitLineByByteRanges('alphabeta', [
+        { start: 0, end: 5 },
+        { start: 5, end: 9 },
+      ])
+    ).toEqual([
+      { text: 'alpha', isMatch: true },
+      { text: 'beta', isMatch: true },
+    ]);
+  });
+
+  it('sorts unsorted input ranges by start ascending', () => {
+    expect(
+      splitLineByByteRanges('alpha beta gamma', [
+        { start: 11, end: 16 },
+        { start: 0, end: 5 },
+      ])
+    ).toEqual([
+      { text: 'alpha', isMatch: true },
+      { text: ' beta ', isMatch: false },
+      { text: 'gamma', isMatch: true },
+    ]);
+  });
+
+  it('merges overlapping ranges into a single highlight', () => {
+    // Ranges [0..5) and [3..8) overlap at bytes 3-4. Merging produces a
+    // single [0..8) highlight rather than two adjacent segments with a
+    // surprising boundary inside the overlap region.
+    expect(
+      splitLineByByteRanges('alphabetagamma', [
+        { start: 0, end: 5 },
+        { start: 3, end: 8 },
+      ])
+    ).toEqual([
+      { text: 'alphabet', isMatch: true },
+      { text: 'agamma', isMatch: false },
+    ]);
+  });
+
+  it('keeps touching ranges as separate highlights so adjacent matches stay countable', () => {
+    expect(
+      splitLineByByteRanges('alphabetagamma', [
+        { start: 0, end: 5 },
+        { start: 5, end: 8 },
+      ])
+    ).toEqual([
+      { text: 'alpha', isMatch: true },
+      { text: 'bet', isMatch: true },
+      { text: 'agamma', isMatch: false },
+    ]);
+  });
+
+  it('splits ranges that include multibyte characters', () => {
+    expect(splitLineByByteRanges('café 😀', [{ start: 3, end: 10 }])).toEqual([
+      { text: 'caf', isMatch: false },
+      { text: 'é 😀', isMatch: true },
+    ]);
+  });
+
+  it('returns the whole text as non-match when ranges have zero width', () => {
+    expect(splitLineByByteRanges('alpha', [{ start: 2, end: 2 }])).toEqual([
+      { text: 'alpha', isMatch: false },
+    ]);
+  });
+
+  it('handles empty text', () => {
+    expect(splitLineByByteRanges('', [])).toEqual([{ text: '', isMatch: false }]);
+    expect(splitLineByByteRanges('', [{ start: 0, end: 5 }])).toEqual([
+      { text: '', isMatch: false },
+    ]);
+  });
+});

--- a/frontend/src/hooks/useWorkspaceSearch.ts
+++ b/frontend/src/hooks/useWorkspaceSearch.ts
@@ -1,0 +1,150 @@
+import { useEffect, useRef } from 'react';
+import { CancelSearch, SearchWorkspace } from '../../wailsjs/go/main/App';
+import { search } from '../../wailsjs/go/models';
+import { useIDEStore } from '../stores/ideStore';
+import { useSearchStore } from '../stores/searchStore';
+import type { SearchResponse, SearchStatus } from '../types/search';
+
+export const SEARCH_DEBOUNCE_MS = 250;
+
+const KNOWN_STATUSES: ReadonlySet<SearchStatus> = new Set<SearchStatus>([
+  'success',
+  'no_matches',
+  'missing_tool',
+  'invalid_regex',
+  'canceled',
+  'failed',
+]);
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string' && err.length > 0) return err;
+  return 'Search failed.';
+}
+
+// Narrow the generated `status: string` to the SearchStatus union, defaulting
+// unknown statuses to 'failed' so the UI surfaces the issue rather than
+// silently dropping the response.
+function narrowResponse(raw: search.SearchResponse): SearchResponse {
+  const status: SearchStatus = KNOWN_STATUSES.has(raw.status as SearchStatus)
+    ? (raw.status as SearchStatus)
+    : 'failed';
+  return {
+    requestId: raw.requestId,
+    status,
+    message:
+      status === 'failed' && !raw.message ? `Unexpected search status: ${raw.status}` : raw.message,
+    files: raw.files,
+    totalFiles: raw.totalFiles,
+    totalLines: raw.totalLines,
+    truncated: raw.truncated,
+    matchCap: raw.matchCap,
+    durationMs: raw.durationMs,
+  };
+}
+
+function fireCancelSearch(requestId: string): void {
+  void CancelSearch(requestId).catch((err) => {
+    console.error(`Search cancel failed for ${requestId}:`, err);
+  });
+}
+
+/**
+ * useWorkspaceSearch wires the search store to backend ripgrep.
+ *
+ * Responsibilities:
+ *   - debounce query/option changes by SEARCH_DEBOUNCE_MS before invoking
+ *     SearchWorkspace, so rapid typing collapses into one request
+ *   - assign each fired request a unique RequestID; drop stale responses by
+ *     comparing against the store's activeRequestId
+ *   - on workspace switch or unmount, fire CancelSearch(activeRequestId) so
+ *     the backend ripgrep process is reaped instead of running to completion
+ *   - keep ideStore.workspace and searchStore in sync: empty query → empty
+ *     state, no workspace → no-workspace state
+ *
+ * The hook is fire-and-forget; mount it once at the top of the app.
+ */
+export function useWorkspaceSearch(): void {
+  const workspacePath = useIDEStore((state) => state.workspace?.path ?? null);
+  const query = useSearchStore((state) => state.query);
+  const options = useSearchStore((state) => state.options);
+  const requestCounter = useRef(0);
+
+  // Workspace-switch listener: cancel any in-flight search and reset state
+  // when the user opens a different workspace. Subscribed once at mount; the
+  // dep array is empty so the subscription persists for the hook's lifetime.
+  useEffect(() => {
+    let previousWorkspacePath = useIDEStore.getState().workspace?.path ?? null;
+
+    return useIDEStore.subscribe((state) => {
+      const nextWorkspacePath = state.workspace?.path ?? null;
+      if (nextWorkspacePath === previousWorkspacePath) return;
+
+      const activeRequestId = useSearchStore.getState().activeRequestId;
+      if (activeRequestId) fireCancelSearch(activeRequestId);
+
+      useSearchStore.getState().resetForWorkspace(nextWorkspacePath);
+      previousWorkspacePath = nextWorkspacePath;
+    });
+  }, []);
+
+  // Unmount cleanup: cancel any in-flight backend search so the ripgrep
+  // process does not outlive the IDE session.
+  useEffect(() => {
+    return () => {
+      const activeRequestId = useSearchStore.getState().activeRequestId;
+      if (activeRequestId) fireCancelSearch(activeRequestId);
+    };
+  }, []);
+
+  // Main debounced search effect. Re-runs whenever the workspace, query, or
+  // options change. Stale debounced supersessions are dropped by RequestID;
+  // we deliberately do not fire CancelSearch on debounce-supersession because
+  // the backend run usually finishes within the next debounce window.
+  useEffect(() => {
+    const trimmedQuery = query.trim();
+
+    if (!workspacePath) {
+      useSearchStore.getState().setNoWorkspace();
+      return;
+    }
+
+    if (!trimmedQuery) {
+      useSearchStore.getState().setEmptyQuery();
+      return;
+    }
+
+    let canceled = false;
+    const requestId = `search-${Date.now()}-${++requestCounter.current}`;
+
+    const timer = window.setTimeout(() => {
+      if (canceled) return;
+
+      useSearchStore.getState().beginSearch(requestId);
+
+      const request = new search.SearchRequest({
+        requestId,
+        root: workspacePath,
+        query,
+        options: { ...options },
+      });
+
+      void SearchWorkspace(request)
+        .then((raw) => {
+          if (canceled) return;
+          if (useSearchStore.getState().activeRequestId !== requestId) return;
+          useSearchStore.getState().applyResponse(narrowResponse(raw));
+        })
+        .catch((err) => {
+          if (canceled) return;
+          if (useSearchStore.getState().activeRequestId !== requestId) return;
+          useSearchStore.getState().failSearch(requestId, errorMessage(err));
+        });
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      canceled = true;
+      window.clearTimeout(timer);
+    };
+  }, [options, query, workspacePath]);
+}

--- a/frontend/src/stores/searchStore.ts
+++ b/frontend/src/stores/searchStore.ts
@@ -1,0 +1,239 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import { useShallow } from 'zustand/react/shallow';
+import {
+  defaultSearchOptions,
+  type FileResult,
+  type SearchOptions,
+  type SearchResponse,
+  type SearchUIState,
+} from '../types/search';
+
+// Number of file groups expanded by default when results arrive. Picking a
+// finite cap prevents the panel from auto-expanding 1000+ files on a wide
+// search; smaller results stay fully visible. Task 3 (panel UI) can override
+// per-file via toggleFileExpanded.
+export const DEFAULT_EXPAND_FILE_LIMIT = 10;
+
+interface SearchState {
+  query: string;
+  options: SearchOptions;
+  uiState: SearchUIState;
+  expandedFiles: Set<string>;
+  activeRequestId: string | null;
+}
+
+interface SearchActions {
+  setQuery: (query: string) => void;
+  setOption: (option: keyof SearchOptions, value: boolean) => void;
+  beginSearch: (requestId: string) => void;
+  applyResponse: (response: SearchResponse) => void;
+  failSearch: (requestId: string, message: string) => void;
+  setNoWorkspace: () => void;
+  setEmptyQuery: () => void;
+  resetForWorkspace: (workspacePath: string | null | undefined) => void;
+  toggleFileExpanded: (path: string) => void;
+  clearResults: () => void;
+}
+
+type SearchStore = SearchState & SearchActions;
+
+function responseToUIState(response: SearchResponse): SearchUIState {
+  switch (response.status) {
+    case 'success':
+      if (response.files.length === 0) {
+        return { kind: 'no-matches', durationMs: response.durationMs };
+      }
+      return {
+        kind: 'results',
+        files: response.files,
+        totalFiles: response.totalFiles,
+        totalLines: response.totalLines,
+        truncated: response.truncated,
+        matchCap: response.matchCap,
+        durationMs: response.durationMs,
+      };
+    case 'no_matches':
+      return { kind: 'no-matches', durationMs: response.durationMs };
+    case 'missing_tool':
+      return {
+        kind: 'missing-tool',
+        message: response.message || 'ripgrep is not available on PATH.',
+      };
+    case 'invalid_regex':
+      return {
+        kind: 'invalid-regex',
+        message: response.message || 'The regular expression is invalid.',
+      };
+    case 'canceled':
+      return { kind: 'canceled' };
+    case 'failed':
+      return {
+        kind: 'failed',
+        message: response.message || 'Search failed.',
+      };
+  }
+}
+
+function defaultExpansion(files: FileResult[]): Set<string> {
+  if (files.length === 0) return new Set();
+  return new Set(files.slice(0, DEFAULT_EXPAND_FILE_LIMIT).map((f) => f.path));
+}
+
+export const useSearchStore = create<SearchStore>()(
+  devtools(
+    (set) => ({
+      query: '',
+      options: { ...defaultSearchOptions },
+      uiState: { kind: 'no-workspace' },
+      expandedFiles: new Set<string>(),
+      activeRequestId: null,
+
+      setQuery: (query) => set({ query }, false, 'search/setQuery'),
+
+      setOption: (option, value) =>
+        set(
+          (state) => ({
+            options: { ...state.options, [option]: value },
+          }),
+          false,
+          'search/setOption'
+        ),
+
+      beginSearch: (requestId) =>
+        set(
+          {
+            activeRequestId: requestId,
+            uiState: { kind: 'loading', requestId },
+          },
+          false,
+          'search/beginSearch'
+        ),
+
+      applyResponse: (response) =>
+        set(
+          (state) => {
+            if (state.activeRequestId !== response.requestId) return {};
+
+            const uiState = responseToUIState(response);
+            const expandedFiles =
+              uiState.kind === 'results' ? defaultExpansion(uiState.files) : new Set<string>();
+
+            return {
+              activeRequestId: null,
+              uiState,
+              expandedFiles,
+            };
+          },
+          false,
+          'search/applyResponse'
+        ),
+
+      failSearch: (requestId, message) =>
+        set(
+          (state) => {
+            if (state.activeRequestId !== requestId) return {};
+            return {
+              activeRequestId: null,
+              uiState: { kind: 'failed', message },
+              expandedFiles: new Set<string>(),
+            };
+          },
+          false,
+          'search/failSearch'
+        ),
+
+      setNoWorkspace: () =>
+        set(
+          (state) => {
+            if (
+              state.uiState.kind === 'no-workspace' &&
+              state.activeRequestId === null &&
+              state.expandedFiles.size === 0
+            ) {
+              return {};
+            }
+            return {
+              uiState: { kind: 'no-workspace' },
+              activeRequestId: null,
+              expandedFiles: new Set<string>(),
+            };
+          },
+          false,
+          'search/setNoWorkspace'
+        ),
+
+      setEmptyQuery: () =>
+        set(
+          (state) => {
+            if (
+              state.uiState.kind === 'empty-query' &&
+              state.activeRequestId === null &&
+              state.expandedFiles.size === 0
+            ) {
+              return {};
+            }
+            return {
+              uiState: { kind: 'empty-query' },
+              activeRequestId: null,
+              expandedFiles: new Set<string>(),
+            };
+          },
+          false,
+          'search/setEmptyQuery'
+        ),
+
+      resetForWorkspace: (workspacePath) =>
+        set(
+          {
+            query: '',
+            options: { ...defaultSearchOptions },
+            uiState: workspacePath ? { kind: 'empty-query' } : { kind: 'no-workspace' },
+            expandedFiles: new Set<string>(),
+            activeRequestId: null,
+          },
+          false,
+          'search/resetForWorkspace'
+        ),
+
+      toggleFileExpanded: (path) =>
+        set(
+          (state) => {
+            const expandedFiles = new Set(state.expandedFiles);
+            if (expandedFiles.has(path)) {
+              expandedFiles.delete(path);
+            } else {
+              expandedFiles.add(path);
+            }
+            return { expandedFiles };
+          },
+          false,
+          'search/toggleFileExpanded'
+        ),
+
+      clearResults: () =>
+        set(
+          {
+            uiState: { kind: 'empty-query' },
+            expandedFiles: new Set<string>(),
+            activeRequestId: null,
+          },
+          false,
+          'search/clearResults'
+        ),
+    }),
+    { name: 'search-store' }
+  )
+);
+
+export const useSearchOptions = () => useSearchStore((state) => state.options);
+
+export const useSearchSnapshot = () =>
+  useSearchStore(
+    useShallow((state) => ({
+      query: state.query,
+      options: state.options,
+      uiState: state.uiState,
+      expandedFiles: state.expandedFiles,
+    }))
+  );

--- a/frontend/src/types/search.ts
+++ b/frontend/src/types/search.ts
@@ -1,0 +1,78 @@
+import type { search } from '../../wailsjs/go/models';
+
+export type MatchRange = Pick<search.MatchRange, 'start' | 'end'>;
+
+export interface LineMatch {
+  line: number;
+  column: number;
+  text: string;
+  submatches: MatchRange[];
+}
+
+export interface FileResult {
+  path: string;
+  relativePath: string;
+  matches: LineMatch[];
+}
+
+export interface SearchOptions {
+  regex: boolean;
+  caseSensitive: boolean;
+  wholeWord: boolean;
+}
+
+export interface SearchRequest {
+  requestId: string;
+  root: string;
+  query: string;
+  options: SearchOptions;
+}
+
+export type SearchStatus =
+  | 'success'
+  | 'no_matches'
+  | 'missing_tool'
+  | 'invalid_regex'
+  | 'canceled'
+  | 'failed';
+
+// Frontend-facing response. The generated Wails type has `status: string`; we
+// narrow it to the `SearchStatus` literal union and re-type `files` in terms
+// of our local `FileResult` (which is structurally identical but doesn't carry
+// the generated `convertValues` helper).
+export type SearchResponse = Omit<search.SearchResponse, 'status' | 'files' | 'convertValues'> & {
+  status: SearchStatus;
+  files: FileResult[];
+};
+
+// SearchUIState is a discriminated union of the mutually exclusive UI states.
+// Each variant carries only the data the panel needs to render that state.
+//
+// Backend response metadata (durationMs, matchCap, totalFiles, totalLines,
+// truncated) is only attached to states where it is meaningful for display:
+// `results` renders match counts and truncation, `no-matches` may want
+// duration. Terminal-error states carry only `message`.
+export type SearchUIState =
+  | { kind: 'no-workspace' }
+  | { kind: 'empty-query' }
+  | { kind: 'loading'; requestId: string }
+  | {
+      kind: 'results';
+      files: FileResult[];
+      totalFiles: number;
+      totalLines: number;
+      truncated: boolean;
+      matchCap: number;
+      durationMs: number;
+    }
+  | { kind: 'no-matches'; durationMs: number }
+  | { kind: 'missing-tool'; message: string }
+  | { kind: 'invalid-regex'; message: string }
+  | { kind: 'canceled' }
+  | { kind: 'failed'; message: string };
+
+export const defaultSearchOptions: SearchOptions = {
+  regex: false,
+  caseSensitive: false,
+  wholeWord: false,
+};

--- a/frontend/src/utils/searchRanges.ts
+++ b/frontend/src/utils/searchRanges.ts
@@ -1,0 +1,142 @@
+import type { MatchRange } from '../types/search';
+
+export interface SearchTextSegment {
+  text: string;
+  isMatch: boolean;
+}
+
+const encoder = new TextEncoder();
+
+/**
+ * Converts a UTF-8 byte offset (as reported by ripgrep) into the JavaScript
+ * UTF-16 string index of the same boundary.
+ *
+ * Behavior:
+ *   - Negative or non-finite offsets return 0.
+ *   - Offsets past `text`'s UTF-8 byte length clamp to `text.length`.
+ *   - Offsets that fall *inside* a multi-byte codepoint return the boundary
+ *     before the codepoint (so the caller never lands inside a UTF-16
+ *     surrogate pair, and never splits a Unicode character mid-stream).
+ *
+ * The conversion is approximate when the line text contains U+FFFD
+ * replacement characters that the backend substituted for invalid UTF-8
+ * (`internal/search/parser.go` does this), because the byte offsets refer
+ * to the original ripgrep bytes while the substituted text differs in byte
+ * length. Source-code lines with valid UTF-8 — the realistic case — convert
+ * exactly.
+ */
+export function byteOffsetToCharIndex(text: string, byteOffset: number): number {
+  if (!Number.isFinite(byteOffset) || byteOffset <= 0) return 0;
+
+  const target = Math.trunc(byteOffset);
+  let byteCount = 0;
+
+  for (let index = 0; index < text.length; ) {
+    const codePoint = text.codePointAt(index);
+    if (codePoint === undefined) break;
+
+    const char = String.fromCodePoint(codePoint);
+    const nextByteCount = byteCount + encoder.encode(char).length;
+    if (nextByteCount > target) {
+      return index;
+    }
+
+    byteCount = nextByteCount;
+    index += char.length;
+
+    if (byteCount === target) {
+      return index;
+    }
+  }
+
+  return text.length;
+}
+
+/**
+ * Converts a 1-based UTF-8 byte column (as reported by ripgrep on a
+ * `LineMatch`) into a 1-based UTF-16 character column suitable for
+ * `navigateToEditorLocation()`.
+ *
+ * Columns at or below 1 clamp to 1; columns past line end clamp to one past
+ * the last character.
+ */
+export function byteColumnToCharColumn(text: string, byteColumn: number): number {
+  const zeroBasedByteOffset = Math.max(0, Math.trunc(byteColumn) - 1);
+  return byteOffsetToCharIndex(text, zeroBasedByteOffset) + 1;
+}
+
+/**
+ * Normalizes match ranges by sorting, dropping zero/negative-width entries,
+ * and merging overlaps so the renderer never produces unexpected gaps.
+ *
+ * ripgrep's submatches per match event are non-overlapping in practice, but
+ * defensive normalization keeps `splitLineByByteRanges` correct under any
+ * input — including unsorted ranges from upstream callers and overlap
+ * artifacts that could arise once Task 3 layers regex group highlighting on
+ * top of literal-match ranges.
+ */
+function normalizeRanges(ranges: readonly MatchRange[]): MatchRange[] {
+  const cleaned = ranges
+    .map((r) => ({
+      start: Math.max(0, Math.trunc(r.start)),
+      end: Math.max(0, Math.trunc(r.end)),
+    }))
+    .filter((r) => r.end > r.start)
+    .sort((a, b) => a.start - b.start || a.end - b.end);
+
+  if (cleaned.length === 0) return [];
+
+  const merged: MatchRange[] = [{ start: cleaned[0].start, end: cleaned[0].end }];
+  for (let i = 1; i < cleaned.length; i++) {
+    const last = merged[merged.length - 1];
+    const curr = cleaned[i];
+    if (curr.start < last.end) {
+      // Strict overlap: extend the previous range. Touching ranges
+      // (curr.start === last.end) stay separate so two adjacent literal
+      // matches render as two highlights, preserving the user's match count.
+      last.end = Math.max(last.end, curr.end);
+    } else {
+      merged.push({ start: curr.start, end: curr.end });
+    }
+  }
+  return merged;
+}
+
+/**
+ * Splits `text` into alternating match/non-match segments at the given byte
+ * ranges. Used by the search panel to render highlighted spans.
+ *
+ * Overlapping or out-of-order input ranges are normalized first; the result
+ * is a flat list of segments in document order, with adjacent matches
+ * preserved as separate segments so the renderer can distinguish "two matches
+ * touching" from "one wide match" if it ever needs to.
+ */
+export function splitLineByByteRanges(
+  text: string,
+  ranges: readonly MatchRange[]
+): SearchTextSegment[] {
+  const normalized = normalizeRanges(ranges);
+  if (normalized.length === 0) {
+    return [{ text, isMatch: false }];
+  }
+
+  const segments: SearchTextSegment[] = [];
+  let cursor = 0;
+  for (const range of normalized) {
+    const start = Math.max(cursor, byteOffsetToCharIndex(text, range.start));
+    const end = Math.max(start, byteOffsetToCharIndex(text, range.end));
+    if (end <= start) continue;
+
+    if (start > cursor) {
+      segments.push({ text: text.slice(cursor, start), isMatch: false });
+    }
+    segments.push({ text: text.slice(start, end), isMatch: true });
+    cursor = end;
+  }
+
+  if (cursor < text.length) {
+    segments.push({ text: text.slice(cursor), isMatch: false });
+  }
+
+  return segments.length > 0 ? segments : [{ text, isMatch: false }];
+}


### PR DESCRIPTION
## Summary

Adds Milestone 6 Task 2 (frontend search state + Wails client), consuming the typed `SearchRequest`/`SearchResponse` contract from `internal/search/types.go` introduced by PR #86.

- **`types/search.ts`** — Discriminated `SearchUIState` union; each variant carries only the data its UI state needs (loading, results, no-matches, missing-tool, invalid-regex, canceled, failed).
- **`utils/searchRanges.ts`** — UTF-8 byte → JS UTF-16 offset converter with surrogate-pair, combining-mark, and ZWJ-sequence handling; overlap-merging line splitter for highlight rendering.
- **`stores/searchStore.ts`** — Zustand store separate from `ideStore`; auto-expands the first 10 result files (`DEFAULT_EXPAND_FILE_LIMIT`) so wide searches don't blow up the panel; idempotent `setNoWorkspace`/`setEmptyQuery`.
- **`hooks/useWorkspaceSearch.ts`** — 250 ms debounce, monotonic request id, stale-drop on supersession by `activeRequestId` comparison, `CancelSearch` on workspace switch and on unmount; narrows unknown backend statuses to `failed`.

## Test coverage

73 new tests across three files (full state machine, debounce, cancellation, stale-drop, workspace switch, backend-status mapping). Adversarial cases from the plan are exercised: emoji, combining marks, ZWJ sequences, overlapping ranges, truncated results, error paths, missing-rg, invalid regex, unknown statuses.

Total suite: 600 tests passing, frontend production build clean, ESLint/Prettier clean.

## Out of scope

`SearchPanel` UI, `App.tsx` left-panel routing, and `Cmd+Shift+F` shortcut belong to Task 3 per the plan's parallelization strategy. Task 3 will consume the store/hook APIs after this Task 2 PR is reviewed.

## Test plan

- [x] `cd frontend && npm test -- --watch=false` — 600 passed
- [x] `cd frontend && npm run build` — successful
- [x] `cd frontend && npm run lint` — 0 errors (pre-existing warnings only, in untouched files)
- [x] `cd frontend && npm run format:check` — clean
- [x] `git diff --check` — clean
- [x] `/code-review` cycle — clean on first pass
- [x] `/criticize-review` cycle — clean on first pass

Generated with [Claude Code](https://claude.com/claude-code)