### PR TITLE
lsp: per-package TypeScript project-root detection (#20)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,7 +26,7 @@ Firn IDE brings the focused, keyboard-first productivity of JetBrains IDEs to a 
 | Milestone 2: Terminal Integration | **IN PROGRESS** | #10-12 complete, #47 open |
 | Milestone 3: Workspace Management | **IN PROGRESS** | #13-15 complete, #53-54 open |
 | Milestone 4: Run Profiles | **IN PROGRESS** | #16, #59-61 complete; #17-18, #62-64, #71 open |
-| Milestone 5: Language Server Protocol | **IN PROGRESS** | #19, #21-22, #73 complete; #20, #74-76 open |
+| Milestone 5: Language Server Protocol | **IN PROGRESS** | #19-22, #73 complete; #74-76 open |
 | Milestone 6: Search | **COMPLETE** | #23-25 |
 | Milestone 7: Git Integration | Not started | #26-27 |
 | Performance | Not started | #37-39 |
@@ -40,7 +40,7 @@ Firn IDE brings the focused, keyboard-first productivity of JetBrains IDEs to a 
 
 ## Next Priorities
 
-1. **#20: Finish TypeScript project-root detection** — the LSP TypeScript path is functional, but this ticket still requires nearest `tsconfig.json`, `jsconfig.json`, or `package.json` root resolution rather than only using the active workspace root.
+1. **#75 / #76: Finish LSP epic** — apply the `ResolveProjectRoot(filePath, workspaceRoot, markers)` helper landed for #20 to nearest-`go.mod` (Go) and nearest-`pyproject.toml` / `requirements.txt` / `setup.py` (Python) detection. Closes epic #74.
 2. **#62: Run Profiles - Clickable Error Links** — parse common `file:line:col` output formats and jump from run output to source.
 3. **#64: Run Profiles - Environment Variants** — complete `ActiveVariant` env-file resolution and add the frontend variant selector.
 4. **#63: Run Profiles - Compound Profile Execution** — add sequential step execution, stop-on-failure, and per-step UI.
@@ -197,7 +197,7 @@ Epic for Firn's production LSP foundation and TypeScript vertical slice.
 - [x] Frontend document sync
 - [x] Diagnostics UX and Problems panel
 - [x] Completion, hover, and definition UX
-- [ ] TypeScript project-root detection completion (#20)
+- [x] TypeScript project-root detection completion (#20)
 
 ### #19: LSP - Client Foundation ✅
 - [x] JSON-RPC 2.0 message handling
@@ -220,11 +220,11 @@ Epic for Firn's production LSP foundation and TypeScript vertical slice.
 - [x] Reconnect handling after language-server crash recovery
 - [x] Surface backend LSP status/errors through frontend events
 
-### #20: LSP - TypeScript Integration (IN PROGRESS)
-- [ ] Auto-detect TypeScript/JavaScript projects by nearest `tsconfig.json`, `jsconfig.json`, or `package.json`
-- [x] Resolve `typescript-language-server` from workspace-local install first, then PATH
+### #20: LSP - TypeScript Integration ✅
+- [x] Auto-detect TypeScript/JavaScript projects by nearest `tsconfig.json`, `jsconfig.json`, or `package.json` (bounded by active workspace)
+- [x] Resolve `typescript-language-server` from project-local install first, then PATH
 - [x] Launch `typescript-language-server --stdio`
-- [x] Start/stop the server based on open TS/JS documents in the active workspace
+- [x] Start/stop the server based on open TS/JS documents (per detected project root, so monorepo packages get separate servers)
 - [x] Route diagnostics, hover, definition, and completion requests through the shared client
 - [x] Surface actionable errors when server startup fails
 

--- a/frontend/src/__tests__/hooks/useLSPDocumentSync.test.ts
+++ b/frontend/src/__tests__/hooks/useLSPDocumentSync.test.ts
@@ -495,6 +495,50 @@ describe('useLSPDocumentSync', () => {
       expect(mockDidOpen).toHaveBeenCalledTimes(1);
     });
 
+    it('should re-send didOpen when reconnect workspace is a nested project root', async () => {
+      // After PR #95, backend emits payload.workspace as the detected TS
+      // project root (e.g. /repo/packages/ui), not the active workspace
+      // (/repo). Equality-based filtering dropped these events and left
+      // restarted servers with no open documents until the file was reopened.
+      const getReconnectHandler = captureReconnectHandler();
+
+      renderHook(() => useLSPDocumentSync());
+
+      act(() => {
+        openTestFile({
+          id: '/test/workspace/packages/ui/main.ts',
+          name: 'main.ts',
+          path: '/test/workspace/packages/ui/main.ts',
+        });
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockDidOpen).toHaveBeenCalledTimes(1);
+
+      const reconnectHandler = getReconnectHandler();
+      act(() => {
+        reconnectHandler!({
+          workspace: '/test/workspace/packages/ui',
+          documents: ['file:///test/workspace/packages/ui/main.ts'],
+        });
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockDidOpen).toHaveBeenCalledTimes(2);
+      expect(mockDidOpen).toHaveBeenLastCalledWith(
+        '/test/workspace/packages/ui/main.ts',
+        'typescript',
+        expect.any(Number),
+        'const x = 1;'
+      );
+    });
+
     it('should match reconnect URIs with percent-encoded Unix paths', async () => {
       const getReconnectHandler = captureReconnectHandler();
 

--- a/frontend/src/__tests__/hooks/useLSPEvents.test.ts
+++ b/frontend/src/__tests__/hooks/useLSPEvents.test.ts
@@ -266,4 +266,72 @@ describe('useLSPEvents', () => {
 
     cancelFns.forEach((fn) => expect(fn).toHaveBeenCalled());
   });
+
+  // --- Project-root containment (#20) ---
+
+  it('accepts lsp:diagnostics from a project root inside the active workspace', () => {
+    // Backend now emits diagnostics with workspace = detected project root,
+    // which is *inside* the active workspace for TypeScript monorepo files.
+    // The stale-event guard must accept these, not just exact matches.
+    const handlers = captureEventHandlers();
+    setActiveWorkspace('/project');
+    renderHook(() => useLSPEvents());
+
+    act(() => {
+      handlers['lsp:diagnostics']({
+        workspace: '/project/frontend',
+        uri: 'file:///project/frontend/src/App.tsx',
+        diagnostics: [
+          {
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } },
+            severity: 1,
+            message: 'Type error from nested package',
+          },
+        ],
+      });
+    });
+
+    expect(useLSPStore.getState().diagnostics.size).toBe(1);
+  });
+
+  it('accepts lsp:status from a project root inside the active workspace', () => {
+    const handlers = captureEventHandlers();
+    setActiveWorkspace('/project');
+    renderHook(() => useLSPEvents());
+
+    act(() => {
+      handlers['lsp:status']({
+        family: 'typescript',
+        workspace: '/project/frontend',
+        state: 'ready',
+      });
+    });
+
+    const statuses = useLSPStore.getState().serverStatuses;
+    expect(statuses.size).toBe(1);
+    expect(Array.from(statuses.values())[0].workspace).toBe('/project/frontend');
+  });
+
+  it('rejects lsp:diagnostics whose workspace prefix-collides with the active workspace', () => {
+    // /project-other must not be classified as inside /project.
+    const handlers = captureEventHandlers();
+    setActiveWorkspace('/project');
+    renderHook(() => useLSPEvents());
+
+    act(() => {
+      handlers['lsp:diagnostics']({
+        workspace: '/project-other',
+        uri: 'file:///project-other/test.ts',
+        diagnostics: [
+          {
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 5 } },
+            severity: 1,
+            message: 'should not appear',
+          },
+        ],
+      });
+    });
+
+    expect(useLSPStore.getState().diagnostics.size).toBe(0);
+  });
 });

--- a/frontend/src/__tests__/stores/lspStore.test.ts
+++ b/frontend/src/__tests__/stores/lspStore.test.ts
@@ -6,7 +6,10 @@ import {
   useLSPInfoCount,
   useLSPWarningCount,
   useGroupedDiagnostics,
+  findServerStatusForFile,
+  pathContainsOrEquals,
   type LSPDiagnostic,
+  type LSPServerStatus,
 } from '../../stores/lspStore';
 
 beforeEach(() => {
@@ -307,6 +310,123 @@ describe('lspStore', () => {
       useLSPStore.getState().clearWorkspaceState('/project');
 
       expect(useLSPStore.getState().serverStatuses.has('/project::typescript')).toBe(false);
+    });
+
+    it('clears nested project-root statuses inside the workspace', () => {
+      // TypeScript project-root detection (#20) means a single workspace can
+      // host multiple servers keyed by nested project roots. Workspace cleanup
+      // must sweep all of them.
+      const state = useLSPStore.getState();
+      state.setServerStatus({
+        family: 'typescript',
+        workspace: '/project/frontend',
+        state: 'ready',
+      });
+      state.setServerStatus({
+        family: 'typescript',
+        workspace: '/project/admin',
+        state: 'ready',
+      });
+      state.setServerStatus({
+        family: 'typescript',
+        workspace: '/other-project',
+        state: 'ready',
+      });
+
+      useLSPStore.getState().clearWorkspaceState('/project');
+
+      const statuses = useLSPStore.getState().serverStatuses;
+      expect(statuses.size).toBe(1);
+      expect(Array.from(statuses.values())[0].workspace).toBe('/other-project');
+    });
+  });
+
+  describe('pathContainsOrEquals', () => {
+    it('treats equal paths as contained', () => {
+      expect(pathContainsOrEquals('/a/b', '/a/b')).toBe(true);
+    });
+
+    it('accepts strict descendants', () => {
+      expect(pathContainsOrEquals('/a/b', '/a/b/c')).toBe(true);
+      expect(pathContainsOrEquals('/a/b', '/a/b/c/d/e.ts')).toBe(true);
+    });
+
+    it('rejects prefix collisions', () => {
+      expect(pathContainsOrEquals('/a/b', '/a/bc')).toBe(false);
+      expect(pathContainsOrEquals('/foo', '/foobar')).toBe(false);
+    });
+
+    it('rejects ancestors and siblings', () => {
+      expect(pathContainsOrEquals('/a/b', '/a')).toBe(false);
+      expect(pathContainsOrEquals('/a/b', '/a/c')).toBe(false);
+    });
+
+    it('treats empty inputs as not contained', () => {
+      expect(pathContainsOrEquals('', '/a')).toBe(false);
+      expect(pathContainsOrEquals('/a', '')).toBe(false);
+    });
+  });
+
+  describe('findServerStatusForFile', () => {
+    const ready = (workspace: string, family = 'typescript'): LSPServerStatus => ({
+      family,
+      workspace,
+      state: 'ready',
+    });
+
+    it('returns undefined when no status covers the file', () => {
+      const statuses = new Map([['/proj::typescript', ready('/proj')]]);
+      expect(findServerStatusForFile(statuses, '/elsewhere/foo.ts', 'typescript')).toBeUndefined();
+    });
+
+    it('picks the longest-matching workspace root', () => {
+      // Monorepo with a repo-root server (legacy single workspace install) AND
+      // a per-package server. A file inside the package must resolve to the
+      // package-specific status, not the repo-root one.
+      const repoRoot = ready('/repo');
+      const pkgRoot = ready('/repo/packages/ui');
+      const statuses = new Map([
+        ['/repo::typescript', repoRoot],
+        ['/repo/packages/ui::typescript', pkgRoot],
+      ]);
+
+      const got = findServerStatusForFile(
+        statuses,
+        '/repo/packages/ui/src/Button.tsx',
+        'typescript'
+      );
+      expect(got).toBe(pkgRoot);
+    });
+
+    it('falls back to a covering workspace-root status', () => {
+      const statuses = new Map([['/repo::typescript', ready('/repo')]]);
+      const got = findServerStatusForFile(statuses, '/repo/src/index.ts', 'typescript');
+      expect(got?.workspace).toBe('/repo');
+    });
+
+    it('ignores statuses for other families', () => {
+      const statuses = new Map([
+        ['/repo::go', ready('/repo', 'go')],
+        ['/repo/pkg::typescript', ready('/repo/pkg')],
+      ]);
+      const got = findServerStatusForFile(statuses, '/repo/pkg/a.ts', 'go');
+      // No Go status covers /repo/pkg/a.ts because Go status is rooted at /repo
+      // and the file is at /repo/pkg/a.ts — so containment matches but family
+      // discrimination must keep TS out and only the Go status remains.
+      expect(got?.family).toBe('go');
+      expect(got?.workspace).toBe('/repo');
+    });
+
+    it('does not confuse prefix-collision paths', () => {
+      const statuses = new Map([['/repo/ba::typescript', ready('/repo/ba')]]);
+      // /repo/bar/index.ts must NOT match /repo/ba
+      const got = findServerStatusForFile(statuses, '/repo/bar/index.ts', 'typescript');
+      expect(got).toBeUndefined();
+    });
+
+    it('returns undefined for empty file path', () => {
+      const statuses = new Map([['/repo::typescript', ready('/repo')]]);
+      expect(findServerStatusForFile(statuses, '', 'typescript')).toBeUndefined();
     });
   });
 });

--- a/frontend/src/components/Editor/CodeMirrorEditor.tsx
+++ b/frontend/src/components/Editor/CodeMirrorEditor.tsx
@@ -24,7 +24,7 @@ import {
   updateEditorDiagnostics,
 } from './codemirror';
 import { useIDEStore, type EditorNavigationRequest } from '../../stores/ideStore';
-import { useLSPStore, serverStatusKey } from '../../stores/lspStore';
+import { useLSPStore, findServerStatusForFile } from '../../stores/lspStore';
 import { filePathToURI } from '../../utils/lspUri';
 import { lspFamilyForFile } from '../../utils/lspLanguageId';
 import styles from './CodeMirrorEditor.module.css';
@@ -251,14 +251,14 @@ export const CodeMirrorEditor = memo(function CodeMirrorEditor({
       const currentView = editorRef.current;
       if (!currentView) return;
 
-      const workspacePath = useIDEStore.getState().workspace?.path;
-      const status = workspacePath
-        ? useLSPStore.getState().serverStatuses.get(serverStatusKey(workspacePath, family))
-        : undefined;
+      // fileId is the file's local path (EditorFile.id === EditorFile.path).
+      // Status lookup is by file path so nested project-root servers (#20)
+      // drive completion/hover correctly inside monorepo packages.
+      const status = findServerStatusForFile(useLSPStore.getState().serverStatuses, fileId, family);
       const isReady = status?.state === 'ready';
       const triggerCharacters = status?.completionTriggerCharacters ?? [];
       const nextConfigKey = isReady
-        ? `${workspacePath ?? ''}::${family}::${triggerCharacters.join('\u0000')}`
+        ? `${status?.workspace ?? ''}::${family}::${triggerCharacters.join('\u0000')}`
         : null;
 
       if (nextConfigKey === lastConfigKey) return;
@@ -278,16 +278,12 @@ export const CodeMirrorEditor = memo(function CodeMirrorEditor({
 
     applyLSPFeatureConfiguration();
 
-    // Use reference equality on the status entry to skip work during unrelated
-    // store updates (e.g. diagnostics arriving on every keystroke).
-    let prevStatus = useLSPStore
-      .getState()
-      .serverStatuses.get(serverStatusKey(useIDEStore.getState().workspace?.path ?? '', family));
+    // Use reference equality on the resolved status entry to skip work during
+    // unrelated store updates (e.g. diagnostics arriving on every keystroke).
+    let prevStatus = findServerStatusForFile(useLSPStore.getState().serverStatuses, fileId, family);
 
     const cancelStatus = useLSPStore.subscribe((state) => {
-      const workspacePath = useIDEStore.getState().workspace?.path;
-      if (!workspacePath) return;
-      const status = state.serverStatuses.get(serverStatusKey(workspacePath, family));
+      const status = findServerStatusForFile(state.serverStatuses, fileId, family);
       if (status === prevStatus) return;
       prevStatus = status;
       applyLSPFeatureConfiguration();

--- a/frontend/src/hooks/useLSPDocumentSync.ts
+++ b/frontend/src/hooks/useLSPDocumentSync.ts
@@ -3,6 +3,7 @@ import { useIDEStore, type EditorFile } from '../stores/ideStore';
 import { EventsOn } from '../../wailsjs/runtime/runtime';
 import { languageIdForFile } from '../utils/lspLanguageId';
 import { filePathToURI } from '../utils/lspUri';
+import { pathContainsOrEquals } from '../stores/lspStore';
 import {
   closeLSPDocument,
   forgetLSPDocument,
@@ -137,8 +138,15 @@ export function useLSPDocumentSync() {
       const reconnectedURIs = payload?.documents;
       if (!reconnectedURIs || reconnectedURIs.length === 0) return;
 
+      // payload.workspace is the server's project root (may be a nested
+      // package), not the active workspace path — use containment so
+      // nested TypeScript project reconnects aren't dropped.
       const activeWorkspace = useIDEStore.getState().workspace?.path;
-      if (payload.workspace && payload.workspace !== activeWorkspace) {
+      if (
+        activeWorkspace &&
+        payload.workspace &&
+        !pathContainsOrEquals(activeWorkspace, payload.workspace)
+      ) {
         return;
       }
 

--- a/frontend/src/hooks/useLSPEvents.ts
+++ b/frontend/src/hooks/useLSPEvents.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { EventsOn } from '../../wailsjs/runtime/runtime';
-import { useLSPStore } from '../stores/lspStore';
+import { useLSPStore, pathContainsOrEquals } from '../stores/lspStore';
 import { useIDEStore } from '../stores/ideStore';
 import type { LSPDiagnostic, LSPServerStatus } from '../stores/lspStore';
 import { canonicalizeFileURI } from '../utils/lspUri';
@@ -18,9 +18,17 @@ interface ErrorPayload {
   message: string;
 }
 
+/**
+ * Accepts LSP backend events whose `workspace` field is at or inside the
+ * active workspace. TypeScript project-root detection (#20) emits events
+ * keyed by the detected project root, which is a path *inside* the active
+ * workspace; before #20 this was always an exact match. Containment keeps
+ * the stale-event guard correct for both legacy and project-root events.
+ */
 function isActiveWorkspaceEvent(workspace?: string): boolean {
   const activeWorkspace = useIDEStore.getState().workspace?.path;
-  return !activeWorkspace || !workspace || workspace === activeWorkspace;
+  if (!activeWorkspace || !workspace) return true;
+  return pathContainsOrEquals(activeWorkspace, workspace);
 }
 
 /**

--- a/frontend/src/stores/lspStore.ts
+++ b/frontend/src/stores/lspStore.ts
@@ -1,6 +1,28 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { fileURIToPath } from '../utils/lspUri';
+import { getPlatform } from '../utils/platform';
+
+const pathSep = getPlatform() === 'windows' ? '\\' : '/';
+
+/**
+ * Reports whether `child` is exactly `parent` or strictly below it.
+ *
+ * Both arguments must use the host platform's path separator and be
+ * cleaned absolute paths (the backend cleans them via filepath.Clean
+ * before emitting). A separator-suffixed prefix check is used so that
+ * "/foo/bar" is not falsely classified as a child of "/foo/ba".
+ *
+ * Case sensitivity follows the underlying filesystem behavior of the
+ * paths — since both sides come from the same Go source they will be
+ * cased consistently in practice.
+ */
+export function pathContainsOrEquals(parent: string, child: string): boolean {
+  if (!parent || !child) return false;
+  if (parent === child) return true;
+  const parentWithSep = parent.endsWith(pathSep) ? parent : parent + pathSep;
+  return child.startsWith(parentWithSep);
+}
 
 // --- Types ---
 
@@ -124,9 +146,13 @@ export const useLSPStore = create<LSPStore>()(
       clearWorkspaceState: (workspace) =>
         set(
           (state) => {
+            // Server status entries may be keyed by nested project roots
+            // (TypeScript monorepo packages). Clearing a workspace must
+            // sweep every status whose root is at or beneath the cleared
+            // workspace path, not just exact matches.
             const nextStatuses = new Map(state.serverStatuses);
             for (const [key, status] of nextStatuses) {
-              if (status.workspace === workspace) {
+              if (pathContainsOrEquals(workspace, status.workspace)) {
                 nextStatuses.delete(key);
               }
             }
@@ -159,6 +185,41 @@ export const useLSPStore = create<LSPStore>()(
     { name: 'lsp-store' }
   )
 );
+
+/**
+ * Finds the most specific server status for a file path.
+ *
+ * Since TypeScript root detection (#20) keys servers by detected project
+ * root rather than the active workspace, the editor needs to look up
+ * status by the file's path: it picks the status whose `workspace` is
+ * the longest prefix of `filePath` for the matching family. This makes
+ * completion trigger characters and ready-state UX work correctly for
+ * nested monorepo packages.
+ *
+ * For language families that still key by active workspace root, the
+ * lookup also works because the workspace prefix is the only candidate
+ * and it always wins.
+ *
+ * Returns undefined when no server for the family covers the file.
+ */
+export function findServerStatusForFile(
+  serverStatuses: Map<string, LSPServerStatus>,
+  filePath: string,
+  family: string
+): LSPServerStatus | undefined {
+  if (!filePath) return undefined;
+  let best: LSPServerStatus | undefined;
+  let bestLen = -1;
+  for (const status of serverStatuses.values()) {
+    if (status.family !== family) continue;
+    if (!pathContainsOrEquals(status.workspace, filePath)) continue;
+    if (status.workspace.length > bestLen) {
+      best = status;
+      bestLen = status.workspace.length;
+    }
+  }
+  return best;
+}
 
 // --- Reactive selector hooks ---
 

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -49,6 +49,18 @@ type Manager struct {
 	mu      sync.Mutex
 	servers map[serverKey]*serverEntry
 
+	// docKeys maps an open document URI to the serverKey of the server
+	// that owns it. Populated by DidOpen after ensureServer succeeds, used
+	// by serverForPath / DidClose to skip the project-root filesystem walk
+	// on every subsequent call (DidChange, DidSave, Hover, Definition,
+	// Complete, ResolveCompletionItem). Removed when the document's
+	// refCount hits zero.
+	//
+	// The plan explicitly defers hot-migration when a marker appears mid-
+	// session, so caching the resolved root is consistent with the spec:
+	// the next open/reopen picks up the new root.
+	docKeys map[string]serverKey
+
 	// workspaceRoot is the active workspace root path (not URI).
 	workspaceRoot string
 
@@ -85,6 +97,7 @@ func NewManager(emitter EventEmitter) *Manager {
 		registry: NewRegistry(),
 		emitter:  emitter,
 		servers:  make(map[serverKey]*serverEntry),
+		docKeys:  make(map[string]serverKey),
 	}
 }
 
@@ -157,6 +170,10 @@ func (m *Manager) DidOpen(ctx context.Context, path, languageID string, version 
 	} else {
 		entry.openDocs[uri] = &docState{refCount: 1, version: version}
 	}
+	// Cache the resolved key so that DidChange / DidSave / Hover /
+	// Definition / Complete / ResolveCompletionItem can route this URI
+	// without re-walking the filesystem on every keystroke.
+	m.docKeys[uri] = serverKey{family: family, workspace: workspace}
 	m.mu.Unlock()
 
 	// Only send didOpen to the server on the first open
@@ -219,22 +236,27 @@ func (m *Manager) DidClose(ctx context.Context, path string) error {
 		return fmt.Errorf("invalid path %q: %w", path, err)
 	}
 
-	workspace, rerr := m.projectRootForPath(family, path)
-	if rerr != nil {
-		// No workspace, or path outside workspace — no server to close against.
+	m.mu.Lock()
+	// Use the cached key from DidOpen rather than re-resolving the project
+	// root — the document's owning server is fixed at open time.
+	key, cached := m.docKeys[uri]
+	if !cached {
+		// Document was never opened (or already fully closed). Silent no-op.
+		m.mu.Unlock()
 		return nil
 	}
-
-	m.mu.Lock()
-	key := serverKey{family: family, workspace: workspace}
 	entry, ok := m.servers[key]
 	if !ok {
+		// Server already torn down (workspace switch, crash, etc.). Clean up
+		// the stale cache entry and bail.
+		delete(m.docKeys, uri)
 		m.mu.Unlock()
 		return nil
 	}
 
 	ds, docExists := entry.openDocs[uri]
 	if !docExists {
+		delete(m.docKeys, uri)
 		m.mu.Unlock()
 		return nil
 	}
@@ -242,6 +264,7 @@ func (m *Manager) DidClose(ctx context.Context, path string) error {
 	ds.refCount--
 	if ds.refCount <= 0 {
 		delete(entry.openDocs, uri)
+		delete(m.docKeys, uri)
 	}
 	shouldShutdown := len(entry.openDocs) == 0
 	m.mu.Unlock()
@@ -602,6 +625,12 @@ func (m *Manager) monitorServer(key serverKey, entry *serverEntry) {
 // serverForPath finds the server entry responsible for the given file path.
 // For TypeScript-family files the lookup is keyed by the detected project
 // root, so nested packages route to their own server instance.
+//
+// Hot-path callers (DidChange/DidSave/Hover/Definition/Complete) call this
+// per keystroke or per request; it MUST avoid filesystem I/O. The cache
+// populated by DidOpen makes the common case a single map lookup. The
+// fallback resolution path runs only for unopened documents, which the
+// existing API contract treats as no-ops anyway.
 func (m *Manager) serverForPath(path string) (*serverEntry, string, serverKey) {
 	ext := filepath.Ext(path)
 	family := m.registry.FamilyForExtension(ext)
@@ -614,6 +643,24 @@ func (m *Manager) serverForPath(path string) (*serverEntry, string, serverKey) {
 		return nil, "", serverKey{}
 	}
 
+	m.mu.Lock()
+	if key, cached := m.docKeys[uri]; cached {
+		entry, ok := m.servers[key]
+		if !ok {
+			// Server was torn down out from under the cache — clean up.
+			delete(m.docKeys, uri)
+			m.mu.Unlock()
+			return nil, "", key
+		}
+		m.mu.Unlock()
+		return entry, uri, key
+	}
+	m.mu.Unlock()
+
+	// Fallback for documents that were never DidOpen'd through this manager.
+	// Existing callers (DidChange/DidSave/Hover/etc.) already treat a nil
+	// entry as a silent no-op, so this branch effectively just preserves
+	// "unknown document → no server" semantics rather than crashing.
 	workspace, rerr := m.projectRootForPath(family, path)
 	if rerr != nil {
 		return nil, "", serverKey{}
@@ -621,7 +668,6 @@ func (m *Manager) serverForPath(path string) (*serverEntry, string, serverKey) {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-
 	key := serverKey{family: family, workspace: workspace}
 	entry, ok := m.servers[key]
 	if !ok {

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -655,7 +655,7 @@ func (m *Manager) projectRootForPath(family, path string) (string, error) {
 	if len(markers) == 0 {
 		return workspace, nil
 	}
-	return ResolveProjectRoot(path, workspace, markers)
+	return ResolveProjectRoot(path, workspace, markers, projectRootSkipDirs(family))
 }
 
 // projectRootMarkers returns the marker filenames used to detect a project
@@ -667,6 +667,22 @@ func projectRootMarkers(family string) []string {
 	switch family {
 	case "typescript":
 		return []string{"tsconfig.json", "jsconfig.json", "package.json"}
+	}
+	return nil
+}
+
+// projectRootSkipDirs returns directory segments whose marker matches must
+// be ignored during project-root resolution for the given family.
+//
+// For TypeScript this returns ["node_modules"] so that navigating into a
+// dependency (e.g. via go-to-definition) does NOT spawn a per-dependency
+// LSP server rooted at node_modules/<dep>/package.json. Instead the walk
+// continues through node_modules until it finds the consuming package's
+// project root above.
+func projectRootSkipDirs(family string) []string {
+	switch family {
+	case "typescript":
+		return []string{"node_modules"}
 	}
 	return nil
 }

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -3,6 +3,7 @@ package lsp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"path/filepath"
@@ -10,6 +11,11 @@ import (
 	"sync"
 	"time"
 )
+
+// errNoWorkspaceRoot signals that an LSP method was called before
+// SetWorkspaceRoot. Only DidOpen surfaces this to the caller; other entry
+// points treat it as a silent no-op.
+var errNoWorkspaceRoot = errors.New("no workspace root set")
 
 const (
 	// serverShutdownTimeout is the time allowed for a single server to shut down gracefully.
@@ -84,10 +90,21 @@ func NewManager(emitter EventEmitter) *Manager {
 
 // SetWorkspaceRoot updates the active workspace root path.
 // This does NOT shut down existing servers — call ShutdownAll first if switching workspaces.
+//
+// The stored root is cleaned and made absolute. This invariant lets later
+// boundary comparisons (e.g. pathContains for crash-recovery guards) treat
+// the workspace prefix consistently regardless of whether the caller passed
+// a trailing separator or a relative path.
 func (m *Manager) SetWorkspaceRoot(root string) {
+	cleaned := root
+	if root != "" {
+		if abs, err := filepath.Abs(root); err == nil {
+			cleaned = filepath.Clean(abs)
+		}
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.workspaceRoot = root
+	m.workspaceRoot = cleaned
 	m.stopped = false
 }
 
@@ -116,12 +133,15 @@ func (m *Manager) DidOpen(ctx context.Context, path, languageID string, version 
 		return fmt.Errorf("invalid path %q: %w", path, err)
 	}
 
-	m.mu.Lock()
-	workspace := m.workspaceRoot
-	m.mu.Unlock()
-
-	if workspace == "" {
-		return fmt.Errorf("no workspace root set")
+	workspace, err := m.projectRootForPath(family, path)
+	if err != nil {
+		if errors.Is(err, errNoWorkspaceRoot) {
+			return fmt.Errorf("no workspace root set")
+		}
+		// Path outside the active workspace or otherwise unresolvable: skip
+		// silently so files opened transiently outside the LSP scope (e.g.,
+		// preview of a sibling repo) do not surface noisy errors.
+		return nil
 	}
 
 	entry, err := m.ensureServer(ctx, family, workspace)
@@ -199,8 +219,13 @@ func (m *Manager) DidClose(ctx context.Context, path string) error {
 		return fmt.Errorf("invalid path %q: %w", path, err)
 	}
 
+	workspace, rerr := m.projectRootForPath(family, path)
+	if rerr != nil {
+		// No workspace, or path outside workspace — no server to close against.
+		return nil
+	}
+
 	m.mu.Lock()
-	workspace := m.workspaceRoot
 	key := serverKey{family: family, workspace: workspace}
 	entry, ok := m.servers[key]
 	if !ok {
@@ -411,7 +436,7 @@ func (m *Manager) startServer(ctx context.Context, key serverKey, config *Server
 	}
 
 	m.mu.Lock()
-	if m.stopped || m.workspaceRoot != key.workspace {
+	if m.stopped || !pathContains(m.workspaceRoot, key.workspace) {
 		m.mu.Unlock()
 		shutCtx, cancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
 		defer cancel()
@@ -535,11 +560,12 @@ func (m *Manager) monitorServer(key serverKey, entry *serverEntry) {
 
 	time.Sleep(backoff)
 
-	// After backoff, verify the manager hasn't been shut down and the workspace
-	// hasn't changed. Without this check, ShutdownAll or a workspace switch during
-	// the sleep would still result in a stray server being resurrected.
+	// After backoff, verify the manager hasn't been shut down and the project
+	// root is still inside the active workspace. Without this check, a
+	// ShutdownAll or a workspace switch during the sleep would still result in
+	// a stray server being resurrected.
 	m.mu.Lock()
-	if m.stopped || m.workspaceRoot != key.workspace {
+	if m.stopped || !pathContains(m.workspaceRoot, key.workspace) {
 		m.mu.Unlock()
 		log.Printf("lsp: skipping %s restart — manager stopped or workspace changed", key.family)
 		return
@@ -574,6 +600,8 @@ func (m *Manager) monitorServer(key serverKey, entry *serverEntry) {
 }
 
 // serverForPath finds the server entry responsible for the given file path.
+// For TypeScript-family files the lookup is keyed by the detected project
+// root, so nested packages route to their own server instance.
 func (m *Manager) serverForPath(path string) (*serverEntry, string, serverKey) {
 	ext := filepath.Ext(path)
 	family := m.registry.FamilyForExtension(ext)
@@ -586,15 +614,61 @@ func (m *Manager) serverForPath(path string) (*serverEntry, string, serverKey) {
 		return nil, "", serverKey{}
 	}
 
+	workspace, rerr := m.projectRootForPath(family, path)
+	if rerr != nil {
+		return nil, "", serverKey{}
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	key := serverKey{family: family, workspace: m.workspaceRoot}
+	key := serverKey{family: family, workspace: workspace}
 	entry, ok := m.servers[key]
 	if !ok {
 		return nil, "", key
 	}
 	return entry, uri, key
+}
+
+// projectRootForPath returns the workspace key for the given file path.
+// For TypeScript-family files this is the nearest project root found by
+// upward walk (tsconfig.json > jsconfig.json > package.json), bounded by the
+// active workspace. For other families it returns the active workspace root
+// unchanged.
+//
+// Must be called WITHOUT the manager lock held — it performs filesystem
+// stat calls during marker probing.
+//
+// Returns errNoWorkspaceRoot if SetWorkspaceRoot has not been called, or
+// ErrPathOutsideWorkspace (wrapped via ResolveProjectRoot) if the file is
+// outside the active workspace.
+func (m *Manager) projectRootForPath(family, path string) (string, error) {
+	m.mu.Lock()
+	workspace := m.workspaceRoot
+	m.mu.Unlock()
+
+	if workspace == "" {
+		return "", errNoWorkspaceRoot
+	}
+
+	markers := projectRootMarkers(family)
+	if len(markers) == 0 {
+		return workspace, nil
+	}
+	return ResolveProjectRoot(path, workspace, markers)
+}
+
+// projectRootMarkers returns the marker filenames used to detect a project
+// root for the given language family. Returning an empty slice means root
+// detection is disabled for the family and callers should use the active
+// workspace root directly. Go and Python are intentionally not wired up here
+// yet — see issues #75 and #76.
+func projectRootMarkers(family string) []string {
+	switch family {
+	case "typescript":
+		return []string{"tsconfig.json", "jsconfig.json", "package.json"}
+	}
+	return nil
 }
 
 func (m *Manager) logRequestFailure(key serverKey, method string, err error) {
@@ -630,7 +704,7 @@ func (m *Manager) handleNotification(key serverKey, method string, params json.R
 		}
 
 		m.mu.Lock()
-		if m.stopped || m.workspaceRoot != key.workspace {
+		if m.stopped || !pathContains(m.workspaceRoot, key.workspace) {
 			m.mu.Unlock()
 			return
 		}

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -3,6 +3,7 @@ package lsp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1049,5 +1050,305 @@ func waitFor(t *testing.T, timeout time.Duration, desc string, cond func() bool)
 		default:
 			time.Sleep(10 * time.Millisecond)
 		}
+	}
+}
+
+// --- Per-project-root routing (#20) ---
+
+func TestManager_ProjectRootForPath_TypeScriptUsesNearestMarker(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	ws := t.TempDir()
+	touch(t, filepath.Join(ws, "package.json"))              // repo-root
+	touch(t, filepath.Join(ws, "frontend", "tsconfig.json")) // package-local
+	file := filepath.Join(ws, "frontend", "src", "App.tsx")
+	touch(t, file)
+	mgr.SetWorkspaceRoot(ws)
+
+	root, err := mgr.projectRootForPath("typescript", file)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(ws, "frontend")
+	if root != want {
+		t.Errorf("root = %q, want %q (nearest tsconfig.json should win)", root, want)
+	}
+}
+
+func TestManager_ProjectRootForPath_GoReturnsWorkspaceUnchanged(t *testing.T) {
+	// Go nearest-go.mod detection is deferred to #75. This ticket keeps Go
+	// behavior identical: project root == active workspace root.
+	mgr, _ := newTestManager(t)
+	ws := t.TempDir()
+	touch(t, filepath.Join(ws, "cmd", "tool", "go.mod"))
+	file := filepath.Join(ws, "cmd", "tool", "main.go")
+	touch(t, file)
+	mgr.SetWorkspaceRoot(ws)
+
+	root, err := mgr.projectRootForPath("go", file)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if root != ws {
+		t.Errorf("Go project root = %q, want workspace %q (Go detection lands with #75)", root, ws)
+	}
+}
+
+func TestManager_ProjectRootForPath_PythonReturnsWorkspaceUnchanged(t *testing.T) {
+	// Python nearest-pyproject.toml detection is deferred to #76.
+	mgr, _ := newTestManager(t)
+	ws := t.TempDir()
+	touch(t, filepath.Join(ws, "service", "pyproject.toml"))
+	file := filepath.Join(ws, "service", "src", "app.py")
+	touch(t, file)
+	mgr.SetWorkspaceRoot(ws)
+
+	root, err := mgr.projectRootForPath("python", file)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if root != ws {
+		t.Errorf("Python project root = %q, want workspace %q (Python detection lands with #76)", root, ws)
+	}
+}
+
+func TestManager_ProjectRootForPath_PathOutsideWorkspaceReturnsError(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	ws := t.TempDir()
+	outside := t.TempDir()
+	file := filepath.Join(outside, "stray.ts")
+	touch(t, file)
+	mgr.SetWorkspaceRoot(ws)
+
+	_, err := mgr.projectRootForPath("typescript", file)
+	if !errors.Is(err, ErrPathOutsideWorkspace) {
+		t.Fatalf("got error %v, want ErrPathOutsideWorkspace", err)
+	}
+}
+
+func TestManager_ProjectRootForPath_NoWorkspaceReturnsSentinel(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	_, err := mgr.projectRootForPath("typescript", "/tmp/foo.ts")
+	if !errors.Is(err, errNoWorkspaceRoot) {
+		t.Fatalf("got error %v, want errNoWorkspaceRoot", err)
+	}
+}
+
+func TestManager_DidOpen_PathOutsideWorkspaceIsSilentNoop(t *testing.T) {
+	mgr, collector := newTestManager(t)
+	ws := t.TempDir()
+	outside := t.TempDir()
+	file := filepath.Join(outside, "stray.ts")
+	touch(t, file)
+	mgr.SetWorkspaceRoot(ws)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := mgr.DidOpen(ctx, file, "typescript", 1, ""); err != nil {
+		t.Fatalf("DidOpen for out-of-workspace path must be a silent no-op, got %v", err)
+	}
+	mgr.mu.Lock()
+	serverCount := len(mgr.servers)
+	mgr.mu.Unlock()
+	if serverCount != 0 {
+		t.Errorf("expected no servers, got %d", serverCount)
+	}
+	if len(collector.eventsByName("lsp:status")) != 0 {
+		t.Errorf("expected no status events for out-of-workspace path")
+	}
+}
+
+// startMockManagerAtRoot starts a mock LSP server at the given project root
+// inside the active workspace, returning the manager and the server key. The
+// caller is responsible for SetWorkspaceRoot before calling.
+func startMockServerAt(t *testing.T, mgr *Manager, family, root string) serverKey {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	t.Setenv("FIRN_MOCK_LSP", "1")
+
+	key := serverKey{family: family, workspace: root}
+	cfg := &ServerConfig{
+		LanguageFamily: family,
+		Command:        os.Args[0],
+		Args:           []string{"-test.run=^TestMockServerProcess$"},
+	}
+	if _, err := mgr.startServer(ctx, key, cfg); err != nil {
+		t.Fatalf("startServer at %s: %v", root, err)
+	}
+	return key
+}
+
+func TestManager_DistinctProjectRootsKeepSeparateServers(t *testing.T) {
+	if os.Getenv("FIRN_MOCK_LSP") == "1" {
+		t.Skip("running as mock server")
+	}
+
+	ws := t.TempDir()
+	touch(t, filepath.Join(ws, "frontend", "tsconfig.json"))
+	touch(t, filepath.Join(ws, "admin", "package.json"))
+	fileA := filepath.Join(ws, "frontend", "src", "a.ts")
+	fileB := filepath.Join(ws, "admin", "src", "b.ts")
+	touch(t, fileA)
+	touch(t, fileB)
+
+	collector := &eventCollector{}
+	mgr := &Manager{
+		registry: NewRegistry(),
+		emitter:  collector.emit,
+		servers:  make(map[serverKey]*serverEntry),
+	}
+	mgr.SetWorkspaceRoot(ws)
+	t.Cleanup(func() { mgr.ShutdownAll(5 * time.Second) })
+
+	rootA, err := mgr.projectRootForPath("typescript", fileA)
+	if err != nil {
+		t.Fatalf("rootA: %v", err)
+	}
+	rootB, err := mgr.projectRootForPath("typescript", fileB)
+	if err != nil {
+		t.Fatalf("rootB: %v", err)
+	}
+	if rootA == rootB {
+		t.Fatalf("expected distinct project roots, got both = %q", rootA)
+	}
+
+	keyA := startMockServerAt(t, mgr, "typescript", rootA)
+	keyB := startMockServerAt(t, mgr, "typescript", rootB)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := mgr.DidOpen(ctx, fileA, "typescript", 1, "// a"); err != nil {
+		t.Fatalf("DidOpen A: %v", err)
+	}
+	if err := mgr.DidOpen(ctx, fileB, "typescript", 1, "// b"); err != nil {
+		t.Fatalf("DidOpen B: %v", err)
+	}
+
+	uriA, _ := FileToURI(fileA)
+	uriB, _ := FileToURI(fileB)
+	mgr.mu.Lock()
+	entryA, hasA := mgr.servers[keyA]
+	entryB, hasB := mgr.servers[keyB]
+	mgr.mu.Unlock()
+	if !hasA || !hasB {
+		t.Fatalf("expected two servers, got hasA=%v hasB=%v", hasA, hasB)
+	}
+	if entryA == entryB {
+		t.Fatal("expected distinct serverEntry pointers per project root")
+	}
+
+	mgr.mu.Lock()
+	_, aOwnsItsDoc := entryA.openDocs[uriA]
+	_, aLeakedB := entryA.openDocs[uriB]
+	_, bOwnsItsDoc := entryB.openDocs[uriB]
+	_, bLeakedA := entryB.openDocs[uriA]
+	mgr.mu.Unlock()
+	if !aOwnsItsDoc || !bOwnsItsDoc {
+		t.Errorf("server missing its own document: a=%v b=%v", aOwnsItsDoc, bOwnsItsDoc)
+	}
+	if aLeakedB || bLeakedA {
+		t.Errorf("cross-root document leak: aLeakedB=%v bLeakedA=%v", aLeakedB, bLeakedA)
+	}
+
+	// Closing the document at root A must only tear down server A.
+	if err := mgr.DidClose(ctx, fileA); err != nil {
+		t.Fatalf("DidClose A: %v", err)
+	}
+	mgr.mu.Lock()
+	_, aStillExists := mgr.servers[keyA]
+	_, bStillExists := mgr.servers[keyB]
+	mgr.mu.Unlock()
+	if aStillExists {
+		t.Error("server A should be torn down after its last document closed")
+	}
+	if !bStillExists {
+		t.Error("server B should remain after closing only A's document")
+	}
+}
+
+func TestManager_SameProjectRootSharesOneServer(t *testing.T) {
+	if os.Getenv("FIRN_MOCK_LSP") == "1" {
+		t.Skip("running as mock server")
+	}
+
+	ws := t.TempDir()
+	touch(t, filepath.Join(ws, "pkg", "tsconfig.json"))
+	fileA := filepath.Join(ws, "pkg", "src", "a.ts")
+	fileB := filepath.Join(ws, "pkg", "src", "deeper", "b.tsx")
+	touch(t, fileA)
+	touch(t, fileB)
+
+	collector := &eventCollector{}
+	mgr := &Manager{
+		registry: NewRegistry(),
+		emitter:  collector.emit,
+		servers:  make(map[serverKey]*serverEntry),
+	}
+	mgr.SetWorkspaceRoot(ws)
+	t.Cleanup(func() { mgr.ShutdownAll(5 * time.Second) })
+
+	root, err := mgr.projectRootForPath("typescript", fileA)
+	if err != nil {
+		t.Fatalf("root: %v", err)
+	}
+	key := startMockServerAt(t, mgr, "typescript", root)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := mgr.DidOpen(ctx, fileA, "typescript", 1, "// a"); err != nil {
+		t.Fatalf("DidOpen A: %v", err)
+	}
+	if err := mgr.DidOpen(ctx, fileB, "typescriptreact", 1, "// b"); err != nil {
+		t.Fatalf("DidOpen B: %v", err)
+	}
+
+	mgr.mu.Lock()
+	serverCount := len(mgr.servers)
+	docCount := len(mgr.servers[key].openDocs)
+	mgr.mu.Unlock()
+	if serverCount != 1 {
+		t.Errorf("expected 1 shared server, got %d", serverCount)
+	}
+	if docCount != 2 {
+		t.Errorf("expected 2 documents on shared server, got %d", docCount)
+	}
+}
+
+func TestManager_ShutdownAllTearsDownAllRoots(t *testing.T) {
+	if os.Getenv("FIRN_MOCK_LSP") == "1" {
+		t.Skip("running as mock server")
+	}
+
+	ws := t.TempDir()
+	touch(t, filepath.Join(ws, "a", "tsconfig.json"))
+	touch(t, filepath.Join(ws, "b", "tsconfig.json"))
+
+	collector := &eventCollector{}
+	mgr := &Manager{
+		registry: NewRegistry(),
+		emitter:  collector.emit,
+		servers:  make(map[serverKey]*serverEntry),
+	}
+	mgr.SetWorkspaceRoot(ws)
+
+	startMockServerAt(t, mgr, "typescript", filepath.Join(ws, "a"))
+	startMockServerAt(t, mgr, "typescript", filepath.Join(ws, "b"))
+
+	mgr.mu.Lock()
+	beforeCount := len(mgr.servers)
+	mgr.mu.Unlock()
+	if beforeCount != 2 {
+		t.Fatalf("expected 2 servers before shutdown, got %d", beforeCount)
+	}
+
+	mgr.ShutdownAll(5 * time.Second)
+
+	mgr.mu.Lock()
+	afterCount := len(mgr.servers)
+	mgr.mu.Unlock()
+	if afterCount != 0 {
+		t.Errorf("expected 0 servers after ShutdownAll, got %d", afterCount)
 	}
 }

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -249,6 +249,7 @@ func TestManager_InitializingServerAbandonedAfterWorkspaceSwitch(t *testing.T) {
 		registry: NewRegistry(),
 		emitter:  collector.emit,
 		servers:  make(map[serverKey]*serverEntry),
+		docKeys:  make(map[string]serverKey),
 	}
 	mgr.SetWorkspaceRoot(oldWorkspace)
 
@@ -513,6 +514,7 @@ func startMockManager(t *testing.T) (*Manager, *eventCollector, serverKey) {
 		registry: NewRegistry(),
 		emitter:  collector.emit,
 		servers:  make(map[serverKey]*serverEntry),
+		docKeys:  make(map[string]serverKey),
 	}
 	mgr.SetWorkspaceRoot(tmpDir)
 
@@ -1198,6 +1200,7 @@ func TestManager_DistinctProjectRootsKeepSeparateServers(t *testing.T) {
 		registry: NewRegistry(),
 		emitter:  collector.emit,
 		servers:  make(map[serverKey]*serverEntry),
+		docKeys:  make(map[string]serverKey),
 	}
 	mgr.SetWorkspaceRoot(ws)
 	t.Cleanup(func() { mgr.ShutdownAll(5 * time.Second) })
@@ -1285,6 +1288,7 @@ func TestManager_SameProjectRootSharesOneServer(t *testing.T) {
 		registry: NewRegistry(),
 		emitter:  collector.emit,
 		servers:  make(map[serverKey]*serverEntry),
+		docKeys:  make(map[string]serverKey),
 	}
 	mgr.SetWorkspaceRoot(ws)
 	t.Cleanup(func() { mgr.ShutdownAll(5 * time.Second) })
@@ -1316,6 +1320,155 @@ func TestManager_SameProjectRootSharesOneServer(t *testing.T) {
 	}
 }
 
+func TestManager_DocKeysCachePopulatedOnDidOpenClearedOnDidClose(t *testing.T) {
+	// The cache eliminates per-keystroke filesystem walks for DidChange/
+	// DidSave/Hover/Definition/Complete. Verify that DidOpen populates it,
+	// DidClose tears it down, and refcount > 1 keeps it alive.
+	if os.Getenv("FIRN_MOCK_LSP") == "1" {
+		t.Skip("running as mock server")
+	}
+
+	ws := t.TempDir()
+	touch(t, filepath.Join(ws, "pkg", "tsconfig.json"))
+	file := filepath.Join(ws, "pkg", "src", "main.ts")
+	touch(t, file)
+
+	collector := &eventCollector{}
+	mgr := &Manager{
+		registry: NewRegistry(),
+		emitter:  collector.emit,
+		servers:  make(map[serverKey]*serverEntry),
+		docKeys:  make(map[string]serverKey),
+	}
+	mgr.SetWorkspaceRoot(ws)
+	t.Cleanup(func() { mgr.ShutdownAll(5 * time.Second) })
+
+	root, err := mgr.projectRootForPath("typescript", file)
+	if err != nil {
+		t.Fatalf("root: %v", err)
+	}
+	startMockServerAt(t, mgr, "typescript", root)
+
+	uri, _ := FileToURI(file)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Before DidOpen, cache is empty.
+	mgr.mu.Lock()
+	_, hasBefore := mgr.docKeys[uri]
+	mgr.mu.Unlock()
+	if hasBefore {
+		t.Fatal("docKeys should be empty before DidOpen")
+	}
+
+	// First DidOpen populates cache with the resolved project root.
+	if err := mgr.DidOpen(ctx, file, "typescript", 1, "// a"); err != nil {
+		t.Fatalf("DidOpen 1: %v", err)
+	}
+	mgr.mu.Lock()
+	cachedKey, ok := mgr.docKeys[uri]
+	mgr.mu.Unlock()
+	if !ok {
+		t.Fatal("docKeys should contain entry after DidOpen")
+	}
+	if cachedKey.workspace != root || cachedKey.family != "typescript" {
+		t.Errorf("cached key = %+v, want {typescript, %s}", cachedKey, root)
+	}
+
+	// Second DidOpen (refcount 2) keeps cache alive.
+	if err := mgr.DidOpen(ctx, file, "typescript", 1, "// a"); err != nil {
+		t.Fatalf("DidOpen 2: %v", err)
+	}
+	mgr.mu.Lock()
+	_, stillCached := mgr.docKeys[uri]
+	mgr.mu.Unlock()
+	if !stillCached {
+		t.Fatal("docKeys entry should persist while refcount > 0")
+	}
+
+	// First DidClose (refcount 1) leaves cache in place.
+	if err := mgr.DidClose(ctx, file); err != nil {
+		t.Fatalf("DidClose 1: %v", err)
+	}
+	mgr.mu.Lock()
+	_, afterFirstClose := mgr.docKeys[uri]
+	mgr.mu.Unlock()
+	if !afterFirstClose {
+		t.Error("docKeys entry should persist after DidClose with refcount > 0")
+	}
+
+	// Final DidClose (refcount 0) clears the cache.
+	if err := mgr.DidClose(ctx, file); err != nil {
+		t.Fatalf("DidClose 2: %v", err)
+	}
+	mgr.mu.Lock()
+	_, afterLastClose := mgr.docKeys[uri]
+	mgr.mu.Unlock()
+	if afterLastClose {
+		t.Error("docKeys entry should be removed after final DidClose")
+	}
+}
+
+func TestManager_DidChangeUsesCacheNotFilesystem(t *testing.T) {
+	// Proves the perf invariant: once DidOpen has cached the document's
+	// project root, subsequent DidChange / Hover / Definition / Complete
+	// calls route through serverForPath WITHOUT walking the filesystem.
+	//
+	// We assert this indirectly by deleting the marker file after DidOpen.
+	// If the hot path re-resolved on every call, removing the marker would
+	// cause routing to fall back to workspaceRoot — a different key — and
+	// the request would land on no server. With the cache, routing remains
+	// pinned to the original project root.
+	if os.Getenv("FIRN_MOCK_LSP") == "1" {
+		t.Skip("running as mock server")
+	}
+
+	ws := t.TempDir()
+	marker := filepath.Join(ws, "pkg", "tsconfig.json")
+	touch(t, marker)
+	file := filepath.Join(ws, "pkg", "src", "main.ts")
+	touch(t, file)
+
+	collector := &eventCollector{}
+	mgr := &Manager{
+		registry: NewRegistry(),
+		emitter:  collector.emit,
+		servers:  make(map[serverKey]*serverEntry),
+		docKeys:  make(map[string]serverKey),
+	}
+	mgr.SetWorkspaceRoot(ws)
+	t.Cleanup(func() { mgr.ShutdownAll(5 * time.Second) })
+
+	pkgRoot := filepath.Join(ws, "pkg")
+	startMockServerAt(t, mgr, "typescript", pkgRoot)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := mgr.DidOpen(ctx, file, "typescript", 1, "// a"); err != nil {
+		t.Fatalf("DidOpen: %v", err)
+	}
+
+	// Remove the marker — if the hot path were re-resolving, this would
+	// shift the resolved root to ws and the request would miss our pkg
+	// server.
+	if err := os.Remove(marker); err != nil {
+		t.Fatalf("remove marker: %v", err)
+	}
+
+	// serverForPath must still find the pkg-rooted server via the cache.
+	uri, _ := FileToURI(file)
+	entry, gotURI, key := mgr.serverForPath(file)
+	if entry == nil {
+		t.Fatal("serverForPath returned nil after marker removal — cache not honored on hot path")
+	}
+	if gotURI != uri {
+		t.Errorf("uri = %q, want %q", gotURI, uri)
+	}
+	if key.workspace != pkgRoot {
+		t.Errorf("routed to workspace %q, want cached %q", key.workspace, pkgRoot)
+	}
+}
+
 func TestManager_ShutdownAllTearsDownAllRoots(t *testing.T) {
 	if os.Getenv("FIRN_MOCK_LSP") == "1" {
 		t.Skip("running as mock server")
@@ -1330,6 +1483,7 @@ func TestManager_ShutdownAllTearsDownAllRoots(t *testing.T) {
 		registry: NewRegistry(),
 		emitter:  collector.emit,
 		servers:  make(map[serverKey]*serverEntry),
+		docKeys:  make(map[string]serverKey),
 	}
 	mgr.SetWorkspaceRoot(ws)
 

--- a/internal/lsp/project_root.go
+++ b/internal/lsp/project_root.go
@@ -86,7 +86,16 @@ func absClean(p string) (string, error) {
 // pathContains reports whether child is at or below parent. Both paths must be
 // absolute and cleaned. Uses a separator-suffixed prefix check so that
 // `/foo/bar` is not treated as a child of `/foo/ba`.
+//
+// Empty inputs are explicitly NOT contained: pathContains("", x) and
+// pathContains(x, "") both return false. This guards manager.go's crash-
+// recovery checks (lines 439, 568, 707) so that a missing workspace root
+// cannot cause the empty-string + leading-slash combination to be classified
+// as containing every absolute path.
 func pathContains(parent, child string) bool {
+	if parent == "" || child == "" {
+		return false
+	}
 	if parent == child {
 		return true
 	}

--- a/internal/lsp/project_root.go
+++ b/internal/lsp/project_root.go
@@ -23,6 +23,13 @@ var ErrPathOutsideWorkspace = errors.New("path outside workspace root")
 // coexist in the same directory the first one in the slice wins. This only
 // affects determinism — the resolved root is the same directory either way.
 //
+// skipDirs names path segments (e.g. "node_modules") that, if present in the
+// directory's relative path from workspaceRoot, suppress marker matching for
+// that directory. The walk continues upward so that files inside a skipped
+// segment route to the consuming package above rather than spawning a server
+// rooted at the dependency itself. A nil or empty skipDirs disables this
+// filtering.
+//
 // Returns ErrPathOutsideWorkspace if filePath resolves outside workspaceRoot
 // after cleaning. Symlinks are not evaluated in this first cut; callers that
 // need symlink-aware policy should resolve before calling.
@@ -30,7 +37,7 @@ var ErrPathOutsideWorkspace = errors.New("path outside workspace root")
 // markers may be empty, in which case workspaceRoot is returned without
 // walking. This makes the helper safe to call for language families that do
 // not yet have project-root detection wired in.
-func ResolveProjectRoot(filePath, workspaceRoot string, markers []string) (string, error) {
+func ResolveProjectRoot(filePath, workspaceRoot string, markers []string, skipDirs []string) (string, error) {
 	if workspaceRoot == "" {
 		return "", errors.New("workspaceRoot is empty")
 	}
@@ -56,9 +63,11 @@ func ResolveProjectRoot(filePath, workspaceRoot string, markers []string) (strin
 	}
 
 	for dir := filepath.Dir(absFile); ; {
-		for _, marker := range markers {
-			if fileExists(filepath.Join(dir, marker)) {
-				return dir, nil
+		if !dirHasSkippedSegment(dir, absWorkspace, skipDirs) {
+			for _, marker := range markers {
+				if fileExists(filepath.Join(dir, marker)) {
+					return dir, nil
+				}
 			}
 		}
 
@@ -72,6 +81,28 @@ func ResolveProjectRoot(filePath, workspaceRoot string, markers []string) (strin
 		}
 		dir = parent
 	}
+}
+
+// dirHasSkippedSegment reports whether dir's relative path from workspace
+// contains any of the named segments. Used to suppress marker matching inside
+// directories like node_modules without halting the upward walk.
+func dirHasSkippedSegment(dir, workspace string, skipDirs []string) bool {
+	if len(skipDirs) == 0 {
+		return false
+	}
+	rel, err := filepath.Rel(workspace, dir)
+	if err != nil || rel == "." || rel == "" {
+		return false
+	}
+	segments := strings.Split(rel, string(filepath.Separator))
+	for _, seg := range segments {
+		for _, skip := range skipDirs {
+			if seg == skip {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // absClean returns an absolute, lexically cleaned path.

--- a/internal/lsp/project_root.go
+++ b/internal/lsp/project_root.go
@@ -1,0 +1,110 @@
+package lsp
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ErrPathOutsideWorkspace is returned when a file path resolves to a location
+// outside the active workspace root after cleaning. Callers should treat this
+// as a guard against `..` escapes and refuse to start a language server for
+// the file.
+var ErrPathOutsideWorkspace = errors.New("path outside workspace root")
+
+// ResolveProjectRoot walks upward from filePath's containing directory toward
+// workspaceRoot, returning the absolute path of the nearest directory that
+// contains any of the given markers. If no marker is found within the
+// workspace boundary, workspaceRoot itself is returned.
+//
+// markers is searched in slice order at each directory: when multiple markers
+// coexist in the same directory the first one in the slice wins. This only
+// affects determinism — the resolved root is the same directory either way.
+//
+// Returns ErrPathOutsideWorkspace if filePath resolves outside workspaceRoot
+// after cleaning. Symlinks are not evaluated in this first cut; callers that
+// need symlink-aware policy should resolve before calling.
+//
+// markers may be empty, in which case workspaceRoot is returned without
+// walking. This makes the helper safe to call for language families that do
+// not yet have project-root detection wired in.
+func ResolveProjectRoot(filePath, workspaceRoot string, markers []string) (string, error) {
+	if workspaceRoot == "" {
+		return "", errors.New("workspaceRoot is empty")
+	}
+	if filePath == "" {
+		return "", errors.New("filePath is empty")
+	}
+
+	absWorkspace, err := absClean(workspaceRoot)
+	if err != nil {
+		return "", fmt.Errorf("clean workspaceRoot: %w", err)
+	}
+	absFile, err := absClean(filePath)
+	if err != nil {
+		return "", fmt.Errorf("clean filePath: %w", err)
+	}
+
+	if !pathContains(absWorkspace, absFile) {
+		return "", ErrPathOutsideWorkspace
+	}
+
+	if len(markers) == 0 {
+		return absWorkspace, nil
+	}
+
+	for dir := filepath.Dir(absFile); ; {
+		for _, marker := range markers {
+			if fileExists(filepath.Join(dir, marker)) {
+				return dir, nil
+			}
+		}
+
+		if dir == absWorkspace {
+			return absWorkspace, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return absWorkspace, nil
+		}
+		dir = parent
+	}
+}
+
+// absClean returns an absolute, lexically cleaned path.
+func absClean(p string) (string, error) {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(abs), nil
+}
+
+// pathContains reports whether child is at or below parent. Both paths must be
+// absolute and cleaned. Uses a separator-suffixed prefix check so that
+// `/foo/bar` is not treated as a child of `/foo/ba`.
+func pathContains(parent, child string) bool {
+	if parent == child {
+		return true
+	}
+	sep := string(filepath.Separator)
+	parentWithSep := parent
+	if !strings.HasSuffix(parentWithSep, sep) {
+		parentWithSep += sep
+	}
+	return strings.HasPrefix(child, parentWithSep)
+}
+
+// fileExists reports whether the given path exists as a regular file.
+// Stat errors other than NotExist (e.g. permission denied) are treated as
+// "not present" so marker probing during the walk never aborts the resolution.
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}

--- a/internal/lsp/project_root_test.go
+++ b/internal/lsp/project_root_test.go
@@ -221,6 +221,13 @@ func TestPathContains(t *testing.T) {
 		{"/a/b", "/a/bc", false}, // prefix collision must be false
 		{"/a/b", "/a", false},
 		{strings.TrimRight("/a/b/", sep), "/a/b/c", true},
+		// Empty-input guard: an unset workspace must not be classified as
+		// containing every absolute path. Without this guard the crash-
+		// recovery checks in manager.go would resurrect servers after
+		// SetWorkspaceRoot("").
+		{"", "/a/b", false},
+		{"/a/b", "", false},
+		{"", "", false},
 	}
 	for _, tc := range cases {
 		if got := pathContains(tc.parent, tc.child); got != tc.want {

--- a/internal/lsp/project_root_test.go
+++ b/internal/lsp/project_root_test.go
@@ -1,0 +1,230 @@
+package lsp
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// tsMarkers mirrors the TypeScript family marker priority that manager.go will
+// pass at the call site.
+var tsMarkers = []string{"tsconfig.json", "jsconfig.json", "package.json"}
+
+// touch creates an empty file at path, creating parent directories as needed.
+func touch(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdirall: %v", err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create %s: %v", path, err)
+	}
+	_ = f.Close()
+}
+
+func TestResolveProjectRoot_NearestTsconfigWins(t *testing.T) {
+	ws := t.TempDir()
+	touch(t, filepath.Join(ws, "package.json"))               // repo-root package
+	touch(t, filepath.Join(ws, "frontend", "tsconfig.json"))  // package-local config
+	touch(t, filepath.Join(ws, "frontend", "package.json"))   // package-local manifest
+	file := filepath.Join(ws, "frontend", "src", "App.tsx")
+	touch(t, file)
+
+	got, err := ResolveProjectRoot(file, ws, tsMarkers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(ws, "frontend")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveProjectRoot_NearestJsconfigWins(t *testing.T) {
+	ws := t.TempDir()
+	touch(t, filepath.Join(ws, "package.json"))
+	touch(t, filepath.Join(ws, "admin", "jsconfig.json"))
+	file := filepath.Join(ws, "admin", "src", "main.js")
+	touch(t, file)
+
+	got, err := ResolveProjectRoot(file, ws, tsMarkers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(ws, "admin")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveProjectRoot_PackageJsonFallback(t *testing.T) {
+	ws := t.TempDir()
+	touch(t, filepath.Join(ws, "packages", "ui", "package.json"))
+	file := filepath.Join(ws, "packages", "ui", "src", "Button.tsx")
+	touch(t, file)
+
+	got, err := ResolveProjectRoot(file, ws, tsMarkers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(ws, "packages", "ui")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveProjectRoot_SameDirectoryMarkerPriority(t *testing.T) {
+	// tsconfig.json should beat package.json when both live in the same dir.
+	// (Same directory wins either way; this only affects determinism.)
+	ws := t.TempDir()
+	touch(t, filepath.Join(ws, "tsconfig.json"))
+	touch(t, filepath.Join(ws, "package.json"))
+	file := filepath.Join(ws, "src", "index.ts")
+	touch(t, file)
+
+	got, err := ResolveProjectRoot(file, ws, tsMarkers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != ws {
+		t.Errorf("got %q, want %q", got, ws)
+	}
+}
+
+func TestResolveProjectRoot_FallbackToWorkspaceRoot(t *testing.T) {
+	ws := t.TempDir()
+	file := filepath.Join(ws, "src", "index.ts")
+	touch(t, file)
+
+	got, err := ResolveProjectRoot(file, ws, tsMarkers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != ws {
+		t.Errorf("got %q, want workspace root %q", got, ws)
+	}
+}
+
+func TestResolveProjectRoot_FileAtWorkspaceRoot(t *testing.T) {
+	ws := t.TempDir()
+	touch(t, filepath.Join(ws, "tsconfig.json"))
+	file := filepath.Join(ws, "index.ts")
+	touch(t, file)
+
+	got, err := ResolveProjectRoot(file, ws, tsMarkers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != ws {
+		t.Errorf("got %q, want %q", got, ws)
+	}
+}
+
+func TestResolveProjectRoot_PathOutsideWorkspace(t *testing.T) {
+	ws := t.TempDir()
+	outside := t.TempDir()
+	file := filepath.Join(outside, "evil.ts")
+	touch(t, file)
+
+	_, err := ResolveProjectRoot(file, ws, tsMarkers)
+	if !errors.Is(err, ErrPathOutsideWorkspace) {
+		t.Fatalf("got error %v, want ErrPathOutsideWorkspace", err)
+	}
+}
+
+func TestResolveProjectRoot_DotDotEscapeRejected(t *testing.T) {
+	ws := t.TempDir()
+	parent := filepath.Dir(ws)
+	// Construct a path that lexically escapes via `..` but is not absolute-cleaned.
+	escapePath := filepath.Join(ws, "..", filepath.Base(parent), "outside.ts")
+
+	_, err := ResolveProjectRoot(escapePath, ws, tsMarkers)
+	if err == nil {
+		t.Fatalf("expected error for `..` escape, got nil")
+	}
+	// May be ErrPathOutsideWorkspace or a related cleaning error; assert no false success.
+}
+
+func TestResolveProjectRoot_EmptyMarkersReturnsWorkspace(t *testing.T) {
+	ws := t.TempDir()
+	file := filepath.Join(ws, "src", "main.go")
+	touch(t, file)
+
+	got, err := ResolveProjectRoot(file, ws, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != ws {
+		t.Errorf("got %q, want workspace %q", got, ws)
+	}
+}
+
+func TestResolveProjectRoot_PathWithSpacesAndUnicode(t *testing.T) {
+	ws := t.TempDir()
+	pkg := filepath.Join(ws, "my package — ünicode")
+	touch(t, filepath.Join(pkg, "tsconfig.json"))
+	file := filepath.Join(pkg, "src", "app.ts")
+	touch(t, file)
+
+	got, err := ResolveProjectRoot(file, ws, tsMarkers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != pkg {
+		t.Errorf("got %q, want %q", got, pkg)
+	}
+}
+
+func TestResolveProjectRoot_RejectsPrefixCollision(t *testing.T) {
+	// `/foo/bar` must not be treated as a child of `/foo/ba`.
+	if runtime.GOOS == "windows" {
+		t.Skip("path semantics differ on Windows; covered separately")
+	}
+	parent := t.TempDir()
+	ws := filepath.Join(parent, "ba")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	sibling := filepath.Join(parent, "bar")
+	touch(t, filepath.Join(sibling, "tsconfig.json"))
+	file := filepath.Join(sibling, "index.ts")
+	touch(t, file)
+
+	_, err := ResolveProjectRoot(file, ws, tsMarkers)
+	if !errors.Is(err, ErrPathOutsideWorkspace) {
+		t.Fatalf("expected ErrPathOutsideWorkspace for prefix collision, got %v", err)
+	}
+}
+
+func TestResolveProjectRoot_EmptyArgsRejected(t *testing.T) {
+	if _, err := ResolveProjectRoot("", "/tmp", tsMarkers); err == nil {
+		t.Error("expected error for empty filePath")
+	}
+	if _, err := ResolveProjectRoot("/tmp/foo.ts", "", tsMarkers); err == nil {
+		t.Error("expected error for empty workspaceRoot")
+	}
+}
+
+// Sanity: pathContains is load-bearing for the boundary guard.
+func TestPathContains(t *testing.T) {
+	sep := string(filepath.Separator)
+	cases := []struct {
+		parent, child string
+		want          bool
+	}{
+		{"/a/b", "/a/b", true},
+		{"/a/b", "/a/b/c", true},
+		{"/a/b", "/a/bc", false}, // prefix collision must be false
+		{"/a/b", "/a", false},
+		{strings.TrimRight("/a/b/", sep), "/a/b/c", true},
+	}
+	for _, tc := range cases {
+		if got := pathContains(tc.parent, tc.child); got != tc.want {
+			t.Errorf("pathContains(%q, %q) = %v, want %v", tc.parent, tc.child, got, tc.want)
+		}
+	}
+}

--- a/internal/lsp/project_root_test.go
+++ b/internal/lsp/project_root_test.go
@@ -34,7 +34,7 @@ func TestResolveProjectRoot_NearestTsconfigWins(t *testing.T) {
 	file := filepath.Join(ws, "frontend", "src", "App.tsx")
 	touch(t, file)
 
-	got, err := ResolveProjectRoot(file, ws, tsMarkers)
+	got, err := ResolveProjectRoot(file, ws, tsMarkers, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestResolveProjectRoot_NearestJsconfigWins(t *testing.T) {
 	file := filepath.Join(ws, "admin", "src", "main.js")
 	touch(t, file)
 
-	got, err := ResolveProjectRoot(file, ws, tsMarkers)
+	got, err := ResolveProjectRoot(file, ws, tsMarkers, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestResolveProjectRoot_PackageJsonFallback(t *testing.T) {
 	file := filepath.Join(ws, "packages", "ui", "src", "Button.tsx")
 	touch(t, file)
 
-	got, err := ResolveProjectRoot(file, ws, tsMarkers)
+	got, err := ResolveProjectRoot(file, ws, tsMarkers, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestResolveProjectRoot_SameDirectoryMarkerPriority(t *testing.T) {
 	file := filepath.Join(ws, "src", "index.ts")
 	touch(t, file)
 
-	got, err := ResolveProjectRoot(file, ws, tsMarkers)
+	got, err := ResolveProjectRoot(file, ws, tsMarkers, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestResolveProjectRoot_FallbackToWorkspaceRoot(t *testing.T) {
 	file := filepath.Join(ws, "src", "index.ts")
 	touch(t, file)
 
-	got, err := ResolveProjectRoot(file, ws, tsMarkers)
+	got, err := ResolveProjectRoot(file, ws, tsMarkers, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestResolveProjectRoot_FileAtWorkspaceRoot(t *testing.T) {
 	file := filepath.Join(ws, "index.ts")
 	touch(t, file)
 
-	got, err := ResolveProjectRoot(file, ws, tsMarkers)
+	got, err := ResolveProjectRoot(file, ws, tsMarkers, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestResolveProjectRoot_PathOutsideWorkspace(t *testing.T) {
 	file := filepath.Join(outside, "evil.ts")
 	touch(t, file)
 
-	_, err := ResolveProjectRoot(file, ws, tsMarkers)
+	_, err := ResolveProjectRoot(file, ws, tsMarkers, nil)
 	if !errors.Is(err, ErrPathOutsideWorkspace) {
 		t.Fatalf("got error %v, want ErrPathOutsideWorkspace", err)
 	}
@@ -139,14 +139,16 @@ func TestResolveProjectRoot_PathOutsideWorkspace(t *testing.T) {
 func TestResolveProjectRoot_DotDotEscapeRejected(t *testing.T) {
 	ws := t.TempDir()
 	parent := filepath.Dir(ws)
-	// Construct a path that lexically escapes via `..` but is not absolute-cleaned.
+	// Construct a path that escapes via `..` to a sibling of ws. After
+	// cleaning this resolves outside ws — the boundary check must reject it
+	// with a typed error so future cleaning-error refactors cannot silently
+	// regress this guard.
 	escapePath := filepath.Join(ws, "..", filepath.Base(parent), "outside.ts")
 
-	_, err := ResolveProjectRoot(escapePath, ws, tsMarkers)
-	if err == nil {
-		t.Fatalf("expected error for `..` escape, got nil")
+	_, err := ResolveProjectRoot(escapePath, ws, tsMarkers, nil)
+	if !errors.Is(err, ErrPathOutsideWorkspace) {
+		t.Fatalf("expected ErrPathOutsideWorkspace for `..` escape, got %v", err)
 	}
-	// May be ErrPathOutsideWorkspace or a related cleaning error; assert no false success.
 }
 
 func TestResolveProjectRoot_EmptyMarkersReturnsWorkspace(t *testing.T) {
@@ -154,7 +156,7 @@ func TestResolveProjectRoot_EmptyMarkersReturnsWorkspace(t *testing.T) {
 	file := filepath.Join(ws, "src", "main.go")
 	touch(t, file)
 
-	got, err := ResolveProjectRoot(file, ws, nil)
+	got, err := ResolveProjectRoot(file, ws, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -170,7 +172,7 @@ func TestResolveProjectRoot_PathWithSpacesAndUnicode(t *testing.T) {
 	file := filepath.Join(pkg, "src", "app.ts")
 	touch(t, file)
 
-	got, err := ResolveProjectRoot(file, ws, tsMarkers)
+	got, err := ResolveProjectRoot(file, ws, tsMarkers, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -194,18 +196,114 @@ func TestResolveProjectRoot_RejectsPrefixCollision(t *testing.T) {
 	file := filepath.Join(sibling, "index.ts")
 	touch(t, file)
 
-	_, err := ResolveProjectRoot(file, ws, tsMarkers)
+	_, err := ResolveProjectRoot(file, ws, tsMarkers, nil)
 	if !errors.Is(err, ErrPathOutsideWorkspace) {
 		t.Fatalf("expected ErrPathOutsideWorkspace for prefix collision, got %v", err)
 	}
 }
 
 func TestResolveProjectRoot_EmptyArgsRejected(t *testing.T) {
-	if _, err := ResolveProjectRoot("", "/tmp", tsMarkers); err == nil {
+	if _, err := ResolveProjectRoot("", "/tmp", tsMarkers, nil); err == nil {
 		t.Error("expected error for empty filePath")
 	}
-	if _, err := ResolveProjectRoot("/tmp/foo.ts", "", tsMarkers); err == nil {
+	if _, err := ResolveProjectRoot("/tmp/foo.ts", "", tsMarkers, nil); err == nil {
 		t.Error("expected error for empty workspaceRoot")
+	}
+}
+
+// --- node_modules skip behavior ---
+
+func TestResolveProjectRoot_NodeModulesPackageDoesNotBecomeRoot(t *testing.T) {
+	// Cmd+Click into a dependency must NOT spawn a server rooted at the
+	// dep — it should fall through to the consuming package above.
+	ws := t.TempDir()
+	consumer := filepath.Join(ws, "packages", "ui")
+	touch(t, filepath.Join(consumer, "package.json"))
+	depFile := filepath.Join(consumer, "node_modules", "lodash", "index.js")
+	touch(t, filepath.Join(consumer, "node_modules", "lodash", "package.json"))
+	touch(t, depFile)
+
+	got, err := ResolveProjectRoot(depFile, ws, tsMarkers, []string{"node_modules"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != consumer {
+		t.Errorf("got %q, want consumer root %q (node_modules/lodash/package.json must not become project root)", got, consumer)
+	}
+}
+
+func TestResolveProjectRoot_NestedNodeModulesAlsoSkipped(t *testing.T) {
+	// node_modules/<dep>/node_modules/<transitive>/index.js must skip the
+	// transitive dep AND its parent dep, falling through to the consumer.
+	ws := t.TempDir()
+	consumer := filepath.Join(ws, "app")
+	touch(t, filepath.Join(consumer, "package.json"))
+	transitive := filepath.Join(consumer, "node_modules", "react", "node_modules", "scheduler")
+	touch(t, filepath.Join(transitive, "package.json"))
+	depFile := filepath.Join(transitive, "src", "scheduler.js")
+	touch(t, depFile)
+
+	got, err := ResolveProjectRoot(depFile, ws, tsMarkers, []string{"node_modules"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != consumer {
+		t.Errorf("got %q, want consumer root %q", got, consumer)
+	}
+}
+
+func TestResolveProjectRoot_NodeModulesAtWorkspaceRootFallsBackToWorkspace(t *testing.T) {
+	// File inside a top-level node_modules with no consuming package above
+	// should fall back to workspaceRoot, not spawn a server inside the dep.
+	ws := t.TempDir()
+	depFile := filepath.Join(ws, "node_modules", "lodash", "index.js")
+	touch(t, filepath.Join(ws, "node_modules", "lodash", "package.json"))
+	touch(t, depFile)
+
+	got, err := ResolveProjectRoot(depFile, ws, tsMarkers, []string{"node_modules"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != ws {
+		t.Errorf("got %q, want workspace root %q", got, ws)
+	}
+}
+
+func TestResolveProjectRoot_NodeModulesSkipDoesNotAffectSiblingPackages(t *testing.T) {
+	// A directory literally named like node_modules but not actually inside
+	// a node_modules path segment should match normally. (Covers e.g.
+	// `/repo/node_modules_archive/<...>` which is a sibling of `node_modules`,
+	// not inside it.)
+	ws := t.TempDir()
+	pkg := filepath.Join(ws, "node_modules_backup", "ui")
+	touch(t, filepath.Join(pkg, "tsconfig.json"))
+	file := filepath.Join(pkg, "src", "App.tsx")
+	touch(t, file)
+
+	got, err := ResolveProjectRoot(file, ws, tsMarkers, []string{"node_modules"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != pkg {
+		t.Errorf("got %q, want %q (node_modules_backup is not node_modules)", got, pkg)
+	}
+}
+
+func TestResolveProjectRoot_SkipDirsNilHasNoEffect(t *testing.T) {
+	// nil skipDirs preserves the no-skip behavior so the helper is safe to
+	// call from non-TS families that don't want filtering.
+	ws := t.TempDir()
+	depFile := filepath.Join(ws, "node_modules", "lodash", "index.js")
+	touch(t, filepath.Join(ws, "node_modules", "lodash", "package.json"))
+	touch(t, depFile)
+
+	got, err := ResolveProjectRoot(depFile, ws, tsMarkers, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantDepRoot := filepath.Join(ws, "node_modules", "lodash")
+	if got != wantDepRoot {
+		t.Errorf("with nil skipDirs got %q, want %q (no skipping)", got, wantDepRoot)
 	}
 }
 

--- a/internal/lsp/registry.go
+++ b/internal/lsp/registry.go
@@ -72,23 +72,30 @@ func (r *Registry) FamilyForExtension(ext string) string {
 	return ""
 }
 
-// ServerConfigFor returns the server configuration for a given language family
-// and workspace root. It resolves binary paths using workspace-local and system lookups.
-func (r *Registry) ServerConfigFor(family, workspaceRoot string) (*ServerConfig, error) {
+// ServerConfigFor returns the server configuration for a given language
+// family and project root. The project root is whatever the caller has
+// resolved for the file being opened — for TypeScript that's the nearest
+// directory with tsconfig.json / jsconfig.json / package.json bounded by the
+// active workspace; for other families it remains the active workspace root.
+//
+// Binary lookups (e.g. node_modules/.bin/typescript-language-server) and
+// local-TypeScript discovery use this project root, so monorepo packages get
+// their own per-package server installation when one exists.
+func (r *Registry) ServerConfigFor(family, projectRoot string) (*ServerConfig, error) {
 	switch family {
 	case "typescript":
-		return r.resolveTypeScriptServer(workspaceRoot)
+		return r.resolveTypeScriptServer(projectRoot)
 	case "go":
-		return r.resolveGoServer(workspaceRoot)
+		return r.resolveGoServer(projectRoot)
 	case "python":
-		return r.resolvePythonServer(workspaceRoot)
+		return r.resolvePythonServer(projectRoot)
 	default:
 		return nil, fmt.Errorf("no language server configured for %q", family)
 	}
 }
 
-func workspaceLocalNodeBin(workspaceRoot, binary string) string {
-	localBin := filepath.Join(workspaceRoot, "node_modules", ".bin", binary)
+func projectLocalNodeBin(projectRoot, binary string) string {
+	localBin := filepath.Join(projectRoot, "node_modules", ".bin", binary)
 	if runtime.GOOS == "windows" {
 		localBin += ".cmd"
 	}
@@ -96,16 +103,23 @@ func workspaceLocalNodeBin(workspaceRoot, binary string) string {
 }
 
 // resolveTypeScriptServer finds and configures typescript-language-server.
-func (r *Registry) resolveTypeScriptServer(workspaceRoot string) (*ServerConfig, error) {
+// The projectRoot argument is the detected nearest TS/JS project root, not
+// necessarily the active workspace root. Lookup order:
+//  1. <projectRoot>/node_modules/.bin/typescript-language-server
+//  2. System PATH (with initOptions.tsserver.path pointing at any
+//     <projectRoot>/node_modules/typescript/lib that exists, so the project's
+//     own TypeScript version is preferred over whatever the global server
+//     bundles).
+func (r *Registry) resolveTypeScriptServer(projectRoot string) (*ServerConfig, error) {
 	binary := "typescript-language-server"
 
-	// 1. Check workspace-local node_modules/.bin/
-	if path, err := exec.LookPath(workspaceLocalNodeBin(workspaceRoot, binary)); err == nil {
+	// 1. Check project-local node_modules/.bin/
+	if path, err := exec.LookPath(projectLocalNodeBin(projectRoot, binary)); err == nil {
 		return &ServerConfig{
 			LanguageFamily: "typescript",
 			Command:        path,
 			Args:           []string{"--stdio"},
-			Dir:            workspaceRoot,
+			Dir:            projectRoot,
 		}, nil
 	}
 
@@ -121,13 +135,14 @@ func (r *Registry) resolveTypeScriptServer(workspaceRoot string) (*ServerConfig,
 
 	args := []string{"--stdio"}
 
-	// 3. If workspace has local TypeScript lib, tell the system server to use it
-	// via initializationOptions.tsserver.path. This ensures the server uses the
-	// project's TS version rather than whatever TypeScript the global server bundles.
-	// (The --tsserver-path CLI flag was removed in typescript-language-server v4+.)
+	// 3. If the project has its own TypeScript lib, point the system server at
+	// it via initializationOptions.tsserver.path. This ensures the server uses
+	// the project's TS version rather than whatever TypeScript the global
+	// server bundles. (The --tsserver-path CLI flag was removed in
+	// typescript-language-server v4+.)
 	// TODO: Gate behind workspace trust when trust system is implemented.
 	var initOpts any
-	localTSLib := filepath.Join(workspaceRoot, "node_modules", "typescript", "lib")
+	localTSLib := filepath.Join(projectRoot, "node_modules", "typescript", "lib")
 	if _, statErr := os.Stat(filepath.Join(localTSLib, "tsserver.js")); statErr == nil {
 		initOpts = map[string]any{
 			"tsserver": map[string]any{
@@ -140,7 +155,7 @@ func (r *Registry) resolveTypeScriptServer(workspaceRoot string) (*ServerConfig,
 		LanguageFamily: "typescript",
 		Command:        path,
 		Args:           args,
-		Dir:            workspaceRoot,
+		Dir:            projectRoot,
 		InitOptions:    initOpts,
 	}, nil
 }
@@ -167,7 +182,7 @@ func (r *Registry) resolveGoServer(workspaceRoot string) (*ServerConfig, error) 
 func (r *Registry) resolvePythonServer(workspaceRoot string) (*ServerConfig, error) {
 	binary := "pyright-langserver"
 
-	if path, err := exec.LookPath(workspaceLocalNodeBin(workspaceRoot, binary)); err == nil {
+	if path, err := exec.LookPath(projectLocalNodeBin(workspaceRoot, binary)); err == nil {
 		return &ServerConfig{
 			LanguageFamily: "python",
 			Command:        path,

--- a/internal/lsp/registry_test.go
+++ b/internal/lsp/registry_test.go
@@ -144,6 +144,98 @@ func TestResolveTypeScriptServer_NotFound(t *testing.T) {
 	}
 }
 
+// Monorepo case: the repo root has no install, but a nested package has its
+// own typescript-language-server. ServerConfigFor must use the package-local
+// install (and its Dir must be the package, not the repo root).
+//
+// Mirrors the runtime invariant after #20: Manager hands the registry the
+// detected project root, not the active workspace root.
+func TestResolveTypeScriptServer_PrefersPackageLocalInMonorepo(t *testing.T) {
+	repoRoot := t.TempDir()
+	pkgRoot := filepath.Join(repoRoot, "packages", "ui")
+	pkgBinDir := filepath.Join(pkgRoot, "node_modules", ".bin")
+	if err := os.MkdirAll(pkgBinDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	binary := "typescript-language-server"
+	if runtime.GOOS == "windows" {
+		binary += ".cmd"
+	}
+	pkgBinPath := filepath.Join(pkgBinDir, binary)
+	if err := os.WriteFile(pkgBinPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A different fake server is on PATH; it must lose to the package-local install.
+	systemBinDir := fakeTSLSBin(t)
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", systemBinDir+string(os.PathListSeparator)+origPath)
+
+	registry := NewRegistry()
+	config, err := registry.ServerConfigFor("typescript", pkgRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if config.Command != pkgBinPath {
+		t.Errorf("Command = %q, want package-local %q", config.Command, pkgBinPath)
+	}
+	if config.Dir != pkgRoot {
+		t.Errorf("Dir = %q, want package root %q (not repo root)", config.Dir, pkgRoot)
+	}
+	if config.InitOptions != nil {
+		// No package-local TS lib was created, so tsserver.path must not be set.
+		t.Errorf("InitOptions should be nil for package-local server without local TS lib, got %v", config.InitOptions)
+	}
+}
+
+// Monorepo case 2: package-local install missing, package has its own
+// TypeScript lib. The system server is used, but initializationOptions
+// tsserver.path must point at the PACKAGE's TypeScript lib, not the repo's.
+func TestResolveTypeScriptServer_SystemServerUsesPackageLocalTSLib(t *testing.T) {
+	repoRoot := t.TempDir()
+	pkgRoot := filepath.Join(repoRoot, "packages", "ui")
+	// Package-local TS lib (no package-local server)
+	pkgTSLib := filepath.Join(pkgRoot, "node_modules", "typescript", "lib")
+	if err := os.MkdirAll(pkgTSLib, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgTSLib, "tsserver.js"), []byte("// stub"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Repo-root TS lib that must NOT be selected
+	repoTSLib := filepath.Join(repoRoot, "node_modules", "typescript", "lib")
+	if err := os.MkdirAll(repoTSLib, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoTSLib, "tsserver.js"), []byte("// repo stub"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeBinDir := fakeTSLSBin(t)
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", fakeBinDir+string(os.PathListSeparator)+origPath)
+
+	registry := NewRegistry()
+	config, err := registry.ServerConfigFor("typescript", pkgRoot)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if config.Dir != pkgRoot {
+		t.Errorf("Dir = %q, want %q", config.Dir, pkgRoot)
+	}
+	opts, ok := config.InitOptions.(map[string]any)
+	if !ok {
+		t.Fatalf("expected tsserver init options for package-local TS lib, got %T", config.InitOptions)
+	}
+	tsserverOpts := opts["tsserver"].(map[string]any)
+	if tsserverOpts["path"] != pkgTSLib {
+		t.Errorf("tsserver.path = %q, want package-local %q (repo-root TS lib must lose)", tsserverOpts["path"], pkgTSLib)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }

--- a/internal/lsp/uri_test.go
+++ b/internal/lsp/uri_test.go
@@ -128,18 +128,18 @@ func TestURIToFile_InvalidScheme(t *testing.T) {
 	}
 }
 
-func TestWorkspaceLocalNodeBinPlatformSuffix(t *testing.T) {
-	got := workspaceLocalNodeBin("/workspace", "pyright-langserver")
+func TestProjectLocalNodeBinPlatformSuffix(t *testing.T) {
+	got := projectLocalNodeBin("/workspace", "pyright-langserver")
 	wantSuffix := filepath.Join("node_modules", ".bin", "pyright-langserver")
 	if runtime.GOOS == "windows" {
 		wantSuffix += ".cmd"
 		if !strings.HasSuffix(got, wantSuffix) {
-			t.Fatalf("workspaceLocalNodeBin on Windows = %q, want .cmd suffix", got)
+			t.Fatalf("projectLocalNodeBin on Windows = %q, want .cmd suffix", got)
 		}
 		return
 	}
 
 	if !strings.HasSuffix(got, wantSuffix) {
-		t.Fatalf("workspaceLocalNodeBin = %q, want Unix-style local bin path", got)
+		t.Fatalf("projectLocalNodeBin = %q, want Unix-style local bin path", got)
 	}
 }


### PR DESCRIPTION
## Summary
Closes #20. TypeScript LSP now keys servers by the file's nearest project root (tsconfig.json > jsconfig.json > package.json) bounded by the active workspace, instead of always rooting at the workspace itself. Monorepo packages each get their own server with the right TypeScript version and `node_modules/.bin/typescript-language-server` resolution.

The resolver is intentionally generalized (`ResolveProjectRoot(filePath, workspaceRoot, markers, skipDirs)`) so the follow-up PR for #75 (Go: nearest `go.mod`) and #76 (Python: nearest `pyproject.toml`) can reuse it without further refactor.

### Behavior changes
- Per-package TS server keying — open `packages/web/app.tsx` and `packages/api/server.ts` and you get two separate `typescript-language-server` processes, each rooted at its own package.
- Local TypeScript version preference — when `<projectRoot>/node_modules/typescript/lib` exists, `initializationOptions.tsserver.path` points the system server at it.
- `node_modules` is skipped during the walk — Cmd+Click into `node_modules/lodash/index.js` routes the request to the *consuming* package's server, not a server rooted at lodash. The walk continues *through* `node_modules` segments rather than halting on a `package.json` inside one.
- Frontend status lookup switches from exact-key match to longest-prefix selector (`findServerStatusForFile`), so the editor still shows the right LSP badge when nested project roots coexist.
- `pathContains` rejects empty inputs explicitly — guards manager crash-recovery checks against the empty-string + leading-slash footgun.

### Performance
`DidChange` is on the keystroke hot path. Naively, each change would re-walk up to 18 stat calls for a 6-deep TS file. Fixed via `Manager.docKeys map[string]serverKey` populated by `DidOpen` and cleared by `DidClose`; `serverForPath` consults the cache first. Test `TestManager_DidChangeUsesCacheNotFilesystem` proves the cache is honored by deleting the marker file post-open and asserting routing still succeeds.

### Quality gates run
- `/code-review` — one issue surfaced (`pathContains("")` returning true for any absolute path); fixed in commit 6.
- `/criticize-review` — three issues surfaced:
  - **C1 (CRITICAL)** filesystem walk per keystroke → per-URI cache (commit 8).
  - **C2 (HIGH)** Cmd+Click into `node_modules` deps would spawn dep-rooted servers → `skipDirs` parameter (commit 7).
  - **C3 (MEDIUM)** loose error assertion in resolver test → tightened to `errors.Is(err, ErrPathOutsideWorkspace)`.

### Commit shape
| # | SHA | Scope |
|---|---|---|
| 1 | 8b66769 | resolver + tests |
| 2 | ac3a6a5 | manager wiring (per-root keying, cache map) |
| 3 | a2492ea | registry uses project root |
| 4 | bfc1eb8 | frontend longest-prefix status selector |
| 5 | 399c4f3 | roadmap doc |
| 6 | d3b3e37 | code-review fix |
| 7 | 44a46bd | skeptic-review C2 (skipDirs) |
| 8 | 7b32d22 | skeptic-review C1 (per-doc cache) |

## Test plan
- [x] `go test ./...` — full suite green
- [x] `npm test` (frontend) — 658 tests, 54 suites green
- [x] `npm run build` — production build green
- [x] Manual: open a monorepo with `packages/a` and `packages/b`, confirm two `typescript-language-server` processes in `ps`, each rooted at its package
- [x] Manual: Cmd+Click an import that resolves into `node_modules/<dep>` and confirm the request is served by the consuming package's server, not a new dep-rooted one
- [x] Manual: open a TS file outside any `tsconfig.json` and confirm fallback to workspace root works without error

## Follow-up
Next PR will close #75 and #76 by applying `ResolveProjectRoot` to Go (`go.mod` marker) and Python (`pyproject.toml`, `setup.py`, `setup.cfg` markers) families. The resolver signature already accepts arbitrary markers, so it should be a small change in `manager.go` plus per-family tests.

Generated with [Claude Code](https://claude.com/claude-code)