### PR TITLE
[codex] sync roadmap docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Firn uses [Wails](https://wails.io) (Go backend + system WebView) instead of Ele
 
 The trade-off: Fewer npm packages that rely on Node.js APIs work out-of-the-box. Worth it for a lightweight, fast IDE.
 
-### AI Integration
+### Future AI Integration
 
-Built-in AI assistant panel with:
+The roadmap includes a built-in AI assistant panel with:
 - Context-aware code assistance (current file, selection, workspace)
 - Multiple provider support (Claude, OpenAI, local Ollama)
 - Diff preview before applying suggested changes
@@ -66,7 +66,8 @@ Built-in AI assistant panel with:
 │  │  • Run Profiles │              │  • Run Profile Cards    │  │
 │  │  • PTY Terminal │              │  • Panel System         │  │
 │  │  • Workspace    │              │  • Run Output Views     │  │
-│  │  • Git Ops      │              │  • Theme Engine         │  │
+│  │  • LSP Client   │              │  • LSP Editor UX        │  │
+│  │  • ripgrep      │              │  • Search UI            │  │
 │  └─────────────────┘              └─────────────────────────┘  │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
@@ -79,8 +80,8 @@ Built-in AI assistant panel with:
 | State | Zustand |
 | Editor | CodeMirror 6 |
 | File Watching | fsnotify with debounce |
-| Language Intelligence | LSP per workspace (planned) |
-| Search | ripgrep (planned) |
+| Language Intelligence | LSP per active workspace |
+| Search | ripgrep workspace search + CodeMirror in-file search |
 
 ### Performance Targets
 
@@ -100,6 +101,8 @@ Built-in AI assistant panel with:
 - [x] `WriteFile` — content writing with encoding preservation
 - [x] File system watcher — real-time external change detection with debounced events
 - [x] Workspace store — open folder, persistence, recent projects
+- [x] LSP client foundation — JSON-RPC framing, stdio transport, lifecycle, crash recovery, diagnostics/status events
+- [x] Search backend — ripgrep JSON parsing, cancellation, typed errors, and result caps
 
 **Run Profiles (Go + React)**
 - [x] Auto-detection from package.json, go.mod, Makefile, pyproject.toml, docker-compose
@@ -128,6 +131,21 @@ Built-in AI assistant panel with:
 - [x] Status bar (cursor position, language, git branch)
 - [x] Toast notification system
 
+**Language Intelligence**
+- [x] Frontend document sync (`didOpen`, debounced `didChange`, `didSave`, `didClose`)
+- [x] TypeScript/JavaScript LSP vertical slice through `typescript-language-server --stdio`
+- [x] Diagnostics underlines, gutter markers, Problems panel, and status-bar counts
+- [x] Completion source with trigger characters, detail/docs, and snippet support
+- [x] Hover tooltips and go-to-definition (`F12`, Cmd/Ctrl-click)
+- [x] Shared registry entries for Go (`gopls`) and Python (`pyright-langserver`)
+
+**Search**
+- [x] Workspace-wide ripgrep search with regex, case, and whole-word options
+- [x] Results grouped by file with highlighted matches and keyboard navigation
+- [x] Cmd+Shift+F opens workspace search
+- [x] Click result to open the file at the match location
+- [x] In-file find/replace through CodeMirror search (`Cmd+F`)
+
 **Terminal Integration**
 - [x] PTY backend — shell sessions with bidirectional I/O and ANSI support
 - [x] xterm.js frontend — themed terminal with Firn Glacier colors
@@ -142,11 +160,12 @@ Built-in AI assistant panel with:
 
 ### Planned
 
-- [ ] LSP client integration
+- [ ] Complete TypeScript project-root detection for nearest `tsconfig.json`, `jsconfig.json`, or `package.json`
 - [ ] Git integration
-- [ ] Search with ripgrep
+- [ ] Run output clickable `file:line:col` links
+- [ ] Run Profile environment variants and compound execution
+- [ ] Workspace identity and Project/Workspace file tree views
 - [ ] AI Chat Panel
-- [ ] Clickable file:line:col links in output (jump to source from errors)
 
 ## Project Structure
 
@@ -156,7 +175,9 @@ firn-ide/
 ├── app.go                      # Wails bindings
 ├── internal/
 │   ├── filesystem/             # File read/write/watch
+│   ├── lsp/                    # LSP client, registry, transports, URI handling
 │   ├── runprofile/             # Run profile detection, execution, management
+│   ├── search/                 # ripgrep search runner and parser
 │   ├── terminal/               # PTY session management
 │   ├── watcher/                # FS event watcher
 │   ├── workspace/              # Workspace persistence
@@ -168,6 +189,7 @@ firn-ide/
 │   │   │   ├── FileExplorer/   # File tree navigation
 │   │   │   ├── RunProfiles/    # Run profile cards and panels
 │   │   │   ├── RunOutput/      # Output display (merged, lanes, diff, timeline)
+│   │   │   ├── Search/         # Workspace-wide search
 │   │   │   ├── Terminal/       # xterm.js terminal
 │   │   │   └── layout/         # Panel system, sidebar, header
 │   │   ├── stores/             # Zustand state management
@@ -216,6 +238,13 @@ The [Design Specification](docs/design-specification.md) contains the complete U
 - Keyboard shortcuts
 
 See the [Roadmap](docs/roadmap.md) for implementation progress and all tracked issues.
+
+## Current Priorities
+
+1. Finish TypeScript project-root detection for the remaining LSP integration work.
+2. Add clickable run-output error links.
+3. Complete Run Profile environment variants and compound execution.
+4. Build workspace identity, active workspace accenting, and Project/Workspace tree views.
 
 ## Contributing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,21 +48,28 @@ Firn IDE uses a hybrid architecture: a **Go backend** for system operations and 
 | Component | Location | Responsibility |
 |-----------|----------|----------------|
 | `IDEShell` | `components/layout/` | Main layout container with panels |
-| `Header` | `components/Header/` | Logo, workspace selector, search |
+| `Header` | `components/Header/` | Logo, workspace/recent-project selector, search trigger |
 | `Sidebar` | `components/Sidebar/` | Navigation icons (Explorer, Search, Git, Run) |
 | `FileExplorer` | `components/FileExplorer/` | File tree navigation |
 | `Editor` | `components/Editor/` | CodeMirror 6 code editor |
+| `SearchPanel` | `components/Search/` | Workspace-wide ripgrep search UI |
 | `Terminal` | `components/Terminal/` | Integrated terminal panel |
 | `RunProfiles` | `components/RunProfiles/` | Build/run configurations |
+| `RunOutput` | `components/RunOutput/` | Streaming run output views |
 | `StatusBar` | `components/StatusBar/` | Git branch, cursor position, diagnostics |
 
 ### Backend Components
 
 | Component | File | Responsibility |
 |-----------|------|----------------|
-| `App` | `app.go` | Main application struct, Wails lifecycle |
-| `FileSystem` | `interfaces.go` | File operations interface (mockable) |
-| `ProcessManager` | `interfaces.go` | Process management interface (mockable) |
+| `App` | `app.go` | Main application struct, Wails lifecycle and bindings |
+| `filesystem` | `internal/filesystem/` | Directory reads, file reads/writes, metadata, encodings |
+| `watcher` | `internal/watcher/` | fsnotify-based file watching with debounce |
+| `workspace` | `internal/workspace/` | Workspace state persistence and recent projects |
+| `runprofile` | `internal/runprofile/` | Profile detection, persistence, execution, output streaming |
+| `terminal` | `internal/terminal/` | PTY session management |
+| `lsp` | `internal/lsp/` | LSP client, stdio transport, registry, URI handling |
+| `search` | `internal/search/` | ripgrep runner, JSON parser, cancellation, typed results |
 
 ## Data Flow
 
@@ -92,19 +99,20 @@ Data flows through the application in a unidirectional pattern:
 2. Component calls `useIDEStore().openFile(fileData)`
 3. Zustand store updates `openFiles` and `activeFileId`
 4. `Editor` component re-renders with new file
-5. (Future) Wails binding reads file content from Go backend
+5. `ensureEditorFileOpen` reads file content from Go via Wails when needed
 
-### Example: Getting Workspace Info
+### Example: Workspace Search
 
-1. Application starts
-2. React calls `window.go.main.App.GetWorkspaceInfo()`
-3. Wails runtime invokes Go method
-4. Go backend returns `WorkspaceInfo` struct
-5. React receives JavaScript object with `name` and `path`
+1. User presses Cmd+Shift+F or opens the Search sidebar
+2. `useWorkspaceSearch` debounces query/options from `searchStore`
+3. React calls `SearchWorkspace` through Wails
+4. Go runs `rg --json` with explicit arguments and cancellation
+5. Parsed file/match results are stored in `searchStore`
+6. `SearchPanel` renders grouped results and opens matches through the editor navigation flow
 
 ## State Management
 
-Firn uses **Zustand** for state management with a single store pattern.
+Firn uses **Zustand** for state management. `ideStore` owns the main IDE/session state, while focused stores such as `lspStore` and `searchStore` own feature-specific state that should not live as derived counters or duplicated data in `ideStore`.
 
 ### Store Structure
 
@@ -114,7 +122,7 @@ Firn uses **Zustand** for state management with a single store pattern.
 interface IDEState {
   // Workspace
   workspace: WorkspaceInfo | null;
-  isLoading: boolean;
+  isLoadingTree: boolean;
 
   // Sidebar
   activeSidebarView: 'explorer' | 'search' | 'git' | 'run';
@@ -126,14 +134,18 @@ interface IDEState {
 
   // Terminal
   activeTerminalTab: 'terminal' | 'output' | 'problems';
-  workingDirectory: string;
+  terminalSessions: TerminalSession[];
+
+  // Run profiles
+  runProfiles: RunProfile[];
+  runOutputs: Record<string, RunOutputState>;
 
   // Status
   gitBranch: string;
-  errorCount: number;
-  warningCount: number;
 }
 ```
+
+Diagnostics live in `lspStore` as a full URI -> diagnostics map. Error/warning/info counts are derived selector hooks, not separately maintained status fields.
 
 ### Selector Hooks
 
@@ -161,8 +173,10 @@ const workspace = useIDEStore(state => state.workspace);
 | `useCursorPosition()` | Cursor line/column |
 | `useTerminalTab()` | Active terminal tab |
 | `useGitBranch()` | Current git branch |
-| `useErrorCount()` | Number of errors |
-| `useWarningCount()` | Number of warnings |
+| `useRunProfiles()` | Run profile list |
+| `useLSPErrorCount()` | Derived LSP error count |
+| `useLSPWarningCount()` | Derived LSP warning count |
+| `useLSPInfoCount()` | Derived LSP info/hint count |
 
 ### Actions
 
@@ -185,12 +199,12 @@ store.setFileModified(fileId, true);
 
 // Terminal
 store.setTerminalTab('output');
-store.setWorkingDirectory('/path/to/dir');
 
 // Status
 store.setGitBranch('main');
-store.setDiagnostics(2, 5);
 ```
+
+For LSP diagnostics and workspace search state, use `lspStore` and `searchStore` actions rather than adding parallel counters or result state to `ideStore`.
 
 ## Adding New Features
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,11 +23,11 @@ Firn IDE brings the focused, keyboard-first productivity of JetBrains IDEs to a 
 | Infrastructure | **COMPLETE** | #28-32 |
 | Milestone 1: Core File Operations | **COMPLETE** | #3-9 |
 | UI/UX Polish | **COMPLETE** | #35-36 |
-| Milestone 2: Terminal Integration | **COMPLETE** | #10-12, #47 |
-| Milestone 3: Workspace Management | **IN PROGRESS** | #13-15, #53, #54 |
-| Milestone 4: Run Profiles | **IN PROGRESS** | #16-18 |
-| Milestone 5: Language Server Protocol | Not started | #19-22 |
-| Milestone 6: Search | Not started | #23-25 |
+| Milestone 2: Terminal Integration | **IN PROGRESS** | #10-12 complete, #47 open |
+| Milestone 3: Workspace Management | **IN PROGRESS** | #13-15 complete, #53-54 open |
+| Milestone 4: Run Profiles | **IN PROGRESS** | #16, #59-61 complete; #17-18, #62-64, #71 open |
+| Milestone 5: Language Server Protocol | **IN PROGRESS** | #19, #21-22, #73 complete; #20, #74-76 open |
+| Milestone 6: Search | **COMPLETE** | #23-25 |
 | Milestone 7: Git Integration | Not started | #26-27 |
 | Performance | Not started | #37-39 |
 | Dependency Upgrades | **COMPLETE** | #40 |
@@ -35,6 +35,16 @@ Firn IDE brings the focused, keyboard-first productivity of JetBrains IDEs to a 
 | Accessibility | Not started | #43 |
 | Future Features | Not started | #44-46 |
 | Bug Fixes | Not started | #33-34 |
+
+---
+
+## Next Priorities
+
+1. **#20: Finish TypeScript project-root detection** — the LSP TypeScript path is functional, but this ticket still requires nearest `tsconfig.json`, `jsconfig.json`, or `package.json` root resolution rather than only using the active workspace root.
+2. **#62: Run Profiles - Clickable Error Links** — parse common `file:line:col` output formats and jump from run output to source.
+3. **#64: Run Profiles - Environment Variants** — complete `ActiveVariant` env-file resolution and add the frontend variant selector.
+4. **#63: Run Profiles - Compound Profile Execution** — add sequential step execution, stop-on-failure, and per-step UI.
+5. **#53 then #54: Workspace Identity and File Tree Views** — workspace definitions, active accent, selector, then Project/Workspace tree modes.
 
 ---
 
@@ -63,7 +73,7 @@ Debounced autosave after ~1.5s idle, save on focus loss, Cmd+S support, error to
 
 ---
 
-## Milestone 2: Terminal Integration (COMPLETE)
+## Milestone 2: Terminal Integration (IN PROGRESS)
 
 ### #10: Terminal - PTY Backend ✅
 - [x] Create PTY session with shell (bash/zsh)
@@ -103,16 +113,16 @@ Debounced autosave after ~1.5s idle, save on focus loss, Cmd+S support, error to
 - [x] Load selected folder into file explorer
 - [x] Update window title with folder name
 
-### #14: Workspace - Persistence
-- [ ] Save/restore open files, cursor positions, scroll state
-- [ ] Save panel sizes and layout
-- [ ] Save active workspace/folder
-- [ ] Store in `~/.firn/workspaces/`
+### #14: Workspace - Persistence ✅
+- [x] Save/restore open files, cursor positions, scroll state
+- [x] Save panel sizes and layout
+- [x] Save active workspace/folder
+- [x] Store in `~/.firn/workspaces/`
 
-### #15: Workspace - Recent Projects
-- [ ] Store last 10 opened folders
-- [ ] Display in welcome screen and File menu
-- [ ] Click to reopen project
+### #15: Workspace - Recent Projects ✅
+- [x] Store recent opened folders
+- [x] Display in workspace menu
+- [x] Click to reopen project
 
 ### #53: Workspace - Identity & Accent System (NEW)
 Defines workspace identity: type, accent color, and how workspaces are configured within a repo.
@@ -150,69 +160,124 @@ Project View (unified) vs Workspace View (focused) with color-coded regions.
 
 ### #17: Run Profiles - Execution Engine [Epic]
 Sub-issues:
-- [ ] #59: Core Process Runner — `os/exec` implementation, env/cwd/envFile, start/stop bindings
-- [ ] #60: Output Streaming — pipe stdout/stderr, Wails events, output panel
-- [ ] #61: Process Lifecycle UI — play/stop/restart controls, state indicators
+- [x] #59: Core Process Runner — `os/exec` implementation, env/cwd/envFile, start/stop bindings
+- [x] #60: Output Streaming — pipe stdout/stderr, Wails events, output panel
+- [x] #61: Process Lifecycle UI — play/stop/restart controls, state indicators
 - [ ] #62: Clickable Error Links — `file:line:col` parsing, jump-to-error
 - [ ] #63: Compound Profile Execution — sequential steps, stop-on-failure
 - [ ] #64: Environment Variants — env file swapping by active variant
 
+### #71: Run Profiles - Activated State, Section Reorganization, and Selection Persistence
+- [ ] Activated profile working set
+- [ ] Reorganize sections into Activated, Pinned, and Detected
+- [ ] Persist activation state per workspace
+- [ ] Header counter with active/total counts
+
 ### #18: Run Profiles - UI Integration
 - [ ] Profile selector dropdown in header toolbar (`[▶ Profile ▾]`)
-- [ ] Play/stop/restart controls
-- [ ] Running status indicator (green dot running, red dot failed)
-- [ ] Output panel with streaming logs and clickable file:line:col
+- [x] Play/stop/restart controls in run profile cards
+- [x] Running status indicators and status badges
+- [x] Output panel with streaming logs
+- [ ] Clickable file:line:col output links
 - [ ] Compound execution view with stage indicators
 - [ ] Environment variant selector (`[env: dev ▾]`)
 - [ ] Edit profile form (create/modify saved profiles)
-- [ ] Profiles grouped by workspace with accent colors (depends on #48)
-- [ ] Status bar: click running profile → opens output panel
+- [ ] Profiles grouped by workspace with accent colors (depends on #53)
+- [x] Status bar / output focus integration for running profiles
 
 > **Design spec ref:** Section 5 (Run Profiles UI)
 
 ---
 
-## Milestone 5: Language Server Protocol
+## Milestone 5: Language Server Protocol (IN PROGRESS)
 
-### #19: LSP - Client Implementation
-- [ ] JSON-RPC 2.0 message handling
-- [ ] Initialize/shutdown lifecycle
-- [ ] textDocument/didOpen, didChange, didSave
-- [ ] Support stdio and TCP transports
+### #74: LSP - Language Intelligence [Epic]
+Epic for Firn's production LSP foundation and TypeScript vertical slice.
+- [x] Backend LSP foundation
+- [x] Frontend document sync
+- [x] Diagnostics UX and Problems panel
+- [x] Completion, hover, and definition UX
+- [ ] TypeScript project-root detection completion (#20)
 
-### #20: LSP - TypeScript Integration
-- [ ] Auto-detect TypeScript projects
-- [ ] Start/stop tsserver appropriately
-- [ ] Diagnostics, hover, go-to-definition
+### #19: LSP - Client Foundation ✅
+- [x] JSON-RPC 2.0 message handling
+- [x] Initialize/shutdown lifecycle
+- [x] `textDocument/didOpen`, `didChange`, `didSave`, `didClose`
+- [x] stdio transport
+- [x] Capability negotiation and storage
+- [x] Path/URI normalization for macOS, Linux, and Windows
+- [x] Crash detection and safe restart behavior
+- [x] Graceful teardown on last document close and app shutdown
+- [x] Request timeout/cancellation plumbing
+- [x] Backend diagnostics, status, and error events
 
-### #21: LSP - Diagnostics Display
-- [ ] Underline errors/warnings in editor
-- [ ] Gutter icons, problems panel
-- [ ] Click to navigate to issue
+### #73: LSP - Frontend Document Sync ✅
+- [x] Send `didOpen` for newly opened/restored editor files
+- [x] Maintain per-file document versions
+- [x] Debounced `didChange` without dropping latest state
+- [x] Send `didSave` after successful save
+- [x] Send `didClose` on tab close and workspace switch
+- [x] Reconnect handling after language-server crash recovery
+- [x] Surface backend LSP status/errors through frontend events
 
-### #22: LSP - Autocomplete
-- [ ] Trigger on typing (configurable)
-- [ ] Display completion items with icons and docs
-- [ ] Insert with Tab/Enter, support snippets
+### #20: LSP - TypeScript Integration (IN PROGRESS)
+- [ ] Auto-detect TypeScript/JavaScript projects by nearest `tsconfig.json`, `jsconfig.json`, or `package.json`
+- [x] Resolve `typescript-language-server` from workspace-local install first, then PATH
+- [x] Launch `typescript-language-server --stdio`
+- [x] Start/stop the server based on open TS/JS documents in the active workspace
+- [x] Route diagnostics, hover, definition, and completion requests through the shared client
+- [x] Surface actionable errors when server startup fails
+
+### #21: LSP - Diagnostics UX & Problems Panel ✅
+- [x] Convert LSP diagnostics into CodeMirror lint diagnostics
+- [x] Editor underlines and lint gutter markers
+- [x] Problems tab grouped by file
+- [x] Click diagnostics to open and position the editor
+- [x] Status bar counts derived from `lspStore`
+- [x] Clear stale diagnostics on workspace switch
+
+### #22: LSP - Completion, Hover & Definition UX ✅
+- [x] CodeMirror completion source backed by LSP completion requests
+- [x] Trigger-character support and non-blocking request behavior
+- [x] Completion details, documentation, and snippets
+- [x] Hover tooltips backed by LSP hover responses
+- [x] F12 and Cmd/Ctrl-click go-to-definition
+- [x] Cross-file definition navigation through the existing editor open flow
+
+### #75: LSP - Go Integration
+- [ ] Auto-detect Go workspaces by nearest `go.mod`
+- [x] Resolve and launch `gopls` through the shared LSP client
+- [x] Use shared diagnostics, hover, definition, and completion plumbing
+- [ ] Handle multi-module edge cases explicitly
+
+### #76: LSP - Python Integration
+- [ ] Auto-detect Python projects by nearest `pyproject.toml`, `requirements.txt`, or `setup.py`
+- [ ] Resolve `pyright-langserver` from active virtual environment before PATH
+- [x] Resolve and launch `pyright-langserver --stdio` through the shared LSP client
+- [x] Use shared diagnostics, hover, definition, and completion plumbing
 
 ---
 
-## Milestone 6: Search
+## Milestone 6: Search (COMPLETE)
 
-### #23: Search - ripgrep Integration
-- [ ] Call rg binary with search parameters
-- [ ] Parse structured results, respect .gitignore
-- [ ] Support regex, case sensitivity, whole word
+### #23: Search - ripgrep Integration ✅
+- [x] Call `rg` with structured arguments
+- [x] Parse JSON results and respect ignore files
+- [x] Support regex, case sensitivity, and whole word
+- [x] Typed statuses for no matches, missing tool, invalid regex, canceled, and failed
 
-### #24: Search - UI Panel
-- [ ] Search input with options (regex, case, whole word)
-- [ ] Results grouped by file with context
-- [ ] Click result to open file at location (Cmd+Shift+F)
+### #24: Search - UI Panel ✅
+- [x] Search input with regex, case, and whole-word toggles
+- [x] Results grouped by file with context and highlights
+- [x] Cmd+Shift+F opens workspace search
+- [x] Click result to open the file at the match location
+- [x] Keyboard navigation and robust loading/error states
 
-### #25: Search - Find in File
-- [ ] Cmd+F opens search bar in editor
-- [ ] Highlight all matches, navigate between
-- [ ] Replace and Replace All, regex support
+### #25: Search - Find in File ✅
+- [x] Cmd+F opens CodeMirror's in-file search panel
+- [x] Highlight all matches and navigate between them
+- [x] Replace and Replace All through CodeMirror search
+- [x] Regex support
 
 ---
 
@@ -299,7 +364,7 @@ Service Adapter Pattern for connecting to external backends.
 ## Bug Fixes
 
 ### #33: Window Dragging Not Working
-Window cannot be dragged from header area on macOS.
+Likely fixed in code via Wails macOS titlebar configuration and `--wails-draggable: drag` on the header; keep open until verified in a packaged macOS app smoke test.
 
 ### #34: Add Button Type Attributes
 Missing explicit `type` attributes on non-submit buttons.


### PR DESCRIPTION
## Summary

- Mark completed LSP and search work as done in the README and roadmap
- Add the next prioritized ticket list for the remaining LSP, run profile, and workspace tasks
- Refresh architecture notes to match the current frontend/backend modules and state stores

## Impact

This keeps project documentation aligned with the GitHub issue cleanup and clarifies the next implementation priorities.

## Validation

- `git diff --cached --check` before commit
- `git diff --check -- README.md docs/roadmap.md docs/architecture.md` before staging

## Notes

Pre-existing generated Wails file edits were intentionally left out of this PR.