### PR TITLE
Milestone 6 Task 3: Search panel UI + Cmd+Shift+F + left-panel routing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { IDEShell } from './components/layout';
 import { Header } from './components/Header';
 import { Sidebar } from './components/Sidebar';
 import { FileExplorer } from './components/FileExplorer';
+import { SearchPanel } from './components/Search';
 import { Editor } from './components/Editor';
 import { Terminal } from './components/Terminal';
 import { RunProfiles } from './components/RunProfiles';
@@ -18,7 +19,8 @@ import { useRunProfilesLoader } from './hooks/useRunProfiles';
 import { useLSPDocumentSync } from './hooks/useLSPDocumentSync';
 import { useLSPEvents } from './hooks/useLSPEvents';
 import { useFileWatcher } from './hooks/useFileWatcher';
-import { useWorkspace, useIDEStore } from './stores/ideStore';
+import { useWorkspaceSearch } from './hooks/useWorkspaceSearch';
+import { useWorkspace, useIDEStore, useSidebarView } from './stores/ideStore';
 import { ReadDirectory, ReadFile } from '../wailsjs/go/main/App';
 import type { FileEvent } from './types/watcher';
 
@@ -31,7 +33,11 @@ function App() {
   useLSPDocumentSync();
   useLSPEvents();
   useRecentWorkspaces();
+  // Mount workspace-search wiring once at the App level so the in-flight
+  // request guards (workspace switch, unmount) survive panel toggling.
+  useWorkspaceSearch();
   const workspace = useWorkspace();
+  const sidebarView = useSidebarView();
   useRunProfilesLoader(workspace?.path);
 
   const refreshDirectoryTree = useCallback(() => {
@@ -126,7 +132,7 @@ function App() {
         accent="project"
         header={<Header />}
         sidebar={<Sidebar />}
-        leftPanel={<FileExplorer />}
+        leftPanel={sidebarView === 'search' ? <SearchPanel /> : <FileExplorer />}
         centerPanel={<Editor />}
         bottomPanel={<Terminal />}
         rightPanel={<RunProfiles />}

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -8,6 +8,7 @@
 import { act, render, screen } from '@testing-library/react';
 import App from '../App';
 import { useIDEStore } from '../stores/ideStore';
+import { useSearchStore } from '../stores/searchStore';
 import { resetLSPDocumentSyncState } from '../utils/lspDocumentSync';
 import type { FileEvent } from '../types/watcher';
 
@@ -18,6 +19,8 @@ const mockDidOpen = jest.fn().mockResolvedValue(undefined);
 const mockDidChange = jest.fn().mockResolvedValue(undefined);
 const mockDidSave = jest.fn().mockResolvedValue(undefined);
 const mockDidClose = jest.fn().mockResolvedValue(undefined);
+const mockSearchWorkspace = jest.fn().mockResolvedValue({});
+const mockCancelSearch = jest.fn().mockResolvedValue(undefined);
 
 // Mock Wails bindings
 jest.mock('../../wailsjs/go/main/App', () => ({
@@ -41,6 +44,8 @@ jest.mock('../../wailsjs/go/main/App', () => ({
   LSPDidChange: (...args: unknown[]) => mockDidChange(...args),
   LSPDidSave: (...args: unknown[]) => mockDidSave(...args),
   LSPDidClose: (...args: unknown[]) => mockDidClose(...args),
+  SearchWorkspace: (...args: unknown[]) => mockSearchWorkspace(...args),
+  CancelSearch: (...args: unknown[]) => mockCancelSearch(...args),
 }));
 
 jest.mock('../../wailsjs/runtime/runtime', () => ({
@@ -71,6 +76,8 @@ describe('App Component', () => {
     mockDidChange.mockClear();
     mockDidSave.mockClear();
     mockDidClose.mockClear();
+    mockSearchWorkspace.mockClear();
+    mockCancelSearch.mockClear();
     resetLSPDocumentSyncState();
     useIDEStore.setState({
       workspace: null,
@@ -78,6 +85,16 @@ describe('App Component', () => {
       activeFileId: null,
       directoryTree: [],
       treeError: null,
+      activeSidebarView: 'explorer',
+      isLeftPanelCollapsed: false,
+    });
+    useSearchStore.setState({
+      query: '',
+      options: { regex: false, caseSensitive: false, wholeWord: false },
+      uiState: { kind: 'no-workspace' },
+      expandedFiles: new Set<string>(),
+      activeRequestId: null,
+      focusInputRevision: 0,
     });
   });
 
@@ -99,6 +116,23 @@ describe('App Component', () => {
     });
     // Look for the app name in the header
     expect(screen.getByText('Firn')).toBeInTheDocument();
+  });
+
+  it('shows the FileExplorer in the left panel when sidebar view is explorer', async () => {
+    useIDEStore.setState({ activeSidebarView: 'explorer' });
+    await act(async () => {
+      render(<App />);
+    });
+    // SearchPanel exposes a textbox labelled "Search query"; the explorer does not.
+    expect(screen.queryByLabelText('Search query')).not.toBeInTheDocument();
+  });
+
+  it('routes the left panel to the SearchPanel when sidebar view is search', async () => {
+    useIDEStore.setState({ activeSidebarView: 'search' });
+    await act(async () => {
+      render(<App />);
+    });
+    expect(screen.getByLabelText('Search query')).toBeInTheDocument();
   });
 
   it.each(['created', 'deleted', 'renamed'] as const)(

--- a/frontend/src/__tests__/components/Search/SearchPanel.test.tsx
+++ b/frontend/src/__tests__/components/Search/SearchPanel.test.tsx
@@ -1,0 +1,573 @@
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { SearchPanel } from '../../../components/Search';
+import { useIDEStore } from '../../../stores/ideStore';
+import { useSearchStore } from '../../../stores/searchStore';
+import type { FileResult, SearchUIState } from '../../../types/search';
+
+const mockNavigate = jest.fn();
+jest.mock('../../../utils/editorNavigation', () => ({
+  navigateToEditorLocation: (...args: unknown[]) => mockNavigate(...args),
+}));
+
+function setUIState(
+  partial: Partial<{
+    query: string;
+    uiState: SearchUIState;
+    expandedFiles: Set<string>;
+    options: { regex: boolean; caseSensitive: boolean; wholeWord: boolean };
+  }>
+) {
+  useSearchStore.setState((state) => ({
+    ...state,
+    ...partial,
+  }));
+}
+
+function makeFile(
+  relativePath: string,
+  matches: Array<{
+    line: number;
+    column?: number;
+    text: string;
+    submatches?: Array<{ start: number; end: number }>;
+  }>
+): FileResult {
+  return {
+    path: `/workspace/${relativePath}`,
+    relativePath,
+    matches: matches.map((m) => ({
+      line: m.line,
+      column: m.column ?? 1,
+      text: m.text,
+      submatches: m.submatches ?? [{ start: 0, end: m.text.length }],
+    })),
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Reset the search store between tests by rebuilding the default state.
+  useSearchStore.setState({
+    query: '',
+    options: { regex: false, caseSensitive: false, wholeWord: false },
+    uiState: { kind: 'no-workspace' },
+    expandedFiles: new Set(),
+    activeRequestId: null,
+    focusInputRevision: 0,
+  });
+});
+
+afterEach(() => {
+  // Clean up any DOM nodes appended directly to document.body by tests
+  // (testing-library's auto-cleanup only unmounts React roots).
+  document.getElementById('mount-focus-sibling')?.remove();
+});
+
+describe('SearchPanel — empty-style states', () => {
+  it('renders the no-workspace state', () => {
+    setUIState({ uiState: { kind: 'no-workspace' } });
+    render(<SearchPanel />);
+    expect(screen.getByText('No workspace open')).toBeInTheDocument();
+    expect(screen.getByText(/Open a folder to search/)).toBeInTheDocument();
+  });
+
+  it('renders the empty-query state', () => {
+    setUIState({ uiState: { kind: 'empty-query' } });
+    render(<SearchPanel />);
+    expect(screen.getByText(/Type to search the workspace/)).toBeInTheDocument();
+  });
+
+  it('renders the loading state', () => {
+    setUIState({ uiState: { kind: 'loading', requestId: 'r1' } });
+    render(<SearchPanel />);
+    expect(screen.getByText(/Searching/)).toBeInTheDocument();
+  });
+
+  it('renders the no-matches state with formatted duration', () => {
+    setUIState({ uiState: { kind: 'no-matches', durationMs: 142 } });
+    render(<SearchPanel />);
+    expect(screen.getByText('No matches')).toBeInTheDocument();
+    expect(screen.getByText(/142 ms/)).toBeInTheDocument();
+  });
+
+  it('renders the missing-tool state as an alert', () => {
+    setUIState({
+      uiState: { kind: 'missing-tool', message: 'ripgrep is not on PATH.' },
+    });
+    render(<SearchPanel />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('ripgrep is not available')).toBeInTheDocument();
+    expect(screen.getByText('ripgrep is not on PATH.')).toBeInTheDocument();
+  });
+
+  it('renders the invalid-regex state and marks the input invalid', () => {
+    setUIState({
+      query: 'foo[',
+      uiState: { kind: 'invalid-regex', message: 'unclosed character class' },
+    });
+    render(<SearchPanel />);
+    expect(screen.getByText('Invalid regular expression')).toBeInTheDocument();
+    const input = screen.getByLabelText('Search query');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('renders the failed state with the message', () => {
+    setUIState({ uiState: { kind: 'failed', message: 'spawn failure' } });
+    render(<SearchPanel />);
+    expect(screen.getByText('Search failed')).toBeInTheDocument();
+    expect(screen.getByText('spawn failure')).toBeInTheDocument();
+  });
+
+  it('renders the canceled state', () => {
+    setUIState({ uiState: { kind: 'canceled' } });
+    render(<SearchPanel />);
+    expect(screen.getByText(/Search canceled/)).toBeInTheDocument();
+  });
+});
+
+describe('SearchPanel — controls', () => {
+  it('updates query on input change', () => {
+    setUIState({ uiState: { kind: 'empty-query' } });
+    render(<SearchPanel />);
+    const input = screen.getByLabelText('Search query');
+    fireEvent.change(input, { target: { value: 'hello' } });
+    expect(useSearchStore.getState().query).toBe('hello');
+  });
+
+  it('toggles each option independently', () => {
+    setUIState({ uiState: { kind: 'empty-query' } });
+    render(<SearchPanel />);
+    const caseBtn = screen.getByRole('button', { name: 'Match case' });
+    const wordBtn = screen.getByRole('button', { name: 'Match whole word' });
+    const regexBtn = screen.getByRole('button', { name: 'Use regular expression' });
+
+    expect(caseBtn).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(caseBtn);
+    expect(useSearchStore.getState().options.caseSensitive).toBe(true);
+    fireEvent.click(wordBtn);
+    expect(useSearchStore.getState().options.wholeWord).toBe(true);
+    fireEvent.click(regexBtn);
+    expect(useSearchStore.getState().options.regex).toBe(true);
+  });
+
+  it('shows the clear button only when there is a query', () => {
+    setUIState({ uiState: { kind: 'empty-query' } });
+    const { rerender } = render(<SearchPanel />);
+    expect(screen.queryByLabelText('Clear search')).not.toBeInTheDocument();
+
+    act(() => {
+      useSearchStore.getState().setQuery('foo');
+    });
+    rerender(<SearchPanel />);
+    fireEvent.click(screen.getByLabelText('Clear search'));
+    expect(useSearchStore.getState().query).toBe('');
+  });
+
+  it('focuses the input on mount regardless of starting focusInputRevision', () => {
+    // Render an unrelated focusable sibling first and focus it; this ensures
+    // any subsequent activeElement === input observation reflects the panel's
+    // mount-time focus effect, not jsdom's body-default behavior. Sibling
+    // is removed by the suite-level afterEach below to survive assertion
+    // failures without leaking into later tests.
+    const sibling = document.createElement('button');
+    sibling.id = 'mount-focus-sibling';
+    sibling.textContent = 'sibling';
+    document.body.appendChild(sibling);
+    sibling.focus();
+    expect(document.activeElement?.id).toBe('mount-focus-sibling');
+
+    // Mount with a non-zero revision to prove the effect fires on mount and
+    // doesn't depend on a 0-valued dep.
+    setUIState({ uiState: { kind: 'empty-query' } });
+    useSearchStore.setState({ focusInputRevision: 5 });
+
+    render(<SearchPanel />);
+    const input = screen.getByLabelText('Search query');
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('refocuses the input when requestInputFocus bumps the revision', () => {
+    setUIState({ uiState: { kind: 'empty-query' } });
+    render(<SearchPanel />);
+    const input = screen.getByLabelText('Search query');
+
+    (document.activeElement as HTMLElement | null)?.blur();
+    expect(document.activeElement).not.toBe(input);
+
+    act(() => {
+      useSearchStore.getState().requestInputFocus();
+    });
+    expect(document.activeElement).toBe(input);
+  });
+});
+
+describe('SearchPanel — results rendering', () => {
+  const fileA = makeFile('src/components/Foo.tsx', [
+    { line: 12, column: 5, text: '  const foo = bar();', submatches: [{ start: 8, end: 11 }] },
+    { line: 30, column: 9, text: 'function foo() {}', submatches: [{ start: 9, end: 12 }] },
+  ]);
+  const fileB = makeFile('Bar.ts', [
+    { line: 4, column: 1, text: 'foo();', submatches: [{ start: 0, end: 3 }] },
+  ]);
+
+  function setResults(opts?: { truncated?: boolean; matchCap?: number }) {
+    setUIState({
+      query: 'foo',
+      uiState: {
+        kind: 'results',
+        files: [fileA, fileB],
+        totalFiles: 2,
+        totalLines: 3,
+        truncated: opts?.truncated ?? false,
+        matchCap: opts?.matchCap ?? 5000,
+        durationMs: 180,
+      },
+      expandedFiles: new Set([fileA.path, fileB.path]),
+    });
+  }
+
+  it('renders the summary with file/match counts and duration', () => {
+    setResults();
+    render(<SearchPanel />);
+    expect(screen.getByText('3 matches in 2 files')).toBeInTheDocument();
+    expect(screen.getByText('180 ms')).toBeInTheDocument();
+  });
+
+  it('groups matches by file and shows match counts on the header', () => {
+    setResults();
+    render(<SearchPanel />);
+    const fooHeader = screen.getByRole('button', { name: /Foo\.tsx \(2 matches\)/ });
+    expect(fooHeader).toBeInTheDocument();
+    expect(within(fooHeader).getByText('2')).toBeInTheDocument();
+
+    const barHeader = screen.getByRole('button', { name: /Bar\.ts \(1 match\)/ });
+    expect(within(barHeader).getByText('1')).toBeInTheDocument();
+  });
+
+  it('renders highlighted match segments via <mark>', () => {
+    setResults();
+    render(<SearchPanel />);
+    const marks = document.querySelectorAll('mark');
+    // 3 total matches across both files → 3 highlight elements.
+    expect(marks.length).toBe(3);
+    expect(marks[0].textContent).toBe('foo');
+  });
+
+  it('renders the truncation banner with a non-color cue when results are capped', () => {
+    setResults({ truncated: true, matchCap: 5000 });
+    render(<SearchPanel />);
+    // Color-only signaling fails WCAG; assert the explicit warning glyph
+    // and word are present so the cue is reachable without color.
+    expect(screen.getByText(/⚠ Truncated at 5,000 matches/)).toBeInTheDocument();
+  });
+
+  it('makes the first item tabbable when no row is focused (Tab-only access)', () => {
+    setResults();
+    render(<SearchPanel />);
+    const firstHeader = screen.getByRole('button', { name: /Foo\.tsx \(2 matches\)/ });
+    expect(firstHeader).toHaveAttribute('tabindex', '0');
+    // The Bar.ts header is not the focused row and is not at index 0, so it
+    // must NOT be in the tab order.
+    const secondHeader = screen.getByRole('button', { name: /Bar\.ts \(1 match\)/ });
+    expect(secondHeader).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('refocuses the previously focused row after a same-shape result refresh', () => {
+    setResults();
+    render(<SearchPanel />);
+    const firstHeader = screen.getByRole('button', { name: /Foo\.tsx \(2 matches\)/ });
+    act(() => {
+      firstHeader.focus();
+    });
+    expect(document.activeElement).toBe(firstHeader);
+
+    // Refresh the store with structurally identical results (different
+    // object identity, same shape). The button DOM nodes are recreated.
+    act(() => {
+      useSearchStore.setState({
+        uiState: {
+          kind: 'results',
+          files: [{ ...fileA }, { ...fileB }],
+          totalFiles: 2,
+          totalLines: 3,
+          truncated: false,
+          matchCap: 5000,
+          durationMs: 60,
+        },
+      });
+    });
+
+    const refreshedHeader = screen.getByRole('button', { name: /Foo\.tsx \(2 matches\)/ });
+    expect(document.activeElement).toBe(refreshedHeader);
+  });
+
+  it('skips navigation if there is no workspace open at click time', async () => {
+    act(() => {
+      useIDEStore.setState({ workspace: null });
+    });
+    const file = makeFile('foo.ts', [
+      { line: 1, column: 1, text: 'foo', submatches: [{ start: 0, end: 3 }] },
+    ]);
+    setUIState({
+      query: 'foo',
+      uiState: {
+        kind: 'results',
+        files: [file],
+        totalFiles: 1,
+        totalLines: 1,
+        truncated: false,
+        matchCap: 5000,
+        durationMs: 5,
+      },
+      expandedFiles: new Set([file.path]),
+    });
+
+    render(<SearchPanel />);
+    const row = screen.getByRole('button', { name: /Line 1 in foo\.ts/ });
+
+    await act(async () => {
+      fireEvent.click(row);
+      await Promise.resolve();
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('clicking a match calls navigateToEditorLocation with byte→char column', async () => {
+    // The activateMatch guard requires a workspace; mock one that contains
+    // the file path. The test assertion is on byte→char column conversion,
+    // not on the workspace gate.
+    act(() => {
+      useIDEStore.setState({ workspace: { name: 'w', path: '/workspace' } });
+    });
+    // Multi-byte case: the line text starts with a 2-byte char (é) and the
+    // backend reports column=3 (1-based byte offset just past 'é '), which
+    // equals char column 3 in JS. Use a clearer 4-byte case: emoji.
+    const file = makeFile('emoji.ts', [
+      // "🙂 const x" — 🙂 is 4 bytes in UTF-8 (and 2 UTF-16 code units).
+      // Backend column 6 = byte index 5 = right after "🙂 " (4 + 1 = 5 bytes).
+      // In UTF-16, that's char index 3 (2 surrogates + 1 space) → 1-based 4.
+      { line: 1, column: 6, text: '🙂 const x', submatches: [{ start: 5, end: 10 }] },
+    ]);
+    setUIState({
+      query: 'const',
+      uiState: {
+        kind: 'results',
+        files: [file],
+        totalFiles: 1,
+        totalLines: 1,
+        truncated: false,
+        matchCap: 5000,
+        durationMs: 5,
+      },
+      expandedFiles: new Set([file.path]),
+    });
+
+    render(<SearchPanel />);
+    const row = screen.getByRole('button', { name: /Line 1 in emoji\.ts/ });
+
+    await act(async () => {
+      fireEvent.click(row);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('/workspace/emoji.ts', 1, 4);
+  });
+
+  it('clicking a file header collapses then expands the group', () => {
+    setResults();
+    render(<SearchPanel />);
+    expect(useSearchStore.getState().expandedFiles.has(fileA.path)).toBe(true);
+
+    const header = screen.getByRole('button', { name: /Foo\.tsx \(2 matches\)/ });
+    fireEvent.click(header);
+    expect(useSearchStore.getState().expandedFiles.has(fileA.path)).toBe(false);
+
+    fireEvent.click(header);
+    expect(useSearchStore.getState().expandedFiles.has(fileA.path)).toBe(true);
+  });
+
+  it('restores focus to the input when results refresh and the focused row unmounts', () => {
+    setResults();
+    render(<SearchPanel />);
+    const input = screen.getByLabelText('Search query');
+    const lastRow = screen.getByRole('button', { name: 'Line 4 in Bar.ts' });
+
+    act(() => {
+      lastRow.focus();
+    });
+    expect(document.activeElement).toBe(lastRow);
+
+    // Simulate a fresh response that drops Bar.ts entirely. The previously
+    // focused row unmounts; without restoration, focus would move to body.
+    act(() => {
+      useSearchStore.setState({
+        uiState: {
+          kind: 'results',
+          files: [fileA],
+          totalFiles: 1,
+          totalLines: 2,
+          truncated: false,
+          matchCap: 5000,
+          durationMs: 50,
+        },
+        expandedFiles: new Set([fileA.path]),
+      });
+    });
+
+    expect(document.activeElement).toBe(input);
+  });
+});
+
+describe('SearchPanel — keyboard navigation', () => {
+  const file = makeFile('a.ts', [
+    { line: 1, column: 1, text: 'foo', submatches: [{ start: 0, end: 3 }] },
+    { line: 2, column: 1, text: 'foo', submatches: [{ start: 0, end: 3 }] },
+  ]);
+
+  function setupResults() {
+    // activateMatch requires a workspace; without it the click is a no-op.
+    useIDEStore.setState({ workspace: { name: 'w', path: '/workspace' } });
+    setUIState({
+      query: 'foo',
+      uiState: {
+        kind: 'results',
+        files: [file],
+        totalFiles: 1,
+        totalLines: 2,
+        truncated: false,
+        matchCap: 5000,
+        durationMs: 10,
+      },
+      expandedFiles: new Set([file.path]),
+    });
+  }
+
+  it('ArrowDown from the input focuses the first item', () => {
+    setupResults();
+    render(<SearchPanel />);
+    const input = screen.getByLabelText('Search query');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    const fileHeader = screen.getByRole('button', { name: /a\.ts \(2 matches\)/ });
+    expect(document.activeElement).toBe(fileHeader);
+  });
+
+  it('ArrowDown moves through the flat item list', () => {
+    setupResults();
+    render(<SearchPanel />);
+    const input = screen.getByLabelText('Search query');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    const fileHeader = screen.getByRole('button', { name: /a\.ts \(2 matches\)/ });
+    fireEvent.keyDown(fileHeader, { key: 'ArrowDown' });
+
+    const firstResult = screen.getByRole('button', { name: 'Line 1 in a.ts' });
+    expect(document.activeElement).toBe(firstResult);
+  });
+
+  it('ArrowUp on the first item returns focus to the input', () => {
+    setupResults();
+    render(<SearchPanel />);
+    const input = screen.getByLabelText('Search query');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    const fileHeader = screen.getByRole('button', { name: /a\.ts \(2 matches\)/ });
+    fireEvent.keyDown(fileHeader, { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('Enter on a result row navigates', async () => {
+    setupResults();
+    render(<SearchPanel />);
+    const firstResult = screen.getByRole('button', { name: 'Line 1 in a.ts' });
+    // act() flushes onFocus state update so focusedItemIndex is set before
+    // the keyDown handler reads it.
+    act(() => {
+      firstResult.focus();
+    });
+    await act(async () => {
+      fireEvent.keyDown(firstResult, { key: 'Enter' });
+    });
+    expect(mockNavigate).toHaveBeenCalledWith(file.path, 1, 1);
+  });
+
+  it('Enter on a file header toggles expansion', () => {
+    setupResults();
+    render(<SearchPanel />);
+    const fileHeader = screen.getByRole('button', { name: /a\.ts \(2 matches\)/ });
+    act(() => {
+      fileHeader.focus();
+    });
+    fireEvent.keyDown(fileHeader, { key: 'Enter' });
+    expect(useSearchStore.getState().expandedFiles.has(file.path)).toBe(false);
+  });
+
+  it('ArrowLeft on a match row moves focus to the parent file header', () => {
+    setupResults();
+    render(<SearchPanel />);
+    const firstResult = screen.getByRole('button', { name: 'Line 1 in a.ts' });
+    act(() => {
+      firstResult.focus();
+    });
+    fireEvent.keyDown(firstResult, { key: 'ArrowLeft' });
+
+    const fileHeader = screen.getByRole('button', { name: /a\.ts \(2 matches\)/ });
+    expect(document.activeElement).toBe(fileHeader);
+  });
+
+  it('ArrowLeft on a collapsed file header returns focus to the input', () => {
+    setUIState({
+      query: 'foo',
+      uiState: {
+        kind: 'results',
+        files: [file],
+        totalFiles: 1,
+        totalLines: 2,
+        truncated: false,
+        matchCap: 5000,
+        durationMs: 10,
+      },
+      expandedFiles: new Set(),
+    });
+    render(<SearchPanel />);
+    const fileHeader = screen.getByRole('button', { name: /a\.ts \(2 matches\)/ });
+    act(() => {
+      fileHeader.focus();
+    });
+    fireEvent.keyDown(fileHeader, { key: 'ArrowLeft' });
+
+    const input = screen.getByLabelText('Search query');
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('ArrowRight on a collapsed file header expands it', () => {
+    setUIState({
+      query: 'foo',
+      uiState: {
+        kind: 'results',
+        files: [file],
+        totalFiles: 1,
+        totalLines: 2,
+        truncated: false,
+        matchCap: 5000,
+        durationMs: 10,
+      },
+      expandedFiles: new Set(),
+    });
+    render(<SearchPanel />);
+    const fileHeader = screen.getByRole('button', { name: /a\.ts \(2 matches\)/ });
+    act(() => {
+      fileHeader.focus();
+    });
+    fireEvent.keyDown(fileHeader, { key: 'ArrowRight' });
+    expect(useSearchStore.getState().expandedFiles.has(file.path)).toBe(true);
+  });
+
+  it('Escape on the input clears a non-empty query', () => {
+    setUIState({ query: 'foo', uiState: { kind: 'empty-query' } });
+    render(<SearchPanel />);
+    const input = screen.getByLabelText('Search query');
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(useSearchStore.getState().query).toBe('');
+  });
+});

--- a/frontend/src/__tests__/components/Search/SearchPanel.test.tsx
+++ b/frontend/src/__tests__/components/Search/SearchPanel.test.tsx
@@ -371,7 +371,21 @@ describe('SearchPanel — results rendering', () => {
     });
 
     expect(mockNavigate).toHaveBeenCalledTimes(1);
-    expect(mockNavigate).toHaveBeenCalledWith('/workspace/emoji.ts', 1, 4);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/workspace/emoji.ts',
+      1,
+      4,
+      expect.objectContaining({ shouldApply: expect.any(Function) })
+    );
+
+    const options = mockNavigate.mock.calls[0][3] as { shouldApply: () => boolean };
+    expect(options.shouldApply()).toBe(true);
+
+    act(() => {
+      useIDEStore.setState({ workspace: { name: 'other', path: '/other-workspace' } });
+    });
+
+    expect(options.shouldApply()).toBe(false);
   });
 
   it('clicking a file header collapses then expands the group', () => {
@@ -488,7 +502,12 @@ describe('SearchPanel — keyboard navigation', () => {
     await act(async () => {
       fireEvent.keyDown(firstResult, { key: 'Enter' });
     });
-    expect(mockNavigate).toHaveBeenCalledWith(file.path, 1, 1);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      file.path,
+      1,
+      1,
+      expect.objectContaining({ shouldApply: expect.any(Function) })
+    );
   });
 
   it('Enter on a file header toggles expansion', () => {

--- a/frontend/src/__tests__/hooks/useKeyboardShortcuts.test.ts
+++ b/frontend/src/__tests__/hooks/useKeyboardShortcuts.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, act } from '@testing-library/react';
 import { getPlatform } from '../../utils/platform';
 import { useIDEStore } from '../../stores/ideStore';
+import { useSearchStore } from '../../stores/searchStore';
 
 // Mock Wails bindings
 const mockOpenFolderDialog = jest.fn();
@@ -28,6 +29,17 @@ function modifierKeyEvent(key: string): KeyboardEvent {
     ctrlKey: !isMac,
     metaKey: isMac,
     bubbles: true,
+  });
+}
+
+function searchShortcutEvent(): KeyboardEvent {
+  return new KeyboardEvent('keydown', {
+    key: 'f',
+    ctrlKey: !isMac,
+    metaKey: isMac,
+    shiftKey: true,
+    bubbles: true,
+    cancelable: true,
   });
 }
 
@@ -114,6 +126,80 @@ describe('useKeyboardShortcuts', () => {
     expect(useIDEStore.getState().navigationForward).toEqual([
       { fileId: '/current.ts', line: 12, column: 8 },
     ]);
+  });
+
+  describe('search shortcut', () => {
+    beforeEach(() => {
+      useSearchStore.setState({
+        query: '',
+        options: { regex: false, caseSensitive: false, wholeWord: false },
+        uiState: { kind: 'no-workspace' },
+        expandedFiles: new Set<string>(),
+        activeRequestId: null,
+        focusInputRevision: 0,
+      });
+    });
+
+    it('switches the sidebar to search and bumps focusInputRevision', async () => {
+      useIDEStore.setState({
+        activeSidebarView: 'explorer',
+        isLeftPanelCollapsed: false,
+      });
+      renderHook(() => useKeyboardShortcuts());
+
+      const event = searchShortcutEvent();
+      await act(async () => {
+        window.dispatchEvent(event);
+      });
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(useIDEStore.getState().activeSidebarView).toBe('search');
+      expect(useSearchStore.getState().focusInputRevision).toBe(1);
+    });
+
+    it('expands the left panel if it was collapsed', async () => {
+      useIDEStore.setState({
+        activeSidebarView: 'search',
+        isLeftPanelCollapsed: true,
+      });
+      renderHook(() => useKeyboardShortcuts());
+
+      await act(async () => {
+        window.dispatchEvent(searchShortcutEvent());
+      });
+
+      expect(useIDEStore.getState().isLeftPanelCollapsed).toBe(false);
+    });
+
+    it('leaves the left panel expanded if already open', async () => {
+      useIDEStore.setState({
+        activeSidebarView: 'search',
+        isLeftPanelCollapsed: false,
+      });
+      renderHook(() => useKeyboardShortcuts());
+
+      await act(async () => {
+        window.dispatchEvent(searchShortcutEvent());
+      });
+
+      expect(useIDEStore.getState().isLeftPanelCollapsed).toBe(false);
+      expect(useSearchStore.getState().focusInputRevision).toBe(1);
+    });
+
+    it('does not trigger on plain "f" or modifier+F without Shift', async () => {
+      renderHook(() => useKeyboardShortcuts());
+
+      await act(async () => {
+        window.dispatchEvent(modifierKeyEvent('f'));
+      });
+      await act(async () => {
+        window.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'f', shiftKey: true, bubbles: true })
+        );
+      });
+
+      expect(useSearchStore.getState().focusInputRevision).toBe(0);
+    });
   });
 
   it('should not handle navigation shortcuts that were already handled', async () => {

--- a/frontend/src/__tests__/hooks/useWorkspaceSearch.test.ts
+++ b/frontend/src/__tests__/hooks/useWorkspaceSearch.test.ts
@@ -88,10 +88,9 @@ async function flushMicrotasks(): Promise<void> {
 }
 
 /**
- * Type a query and advance past the debounce window in two separate acts so
- * React commits the re-render (scheduling the new effect's timer) before the
- * timer is advanced. Then flush microtasks so the SearchWorkspace promise
- * resolves and the store updates land before assertions run.
+ * Type a query, advance past the debounce window, then flush microtasks so
+ * the SearchWorkspace promise resolves and the store updates land before
+ * assertions run.
  */
 async function typeAndDebounce(query: string, ms = SEARCH_DEBOUNCE_MS): Promise<void> {
   act(() => {
@@ -158,6 +157,33 @@ describe('useWorkspaceSearch', () => {
     expect(arg.options).toEqual({ regex: false, caseSensitive: false, wholeWord: false });
     expect(typeof arg.requestId).toBe('string');
     expect(arg.requestId.length).toBeGreaterThan(0);
+  });
+
+  it('does not re-render its host when query or options change', async () => {
+    setWorkspace('/workspace');
+    let renderCount = 0;
+
+    renderHook(() => {
+      renderCount += 1;
+      useWorkspaceSearch();
+    });
+
+    expect(renderCount).toBe(1);
+
+    act(() => {
+      useSearchStore.getState().setQuery('alpha');
+    });
+    act(() => {
+      useSearchStore.getState().setOption('regex', true);
+    });
+    act(() => {
+      jest.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+    });
+    await flushMicrotasks();
+
+    expect(renderCount).toBe(1);
+    expect(mockSearchWorkspace).toHaveBeenCalledTimes(1);
+    expect(mockSearchWorkspace.mock.calls[0][0].options.regex).toBe(true);
   });
 
   it('coalesces rapid typing into one backend call with the latest query', async () => {

--- a/frontend/src/__tests__/utils/editorNavigation.test.ts
+++ b/frontend/src/__tests__/utils/editorNavigation.test.ts
@@ -9,6 +9,16 @@ jest.mock('../../../wailsjs/go/main/App', () => ({
 
 const mockReadFile = ReadFile as jest.MockedFunction<typeof ReadFile>;
 
+function createReadFileResult(content: string) {
+  return {
+    content,
+    encoding: 'utf-8',
+    lineEndings: 'LF',
+    size: content.length,
+    isBinary: false,
+  };
+}
+
 beforeEach(() => {
   useIDEStore.setState(useIDEStore.getInitialState());
   jest.clearAllMocks();
@@ -35,12 +45,7 @@ describe('ensureEditorFileOpen', () => {
   });
 
   it('reads and opens a new file', async () => {
-    mockReadFile.mockResolvedValue({
-      content: 'hello world',
-      encoding: 'utf-8',
-      lineEndings: 'LF',
-      isBinary: false,
-    } as never);
+    mockReadFile.mockResolvedValue(createReadFileResult('hello world') as never);
 
     const file = await ensureEditorFileOpen('/test/new.ts');
     expect(file).not.toBeNull();
@@ -73,12 +78,7 @@ describe('ensureEditorFileOpen', () => {
   });
 
   it('stores new files using the native path form', async () => {
-    mockReadFile.mockResolvedValue({
-      content: 'const x = 1;',
-      encoding: 'utf-8',
-      lineEndings: 'LF',
-      isBinary: false,
-    } as never);
+    mockReadFile.mockResolvedValue(createReadFileResult('const x = 1;') as never);
 
     const inputPath = 'c:/Users/dev/project/file.ts';
     const file = await ensureEditorFileOpen(inputPath);
@@ -116,12 +116,7 @@ describe('ensureEditorFileOpen', () => {
 
 describe('navigateToEditorLocation', () => {
   it('opens file and requests navigation', async () => {
-    mockReadFile.mockResolvedValue({
-      content: 'line1\nline2\nline3',
-      encoding: 'utf-8',
-      lineEndings: 'LF',
-      isBinary: false,
-    } as never);
+    mockReadFile.mockResolvedValue(createReadFileResult('line1\nline2\nline3') as never);
 
     await navigateToEditorLocation('/test/file.ts', 2, 5);
 
@@ -138,6 +133,28 @@ describe('navigateToEditorLocation', () => {
 
     await navigateToEditorLocation('/test/missing.ts', 1, 1);
 
+    expect(useIDEStore.getState().pendingEditorNavigation).toBeNull();
+  });
+
+  it('does not open or navigate when shouldApply turns false while reading', async () => {
+    useIDEStore.setState({ workspace: { name: 'Workspace A', path: '/workspace-a' } });
+    let resolveRead!: (value: ReturnType<typeof createReadFileResult>) => void;
+    mockReadFile.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRead = resolve;
+        })
+    );
+
+    const navigation = navigateToEditorLocation('/workspace-a/file.ts', 2, 5, {
+      shouldApply: () => useIDEStore.getState().workspace?.path === '/workspace-a',
+    });
+
+    useIDEStore.setState({ workspace: { name: 'Workspace B', path: '/workspace-b' } });
+    resolveRead(createReadFileResult('line1\nline2'));
+    await navigation;
+
+    expect(useIDEStore.getState().openFiles).toHaveLength(0);
     expect(useIDEStore.getState().pendingEditorNavigation).toBeNull();
   });
 

--- a/frontend/src/components/Search/SearchPanel.module.css
+++ b/frontend/src/components/Search/SearchPanel.module.css
@@ -1,0 +1,355 @@
+/* ═══════════════════════════════════════════════════════════════
+   Search Panel — Workspace-wide search results
+═══════════════════════════════════════════════════════════════ */
+
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  font-family: var(--font-ui);
+}
+
+/* Header row: input + clear button + options toggles */
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--surface-border-subtle);
+  flex-shrink: 0;
+}
+
+.inputWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.input {
+  flex: 1;
+  width: 100%;
+  padding: 6px 28px 6px 10px;
+  background: var(--surface-base);
+  border: 1px solid var(--surface-border-subtle);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  outline: none;
+  transition: border-color var(--transition);
+}
+
+.input::placeholder {
+  color: var(--text-muted);
+}
+
+.input:focus,
+.input:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent-glow);
+}
+
+.input.invalid {
+  border-color: var(--status-error);
+}
+
+.input.invalid:focus,
+.input.invalid:focus-visible {
+  box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.3);
+}
+
+.clearButton {
+  position: absolute;
+  right: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.clearButton:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.clearButton:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.options {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.optionToggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 22px;
+  padding: 0 6px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.optionToggle:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.optionToggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.optionToggle[aria-pressed='true'] {
+  background: var(--accent-dim);
+  border-color: var(--accent-glow);
+  color: var(--accent);
+}
+
+/* Summary row (match count, duration, truncation) */
+.summary {
+  padding: 4px 10px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--surface-border-subtle);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.summary.truncated {
+  color: var(--status-warning);
+}
+
+/* Results scroller */
+.resultsScroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.resultsList {
+  padding: 2px 0;
+}
+
+/* File group header */
+.fileHeader {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  padding: 3px 10px 3px 6px;
+  background: transparent;
+  border: none;
+  color: var(--text-primary);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--transition);
+}
+
+.fileHeader:hover {
+  background: var(--surface-hover);
+}
+
+.fileHeader:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.fileHeader.focused {
+  background: var(--surface-hover);
+}
+
+.chevron {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+.filePath {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.fileName {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 0;
+  max-width: 60%;
+}
+
+.fileDir {
+  color: var(--text-muted);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  /* direction:rtl + text-align:left right-anchors the string so very long
+     paths ellipsize on the LEFT, keeping the deepest folder visible. The
+     <bdi dir="ltr"> wrapper isolates internal text direction so slashes
+     and any non-ASCII path segments don't re-order across bidi neutrals. */
+  direction: rtl;
+  text-align: left;
+  min-width: 0;
+}
+
+.matchCount {
+  flex-shrink: 0;
+  padding: 0 5px;
+  background: var(--surface-elevated);
+  border-radius: 8px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  line-height: 16px;
+  min-width: 18px;
+  text-align: center;
+}
+
+/* Result rows (a line match) */
+.resultRow {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 2px 10px 2px 26px;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  width: 100%;
+  text-align: left;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+  transition: background var(--transition);
+}
+
+.resultRow:hover {
+  background: var(--surface-hover);
+}
+
+.resultRow:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.resultRow.focused {
+  background: var(--surface-hover);
+}
+
+.lineNumber {
+  flex-shrink: 0;
+  min-width: 36px;
+  text-align: right;
+  color: var(--text-muted);
+  font-size: 11px;
+  user-select: none;
+}
+
+.lineText {
+  flex: 1;
+  min-width: 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+  overflow-wrap: anywhere;
+  color: var(--text-primary);
+}
+
+.match {
+  background: var(--accent-dim);
+  color: var(--accent);
+  border-radius: 2px;
+  padding: 0 1px;
+  font-weight: 600;
+}
+
+/* Empty / error states */
+.statePanel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 24px 20px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.5;
+  gap: 6px;
+}
+
+.statePanel.error {
+  color: var(--status-error);
+}
+
+.statePanel.warning {
+  color: var(--status-warning);
+}
+
+.statePanelTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.statePanel.error .statePanelTitle {
+  color: var(--status-error);
+}
+
+.statePanel.warning .statePanelTitle {
+  color: var(--status-warning);
+}
+
+.loadingDot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-right: 6px;
+  animation: pulse 1s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 1;
+  }
+}

--- a/frontend/src/components/Search/SearchPanel.tsx
+++ b/frontend/src/components/Search/SearchPanel.tsx
@@ -1,0 +1,603 @@
+import {
+  ChangeEvent,
+  KeyboardEvent as ReactKeyboardEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { ChevronDownIcon, ChevronRightIcon } from '../icons';
+import { useIDEStore } from '../../stores/ideStore';
+import { useSearchStore } from '../../stores/searchStore';
+import type { FileResult, LineMatch, SearchUIState } from '../../types/search';
+import { byteColumnToCharColumn, splitLineByByteRanges } from '../../utils/searchRanges';
+import { navigateToEditorLocation } from '../../utils/editorNavigation';
+import styles from './SearchPanel.module.css';
+
+// Search durations span microseconds (cached) to multi-second (cold ripgrep
+// over a large repo). formatDuration() in utils is for run-profile timers and
+// rounds anything under a second to "0s", so we use a search-tuned formatter.
+function formatSearchDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '';
+  if (ms < 1) return '<1 ms';
+  if (ms < 1000) return `${Math.round(ms)} ms`;
+  if (ms < 10_000) return `${(ms / 1000).toFixed(1)} s`;
+  return `${Math.round(ms / 1000)} s`;
+}
+
+interface FileItem {
+  kind: 'file';
+  index: number;
+  file: FileResult;
+  expanded: boolean;
+}
+
+interface MatchItem {
+  kind: 'match';
+  index: number;
+  file: FileResult;
+  match: LineMatch;
+}
+
+type FlatItem = FileItem | MatchItem;
+
+function buildFlatItems(files: FileResult[], expandedFiles: Set<string>): FlatItem[] {
+  const items: FlatItem[] = [];
+  for (const file of files) {
+    const expanded = expandedFiles.has(file.path);
+    items.push({ kind: 'file', index: items.length, file, expanded });
+    if (expanded) {
+      for (const match of file.matches) {
+        items.push({ kind: 'match', index: items.length, file, match });
+      }
+    }
+  }
+  return items;
+}
+
+// Split a relativePath into "filename" and "leading directory" segments for
+// header rendering. The backend (`internal/search/parser.go` →
+// `toRelativeForwardSlash` / `filepath.ToSlash`) always normalizes paths to
+// forward slashes regardless of OS, so this never has to handle backslashes;
+// do not call with native Windows paths.
+function splitFilePath(relativePath: string): { name: string; dir: string } {
+  const idx = relativePath.lastIndexOf('/');
+  if (idx === -1) return { name: relativePath, dir: '' };
+  return { name: relativePath.slice(idx + 1), dir: relativePath.slice(0, idx) };
+}
+
+interface MatchLineProps {
+  match: LineMatch;
+}
+
+function MatchLine({ match }: MatchLineProps) {
+  const segments = useMemo(
+    () => splitLineByByteRanges(match.text, match.submatches),
+    [match.text, match.submatches]
+  );
+  return (
+    <span className={styles.lineText}>
+      {segments.map((seg, i) =>
+        seg.isMatch ? (
+          <mark key={i} className={styles.match}>
+            {seg.text}
+          </mark>
+        ) : (
+          <span key={i}>{seg.text}</span>
+        )
+      )}
+    </span>
+  );
+}
+
+interface FileGroupProps {
+  item: FileItem;
+  focused: boolean;
+  tabbable: boolean;
+  itemRef: (el: HTMLButtonElement | null) => void;
+  onToggle: () => void;
+  onFocus: () => void;
+}
+
+function FileGroupHeader({ item, focused, tabbable, itemRef, onToggle, onFocus }: FileGroupProps) {
+  const { name, dir } = splitFilePath(item.file.relativePath);
+  const ChevIcon = item.expanded ? ChevronDownIcon : ChevronRightIcon;
+  return (
+    <button
+      ref={itemRef}
+      type="button"
+      className={`${styles.fileHeader} ${focused ? styles.focused : ''}`}
+      onClick={onToggle}
+      onFocus={onFocus}
+      tabIndex={tabbable ? 0 : -1}
+      aria-expanded={item.expanded}
+      aria-label={`${item.file.relativePath} (${item.file.matches.length} ${
+        item.file.matches.length === 1 ? 'match' : 'matches'
+      })`}
+      title={item.file.relativePath}
+    >
+      <span className={styles.chevron} aria-hidden="true">
+        <ChevIcon />
+      </span>
+      <span className={styles.filePath}>
+        <span className={styles.fileName}>{name}</span>
+        {/* <bdi> isolates the directory string from any surrounding bidi
+            context. With direction:rtl on .fileDir the *layout* is
+            right-anchored (so we ellipsize the start, keeping the deepest
+            segment visible), but the slashes are bidi-neutral and could
+            otherwise re-order on systems with mixed scripts. <bdi> +
+            unicode-bidi: isolate keeps slash order stable. */}
+        {dir && (
+          <bdi className={styles.fileDir} dir="ltr">
+            {dir}
+          </bdi>
+        )}
+      </span>
+      <span className={styles.matchCount} aria-hidden="true">
+        {item.file.matches.length}
+      </span>
+    </button>
+  );
+}
+
+interface ResultRowProps {
+  item: MatchItem;
+  focused: boolean;
+  tabbable: boolean;
+  itemRef: (el: HTMLButtonElement | null) => void;
+  onActivate: () => void;
+  onFocus: () => void;
+}
+
+function ResultRow({ item, focused, tabbable, itemRef, onActivate, onFocus }: ResultRowProps) {
+  return (
+    <button
+      ref={itemRef}
+      type="button"
+      className={`${styles.resultRow} ${focused ? styles.focused : ''}`}
+      onClick={onActivate}
+      onFocus={onFocus}
+      tabIndex={tabbable ? 0 : -1}
+      aria-label={`Line ${item.match.line} in ${item.file.relativePath}`}
+    >
+      <span className={styles.lineNumber} aria-hidden="true">
+        {item.match.line}
+      </span>
+      <MatchLine match={item.match} />
+    </button>
+  );
+}
+
+function describeMatchSummary(state: Extract<SearchUIState, { kind: 'results' }>): string {
+  const fileWord = state.totalFiles === 1 ? 'file' : 'files';
+  const lineWord = state.totalLines === 1 ? 'match' : 'matches';
+  return `${state.totalLines} ${lineWord} in ${state.totalFiles} ${fileWord}`;
+}
+
+export function SearchPanel() {
+  const query = useSearchStore((s) => s.query);
+  const options = useSearchStore((s) => s.options);
+  const uiState = useSearchStore((s) => s.uiState);
+  const expandedFiles = useSearchStore((s) => s.expandedFiles);
+  const focusInputRevision = useSearchStore((s) => s.focusInputRevision);
+  const setQuery = useSearchStore((s) => s.setQuery);
+  const setOption = useSearchStore((s) => s.setOption);
+  const toggleFileExpanded = useSearchStore((s) => s.toggleFileExpanded);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const itemRefs = useRef<Map<number, HTMLButtonElement>>(new Map());
+  const [focusedItemIndex, setFocusedItemIndex] = useState<number | null>(null);
+
+  // Focus the input on every focusInputRevision bump (and on initial mount,
+  // since useEffect always runs once on mount regardless of dep value).
+  // Caveat: in dev StrictMode / hot reload, an incidental SearchPanel
+  // re-mount will also re-focus the input even if the user didn't request
+  // it. Acceptable trade-off: in production, panel mounts only happen on
+  // user-initiated transitions (sidebar view change, panel expand) where
+  // focusing the input is the desired behavior.
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, [focusInputRevision]);
+
+  const flatItems = useMemo(() => {
+    if (uiState.kind !== 'results') return [];
+    return buildFlatItems(uiState.files, expandedFiles);
+  }, [uiState, expandedFiles]);
+
+  // Restore keyboard focus when results refresh.
+  //
+  // Two cases:
+  //  1. The focused index is now out of range (results shrank). Drop the
+  //     stale index and pull focus back to the input — otherwise the
+  //     unmounted button leaves focus on document.body where the input/list
+  //     keydown listeners can't fire, stranding keyboard nav.
+  //  2. The index is still in range but the array identity changed (results
+  //     refreshed with the same shape, e.g. a re-search that produced the
+  //     same files). The button at that index is a fresh DOM node and the
+  //     previous one unmounted, so document.activeElement reverted to body.
+  //     Re-focus the new button at the same index.
+  //
+  // setState-in-effect lint is suppressed for case (1): flatItems is derived
+  // from an async store refresh that can't be observed via pure render-time
+  // derivation, which is the documented exception for this rule.
+  useEffect(() => {
+    if (focusedItemIndex === null) return;
+    if (focusedItemIndex >= flatItems.length) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setFocusedItemIndex(null);
+      inputRef.current?.focus();
+      return;
+    }
+    const el = itemRefs.current.get(focusedItemIndex);
+    if (el && document.activeElement !== el) {
+      el.focus();
+    }
+  }, [flatItems, focusedItemIndex]);
+
+  const focusItem = useCallback((index: number) => {
+    setFocusedItemIndex(index);
+    const el = itemRefs.current.get(index);
+    el?.focus();
+  }, []);
+
+  const handleQueryChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      setQuery(e.target.value);
+    },
+    [setQuery]
+  );
+
+  const handleClearQuery = useCallback(() => {
+    setQuery('');
+    inputRef.current?.focus();
+  }, [setQuery]);
+
+  const handleInputKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'ArrowDown' && flatItems.length > 0) {
+        e.preventDefault();
+        focusItem(0);
+      } else if (e.key === 'Escape' && query) {
+        e.preventDefault();
+        setQuery('');
+      }
+    },
+    [flatItems.length, focusItem, query, setQuery]
+  );
+
+  const activateMatch = useCallback(async (file: FileResult, match: LineMatch) => {
+    // Capture the workspace at click time. If the user switches workspaces
+    // before the file read resolves, bail rather than open a file from the
+    // old workspace into the new one (otherwise navigateToEditorLocation
+    // would open it as a tab outside the active workspace's scope).
+    const workspaceAtClick = useIDEStore.getState().workspace?.path ?? null;
+    if (!workspaceAtClick) return;
+
+    const charColumn = byteColumnToCharColumn(match.text, match.column);
+    if (useIDEStore.getState().workspace?.path !== workspaceAtClick) return;
+
+    await navigateToEditorLocation(file.path, match.line, charColumn);
+  }, []);
+
+  const handleListKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (focusedItemIndex === null || flatItems.length === 0) return;
+      const item = flatItems[focusedItemIndex];
+      // Stale index belongs to results that have already refreshed; the
+      // restoration effect above will re-focus the input on the next render
+      // tick. Bail out here so we don't act on a phantom item.
+      if (!item) return;
+
+      switch (e.key) {
+        case 'ArrowDown': {
+          e.preventDefault();
+          const next = Math.min(flatItems.length - 1, focusedItemIndex + 1);
+          focusItem(next);
+          return;
+        }
+        case 'ArrowUp': {
+          e.preventDefault();
+          if (focusedItemIndex === 0) {
+            inputRef.current?.focus();
+            setFocusedItemIndex(null);
+          } else {
+            focusItem(focusedItemIndex - 1);
+          }
+          return;
+        }
+        case 'ArrowLeft': {
+          // Tree convention:
+          //   - Expanded file → collapse it.
+          //   - Collapsed file → move focus to parent (here: the input).
+          //   - Match row → move focus to its parent file header.
+          e.preventDefault();
+          if (item.kind === 'file' && item.expanded) {
+            toggleFileExpanded(item.file.path);
+          } else if (item.kind === 'file' && !item.expanded) {
+            inputRef.current?.focus();
+            setFocusedItemIndex(null);
+          } else if (item.kind === 'match') {
+            // Walk back to the nearest preceding file header.
+            for (let i = focusedItemIndex - 1; i >= 0; i--) {
+              if (flatItems[i].kind === 'file') {
+                focusItem(i);
+                return;
+              }
+            }
+          }
+          return;
+        }
+        case 'ArrowRight': {
+          if (item.kind === 'file' && !item.expanded) {
+            e.preventDefault();
+            toggleFileExpanded(item.file.path);
+          }
+          return;
+        }
+        case 'Enter':
+        case ' ': {
+          e.preventDefault();
+          if (item.kind === 'file') {
+            toggleFileExpanded(item.file.path);
+          } else {
+            void activateMatch(item.file, item.match);
+          }
+          return;
+        }
+        case 'Home': {
+          e.preventDefault();
+          focusItem(0);
+          return;
+        }
+        case 'End': {
+          e.preventDefault();
+          focusItem(flatItems.length - 1);
+          return;
+        }
+      }
+    },
+    [activateMatch, flatItems, focusItem, focusedItemIndex, toggleFileExpanded]
+  );
+
+  const setItemRef = useCallback(
+    (index: number) => (el: HTMLButtonElement | null) => {
+      if (el) {
+        itemRefs.current.set(index, el);
+      } else {
+        itemRefs.current.delete(index);
+      }
+    },
+    []
+  );
+
+  const isInvalidRegex = uiState.kind === 'invalid-regex';
+
+  return (
+    <div className={styles.container} role="region" aria-label="Workspace search">
+      <div className={styles.controls}>
+        <div className={styles.inputWrapper}>
+          <input
+            ref={inputRef}
+            type="text"
+            className={`${styles.input} ${isInvalidRegex ? styles.invalid : ''}`}
+            placeholder="Search workspace…"
+            aria-label="Search query"
+            aria-invalid={isInvalidRegex}
+            value={query}
+            onChange={handleQueryChange}
+            onKeyDown={handleInputKeyDown}
+            spellCheck={false}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+          />
+          {query && (
+            <button
+              type="button"
+              className={styles.clearButton}
+              onClick={handleClearQuery}
+              aria-label="Clear search"
+              title="Clear search (Esc)"
+            >
+              ×
+            </button>
+          )}
+        </div>
+        <div className={styles.options} role="group" aria-label="Search options">
+          <button
+            type="button"
+            className={styles.optionToggle}
+            aria-pressed={options.caseSensitive}
+            aria-label="Match case"
+            title="Match case"
+            onClick={() => setOption('caseSensitive', !options.caseSensitive)}
+          >
+            Aa
+          </button>
+          <button
+            type="button"
+            className={styles.optionToggle}
+            aria-pressed={options.wholeWord}
+            aria-label="Match whole word"
+            title="Match whole word"
+            onClick={() => setOption('wholeWord', !options.wholeWord)}
+          >
+            ab|
+          </button>
+          <button
+            type="button"
+            className={styles.optionToggle}
+            aria-pressed={options.regex}
+            aria-label="Use regular expression"
+            title="Use regular expression"
+            onClick={() => setOption('regex', !options.regex)}
+          >
+            .*
+          </button>
+        </div>
+      </div>
+
+      <PanelBody
+        uiState={uiState}
+        flatItems={flatItems}
+        focusedItemIndex={focusedItemIndex}
+        // Default the keyboard-tabbable position to item 0 when no row is
+        // focused, so a Tab-only user can reach the result list via Tab
+        // from the option toggles. Without this, the roving tabindex
+        // pattern (only the focused row gets tabIndex=0) would skip the
+        // entire results region until the user presses ArrowDown first.
+        tabbableIndex={focusedItemIndex ?? 0}
+        setItemRef={setItemRef}
+        onListKeyDown={handleListKeyDown}
+        onToggleFile={toggleFileExpanded}
+        onActivateMatch={activateMatch}
+        onItemFocus={setFocusedItemIndex}
+      />
+    </div>
+  );
+}
+
+interface PanelBodyProps {
+  uiState: SearchUIState;
+  flatItems: FlatItem[];
+  focusedItemIndex: number | null;
+  tabbableIndex: number;
+  setItemRef: (index: number) => (el: HTMLButtonElement | null) => void;
+  onListKeyDown: (e: ReactKeyboardEvent<HTMLDivElement>) => void;
+  onToggleFile: (path: string) => void;
+  onActivateMatch: (file: FileResult, match: LineMatch) => void;
+  onItemFocus: (index: number) => void;
+}
+
+function PanelBody({
+  uiState,
+  flatItems,
+  focusedItemIndex,
+  tabbableIndex,
+  setItemRef,
+  onListKeyDown,
+  onToggleFile,
+  onActivateMatch,
+  onItemFocus,
+}: PanelBodyProps) {
+  switch (uiState.kind) {
+    case 'no-workspace':
+      return (
+        <div className={styles.statePanel}>
+          <span className={styles.statePanelTitle}>No workspace open</span>
+          <span>Open a folder to search across files.</span>
+        </div>
+      );
+
+    case 'empty-query':
+      return (
+        <div className={styles.statePanel}>
+          <span>Type to search the workspace.</span>
+        </div>
+      );
+
+    case 'loading':
+      return (
+        <div className={styles.statePanel} aria-live="polite">
+          <span>
+            <span className={styles.loadingDot} aria-hidden="true" />
+            Searching…
+          </span>
+        </div>
+      );
+
+    case 'no-matches':
+      return (
+        <div className={styles.statePanel}>
+          <span className={styles.statePanelTitle}>No matches</span>
+          <span>Search completed in {formatSearchDuration(uiState.durationMs)}.</span>
+        </div>
+      );
+
+    case 'missing-tool':
+      return (
+        <div className={`${styles.statePanel} ${styles.error}`} role="alert">
+          <span className={styles.statePanelTitle}>ripgrep is not available</span>
+          <span>{uiState.message}</span>
+        </div>
+      );
+
+    case 'invalid-regex':
+      return (
+        <div className={`${styles.statePanel} ${styles.warning}`} role="alert">
+          <span className={styles.statePanelTitle}>Invalid regular expression</span>
+          <span>{uiState.message}</span>
+        </div>
+      );
+
+    case 'canceled':
+      return (
+        <div className={styles.statePanel}>
+          <span>Search canceled.</span>
+        </div>
+      );
+
+    case 'failed':
+      return (
+        <div className={`${styles.statePanel} ${styles.error}`} role="alert">
+          <span className={styles.statePanelTitle}>Search failed</span>
+          <span>{uiState.message}</span>
+        </div>
+      );
+
+    case 'results': {
+      return (
+        <>
+          <div className={`${styles.summary} ${uiState.truncated ? styles.truncated : ''}`}>
+            <span>{describeMatchSummary(uiState)}</span>
+            <span aria-hidden="true">·</span>
+            <span>{formatSearchDuration(uiState.durationMs)}</span>
+            {uiState.truncated && (
+              <>
+                <span aria-hidden="true">·</span>
+                {/* Prefix the warning with a ⚠ glyph so the truncation cue
+                    is not color-only — colorblind users see the icon plus
+                    the explicit "Truncated" word in addition to the warning
+                    color modifier on the summary background. */}
+                <span>⚠ Truncated at {uiState.matchCap.toLocaleString()} matches</span>
+              </>
+            )}
+          </div>
+          <div
+            className={styles.resultsScroll}
+            aria-label="Search results"
+            onKeyDown={onListKeyDown}
+          >
+            <div className={styles.resultsList}>
+              {flatItems.map((item) =>
+                item.kind === 'file' ? (
+                  <FileGroupHeader
+                    key={`f:${item.file.path}`}
+                    item={item}
+                    focused={focusedItemIndex === item.index}
+                    tabbable={tabbableIndex === item.index}
+                    itemRef={setItemRef(item.index)}
+                    onToggle={() => onToggleFile(item.file.path)}
+                    onFocus={() => onItemFocus(item.index)}
+                  />
+                ) : (
+                  <ResultRow
+                    key={`m:${item.file.path}:${item.match.line}:${item.match.column}`}
+                    item={item}
+                    focused={focusedItemIndex === item.index}
+                    tabbable={tabbableIndex === item.index}
+                    itemRef={setItemRef(item.index)}
+                    onActivate={() => onActivateMatch(item.file, item.match)}
+                    onFocus={() => onItemFocus(item.index)}
+                  />
+                )
+              )}
+            </div>
+          </div>
+        </>
+      );
+    }
+  }
+}

--- a/frontend/src/components/Search/SearchPanel.tsx
+++ b/frontend/src/components/Search/SearchPanel.tsx
@@ -274,11 +274,14 @@ export function SearchPanel() {
     // would open it as a tab outside the active workspace's scope).
     const workspaceAtClick = useIDEStore.getState().workspace?.path ?? null;
     if (!workspaceAtClick) return;
+    const isSameWorkspace = () => useIDEStore.getState().workspace?.path === workspaceAtClick;
 
     const charColumn = byteColumnToCharColumn(match.text, match.column);
-    if (useIDEStore.getState().workspace?.path !== workspaceAtClick) return;
+    if (!isSameWorkspace()) return;
 
-    await navigateToEditorLocation(file.path, match.line, charColumn);
+    await navigateToEditorLocation(file.path, match.line, charColumn, {
+      shouldApply: isSameWorkspace,
+    });
   }, []);
 
   const handleListKeyDown = useCallback(

--- a/frontend/src/components/Search/index.ts
+++ b/frontend/src/components/Search/index.ts
@@ -1,0 +1,1 @@
+export { SearchPanel } from './SearchPanel';

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useOpenFolder } from './useOpenFolder';
 import { isMac } from '../utils/platform';
 import { useIDEStore, type NavigationLocation } from '../stores/ideStore';
+import { useSearchStore } from '../stores/searchStore';
 import { navigateToEditorLocation } from '../utils/editorNavigation';
 
 /**
@@ -22,6 +23,23 @@ export function useKeyboardShortcuts() {
       if (modifier && e.key === 'o') {
         e.preventDefault();
         openFolder();
+        return;
+      }
+
+      // Cmd+Shift+F / Ctrl+Shift+F — Workspace search.
+      // Switch the sidebar to the search view, expand the left panel if it's
+      // collapsed, then request input focus. Compare key case-insensitively
+      // because Shift modifies the printed key on some layouts.
+      if (modifier && e.shiftKey && (e.key === 'f' || e.key === 'F')) {
+        e.preventDefault();
+        const ide = useIDEStore.getState();
+        if (ide.activeSidebarView !== 'search') {
+          ide.setSidebarView('search');
+        }
+        if (ide.isLeftPanelCollapsed) {
+          ide.toggleLeftPanel();
+        }
+        useSearchStore.getState().requestInputFocus();
         return;
       }
 

--- a/frontend/src/hooks/useWorkspaceSearch.ts
+++ b/frontend/src/hooks/useWorkspaceSearch.ts
@@ -62,89 +62,101 @@ function fireCancelSearch(requestId: string): void {
  *   - keep ideStore.workspace and searchStore in sync: empty query → empty
  *     state, no workspace → no-workspace state
  *
- * The hook is fire-and-forget; mount it once at the top of the app.
+ * The hook is fire-and-forget; mount it once at the top of the app. It uses
+ * vanilla store subscriptions internally so query/option changes do not
+ * re-render the component that hosts the hook.
  */
 export function useWorkspaceSearch(): void {
-  const workspacePath = useIDEStore((state) => state.workspace?.path ?? null);
-  const query = useSearchStore((state) => state.query);
-  const options = useSearchStore((state) => state.options);
   const requestCounter = useRef(0);
 
-  // Workspace-switch listener: cancel any in-flight search and reset state
-  // when the user opens a different workspace. Subscribed once at mount; the
-  // dep array is empty so the subscription persists for the hook's lifetime.
   useEffect(() => {
-    let previousWorkspacePath = useIDEStore.getState().workspace?.path ?? null;
+    let debounceTimer: number | null = null;
+    let searchGeneration = 0;
 
-    return useIDEStore.subscribe((state) => {
-      const nextWorkspacePath = state.workspace?.path ?? null;
-      if (nextWorkspacePath === previousWorkspacePath) return;
-
-      const activeRequestId = useSearchStore.getState().activeRequestId;
-      if (activeRequestId) fireCancelSearch(activeRequestId);
-
-      useSearchStore.getState().resetForWorkspace(nextWorkspacePath);
-      previousWorkspacePath = nextWorkspacePath;
-    });
-  }, []);
-
-  // Unmount cleanup: cancel any in-flight backend search so the ripgrep
-  // process does not outlive the IDE session.
-  useEffect(() => {
-    return () => {
-      const activeRequestId = useSearchStore.getState().activeRequestId;
-      if (activeRequestId) fireCancelSearch(activeRequestId);
+    const clearPendingSearch = () => {
+      searchGeneration += 1;
+      if (debounceTimer) {
+        window.clearTimeout(debounceTimer);
+        debounceTimer = null;
+      }
     };
-  }, []);
 
-  // Main debounced search effect. Re-runs whenever the workspace, query, or
-  // options change. Stale debounced supersessions are dropped by RequestID;
-  // we deliberately do not fire CancelSearch on debounce-supersession because
-  // the backend run usually finishes within the next debounce window.
-  useEffect(() => {
-    const trimmedQuery = query.trim();
+    const scheduleSearch = () => {
+      clearPendingSearch();
 
-    if (!workspacePath) {
-      useSearchStore.getState().setNoWorkspace();
-      return;
-    }
+      const workspacePath = useIDEStore.getState().workspace?.path ?? null;
+      const { query, options } = useSearchStore.getState();
+      const trimmedQuery = query.trim();
 
-    if (!trimmedQuery) {
-      useSearchStore.getState().setEmptyQuery();
-      return;
-    }
+      if (!workspacePath) {
+        useSearchStore.getState().setNoWorkspace();
+        return;
+      }
 
-    let canceled = false;
-    const requestId = `search-${Date.now()}-${++requestCounter.current}`;
+      if (!trimmedQuery) {
+        useSearchStore.getState().setEmptyQuery();
+        return;
+      }
 
-    const timer = window.setTimeout(() => {
-      if (canceled) return;
+      const requestId = `search-${Date.now()}-${++requestCounter.current}`;
+      const generation = searchGeneration;
+      const requestQuery = query;
+      const requestOptions = { ...options };
 
-      useSearchStore.getState().beginSearch(requestId);
+      debounceTimer = window.setTimeout(() => {
+        debounceTimer = null;
+        if (generation !== searchGeneration) return;
 
-      const request = new search.SearchRequest({
-        requestId,
-        root: workspacePath,
-        query,
-        options: { ...options },
-      });
+        useSearchStore.getState().beginSearch(requestId);
 
-      void SearchWorkspace(request)
-        .then((raw) => {
-          if (canceled) return;
-          if (useSearchStore.getState().activeRequestId !== requestId) return;
-          useSearchStore.getState().applyResponse(narrowResponse(raw));
-        })
-        .catch((err) => {
-          if (canceled) return;
-          if (useSearchStore.getState().activeRequestId !== requestId) return;
-          useSearchStore.getState().failSearch(requestId, errorMessage(err));
+        const request = new search.SearchRequest({
+          requestId,
+          root: workspacePath,
+          query: requestQuery,
+          options: requestOptions,
         });
-    }, SEARCH_DEBOUNCE_MS);
+
+        void SearchWorkspace(request)
+          .then((raw) => {
+            if (generation !== searchGeneration) return;
+            if (useSearchStore.getState().activeRequestId !== requestId) return;
+            useSearchStore.getState().applyResponse(narrowResponse(raw));
+          })
+          .catch((err) => {
+            if (generation !== searchGeneration) return;
+            if (useSearchStore.getState().activeRequestId !== requestId) return;
+            useSearchStore.getState().failSearch(requestId, errorMessage(err));
+          });
+      }, SEARCH_DEBOUNCE_MS);
+    };
+
+    const unsubscribeWorkspace = useIDEStore.subscribe((state, prevState) => {
+      const workspacePath = state.workspace?.path ?? null;
+      const previousWorkspacePath = prevState.workspace?.path ?? null;
+      if (workspacePath === previousWorkspacePath) return;
+
+      clearPendingSearch();
+
+      const activeRequestId = useSearchStore.getState().activeRequestId;
+      if (activeRequestId) fireCancelSearch(activeRequestId);
+
+      useSearchStore.getState().resetForWorkspace(workspacePath);
+    });
+
+    const unsubscribeSearch = useSearchStore.subscribe((state, prevState) => {
+      if (state.query === prevState.query && state.options === prevState.options) return;
+      scheduleSearch();
+    });
+
+    scheduleSearch();
 
     return () => {
-      canceled = true;
-      window.clearTimeout(timer);
+      clearPendingSearch();
+      unsubscribeWorkspace();
+      unsubscribeSearch();
+
+      const activeRequestId = useSearchStore.getState().activeRequestId;
+      if (activeRequestId) fireCancelSearch(activeRequestId);
     };
-  }, [options, query, workspacePath]);
+  }, []);
 }

--- a/frontend/src/stores/searchStore.ts
+++ b/frontend/src/stores/searchStore.ts
@@ -21,6 +21,12 @@ interface SearchState {
   uiState: SearchUIState;
   expandedFiles: Set<string>;
   activeRequestId: string | null;
+  // Monotonic revision bumped whenever a consumer (e.g. the Cmd+Shift+F
+  // keyboard shortcut) wants the SearchPanel input to grab focus. The panel
+  // watches this via useEffect so focus requests work even when the panel
+  // isn't mounted yet — the shortcut bumps the counter, the panel mounts,
+  // sees the new revision in its initial render, and focuses the input.
+  focusInputRevision: number;
 }
 
 interface SearchActions {
@@ -34,6 +40,7 @@ interface SearchActions {
   resetForWorkspace: (workspacePath: string | null | undefined) => void;
   toggleFileExpanded: (path: string) => void;
   clearResults: () => void;
+  requestInputFocus: () => void;
 }
 
 type SearchStore = SearchState & SearchActions;
@@ -88,6 +95,7 @@ export const useSearchStore = create<SearchStore>()(
       uiState: { kind: 'no-workspace' },
       expandedFiles: new Set<string>(),
       activeRequestId: null,
+      focusInputRevision: 0,
 
       setQuery: (query) => set({ query }, false, 'search/setQuery'),
 
@@ -220,6 +228,13 @@ export const useSearchStore = create<SearchStore>()(
           },
           false,
           'search/clearResults'
+        ),
+
+      requestInputFocus: () =>
+        set(
+          (state) => ({ focusInputRevision: state.focusInputRevision + 1 }),
+          false,
+          'search/requestInputFocus'
         ),
     }),
     { name: 'search-store' }

--- a/frontend/src/utils/editorNavigation.ts
+++ b/frontend/src/utils/editorNavigation.ts
@@ -11,35 +11,54 @@ import { ReadFile } from '../../wailsjs/go/main/App';
 import { createEditorFile } from './editorFile';
 import { getFileNameFromPath, pathsReferToSameFile, toNativeLocalPath } from './lspUri';
 
+interface EditorNavigationOptions {
+  shouldApply?: () => boolean;
+}
+
+function shouldApplyNavigation(options?: EditorNavigationOptions): boolean {
+  return options?.shouldApply?.() ?? true;
+}
+
 /**
  * Opens a file in the editor if it isn't already open, and activates its tab.
  * Returns the EditorFile on success, or null if the file could not be read.
  */
-export async function ensureEditorFileOpen(path: string): Promise<EditorFile | null> {
-  const store = useIDEStore.getState();
+export async function ensureEditorFileOpen(
+  path: string,
+  options?: EditorNavigationOptions
+): Promise<EditorFile | null> {
   const localPath = toNativeLocalPath(path);
 
   // Already open — just activate and return
-  const existing = store.openFiles.find((f) => pathsReferToSameFile(f.id, localPath));
+  const existing = useIDEStore
+    .getState()
+    .openFiles.find((f) => pathsReferToSameFile(f.id, localPath));
   if (existing) {
-    store.setActiveFile(existing.id);
+    if (!shouldApplyNavigation(options)) return null;
+    useIDEStore.getState().setActiveFile(existing.id);
     return existing;
   }
 
   // Read and open
   try {
     const content = await ReadFile(localPath);
+    if (!shouldApplyNavigation(options)) return null;
+
     if (content.isBinary) {
-      store.showToast(`Cannot open binary file: ${getFileNameFromPath(localPath)}`, 'error');
+      useIDEStore
+        .getState()
+        .showToast(`Cannot open binary file: ${getFileNameFromPath(localPath)}`, 'error');
       return null;
     }
 
     const file = createEditorFile(localPath, content);
-    store.openFile(file);
+    useIDEStore.getState().openFile(file);
     return file;
   } catch (err) {
+    if (!shouldApplyNavigation(options)) return null;
+
     const message = err instanceof Error ? err.message : 'Unknown error';
-    store.showToast(`Failed to open file: ${message}`, 'error');
+    useIDEStore.getState().showToast(`Failed to open file: ${message}`, 'error');
     return null;
   }
 }
@@ -51,10 +70,12 @@ export async function ensureEditorFileOpen(path: string): Promise<EditorFile | n
 export async function navigateToEditorLocation(
   path: string,
   line: number,
-  column: number
+  column: number,
+  options?: EditorNavigationOptions
 ): Promise<void> {
-  const file = await ensureEditorFileOpen(path);
+  const file = await ensureEditorFileOpen(path, options);
   if (!file) return;
+  if (!shouldApplyNavigation(options)) return;
 
   useIDEStore.getState().requestEditorNavigation(file.id, line, column);
 }


### PR DESCRIPTION
## Summary
Workspace-wide search panel built on the Task 2 search APIs from #88. Lights up the Search sidebar entry, the `Cmd+Shift+F` (`Ctrl+Shift+F`) shortcut, and left-panel routing — `App.tsx`'s leftPanel is no longer hard-coded to FileExplorer.

- `components/Search/SearchPanel.tsx` — exhaustive switch on `SearchUIState` renders all nine states (`no-workspace`, `empty-query`, `loading`, `results`, `no-matches`, `missing-tool`, `invalid-regex`, `canceled`, `failed`) with roles, live regions, and Firn Glacier styling.
- `components/Search/SearchPanel.module.css` — controls, file groups, result rows, state panels. Long-path truncation via flex + RTL-ellipsized directory tail wrapped in `<bdi>` for bidi safety.
- VS Code-style roving tabindex keyboard nav: ArrowDown/Up traverse the flat item list, ArrowLeft on a match returns to its file header (and on a collapsed file to the input), ArrowRight expands collapsed groups, Enter activates. When no row is focused, the first item is tabbable so Tab-only users can reach the list from the option toggles.
- Mounts `useWorkspaceSearch` once at the App level so in-flight cancellation guards survive panel toggling.
- `useKeyboardShortcuts` now handles `Cmd+Shift+F` / `Ctrl+Shift+F`: switches sidebar view to `search`, expands the left panel if collapsed, and bumps `searchStore.focusInputRevision` so the panel focuses its input on next render.
- `searchStore.focusInputRevision` + `requestInputFocus()` lets non-mounted consumers (the keyboard shortcut) request focus that the panel applies on mount/revision-change.
- Result refresh handling: same-shape refresh re-focuses the matching DOM node so keyboard nav doesn't strand on `body`; stale-index refresh returns focus to the input.
- Truncation cue is non-color-only: `⚠ Truncated at N matches`.
- `byteColumnToCharColumn` applied at click time so multi-byte / emoji matches land correctly in the editor.
- Workspace-presence guard at click time avoids stray navigations on stale results after a workspace switch.

Stack note: a small follow-up to #88 — cancel-on-supersession in `useWorkspaceSearch` — is shipped separately as #91 for cleaner review surface.

## Test plan
- [x] `npm test -- --watch=false src/__tests__/components/Search/SearchPanel.test.tsx` (32/32, including focus restoration, byte→char nav, keyboard nav, no-workspace guard)
- [x] `npm test -- --watch=false src/__tests__/hooks/useKeyboardShortcuts.test.ts src/__tests__/App.test.tsx src/__tests__/Sidebar.test.tsx src/__tests__/Header.test.tsx` (full touched-area set)
- [x] `npm test -- --watch=false` (638/638)
- [x] `npm run lint` (0 errors, pre-existing warnings only)
- [x] `npm run format:check`
- [x] `npm run build`
- Manual smoke (next): open a workspace, press `Cmd+Shift+F`, search known text, toggle options, click a result, verify editor navigation; collapse left panel and shortcut again; ArrowDown from input through results; ArrowLeft on match returns to header.

## Adversarial review coverage
Two review passes (code-review + criticize-review) caught and fixed: stale `focusedItemIndex` on result refresh, `role="tree"` half-implementation (downgraded to button-only), `aria-live` spam on every keystroke, O(N·M) result iteration (now O(N+M) via flat-items map), Tab-only inaccessibility of result list, ArrowLeft tree-convention gaps, color-only truncation cue, bidi instability of long paths.

Generated with [Claude Code](https://claude.com/claude-code)