### PR TITLE
[codex] fix LSP stderr capture race

### DIFF
--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -400,12 +400,12 @@ func (m *Manager) startServer(ctx context.Context, key serverKey, config *Server
 		return nil, fmt.Errorf("invalid workspace path %q: %w", key.workspace, err)
 	}
 	if err := client.Initialize(ctx, rootURI, config.InitOptions); err != nil {
-		// Include captured server stderr in the error for diagnostics.
+		// Close waits for the child process and stderr copier so diagnostics are complete.
+		transport.Close()
 		errMsg := err.Error()
 		if stderr := transport.Stderr(); stderr != "" {
 			errMsg = fmt.Sprintf("%s (server stderr: %s)", errMsg, strings.TrimSpace(stderr))
 		}
-		transport.Close()
 		m.emitStatus(key.family, key.workspace, "error", errMsg, config.Command)
 		return nil, fmt.Errorf("initialize %s: %s", config.Command, errMsg)
 	}


### PR DESCRIPTION
## Summary

- Fix a CI flake in LSP startup-error handling by closing the failed stdio transport before reading captured stderr.
- This ensures `exec.Cmd.Wait` and the stderr copy path have completed before manager error/status messages assert on bounded stderr content.

## Root Cause

Develop run `Tests #131` failed in backend job `go test ./...` at `TestManager_InitializeFailureStatusIncludesBoundedStderrAndCommand`. The manager read `transport.Stderr()` immediately after `client.Initialize` returned, before the child-process stderr copier was guaranteed to have flushed. On CI that produced an initialize error without the expected `mock initialize failed:` stderr prefix.

Failing run: https://github.com/kstruzzieri/firn-ide/actions/runs/25710128486

## Validation

- `go test ./internal/lsp -run TestManager_InitializeFailureStatusIncludesBoundedStderrAndCommand -count=50 -v`
- `go test ./internal/lsp`
- `go test ./...`
- `git diff --cached --check`

## Notes

Pre-existing generated Wails file edits remain unstaged and are not part of this PR.