### PR TITLE
[codex] lsp go python project roots

### DIFF
--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -677,10 +677,9 @@ func (m *Manager) serverForPath(path string) (*serverEntry, string, serverKey) {
 }
 
 // projectRootForPath returns the workspace key for the given file path.
-// For TypeScript-family files this is the nearest project root found by
-// upward walk (tsconfig.json > jsconfig.json > package.json), bounded by the
-// active workspace. For other families it returns the active workspace root
-// unchanged.
+// For language families with project markers this is the nearest project root
+// found by upward walk, bounded by the active workspace. Families without
+// marker detection return the active workspace root unchanged.
 //
 // Must be called WITHOUT the manager lock held — it performs filesystem
 // stat calls during marker probing.
@@ -707,12 +706,15 @@ func (m *Manager) projectRootForPath(family, path string) (string, error) {
 // projectRootMarkers returns the marker filenames used to detect a project
 // root for the given language family. Returning an empty slice means root
 // detection is disabled for the family and callers should use the active
-// workspace root directly. Go and Python are intentionally not wired up here
-// yet — see issues #75 and #76.
+// workspace root directly.
 func projectRootMarkers(family string) []string {
 	switch family {
 	case "typescript":
 		return []string{"tsconfig.json", "jsconfig.json", "package.json"}
+	case "go":
+		return []string{"go.mod"}
+	case "python":
+		return []string{"pyproject.toml", "requirements.txt", "setup.py"}
 	}
 	return nil
 }

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -142,6 +142,28 @@ func TestRegistry_GoServerConfigUsesGoplsFromPath(t *testing.T) {
 	}
 }
 
+func TestRegistry_GoServerConfigUsesDetectedProjectRoot(t *testing.T) {
+	r := NewRegistry()
+	binDir := t.TempDir()
+	writeTestExecutable(t, binDir, "gopls")
+	t.Setenv("PATH", binDir)
+
+	repoRoot := t.TempDir()
+	moduleRoot := filepath.Join(repoRoot, "services", "api")
+	if err := os.MkdirAll(moduleRoot, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	config, err := r.ServerConfigFor("go", moduleRoot)
+	if err != nil {
+		t.Fatalf("ServerConfigFor(go): %v", err)
+	}
+
+	if config.Dir != moduleRoot {
+		t.Errorf("Dir = %q, want detected module root %q", config.Dir, moduleRoot)
+	}
+}
+
 func TestRegistry_GoServerConfigReportsMissingGopls(t *testing.T) {
 	r := NewRegistry()
 	t.Setenv("PATH", "")
@@ -181,6 +203,33 @@ func TestRegistry_PythonServerConfigPrefersWorkspaceLocalPyright(t *testing.T) {
 	}
 	if config.Dir != workspace {
 		t.Errorf("Dir = %q, want %q", config.Dir, workspace)
+	}
+}
+
+func TestRegistry_PythonServerConfigPrefersDetectedProjectLocalPyright(t *testing.T) {
+	r := NewRegistry()
+	repoRoot := t.TempDir()
+	projectRoot := filepath.Join(repoRoot, "services", "api")
+	localBin := filepath.Join(projectRoot, "node_modules", ".bin")
+	if err := os.MkdirAll(localBin, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	pyrightPath := writeTestExecutable(t, localBin, "pyright-langserver")
+
+	systemBin := t.TempDir()
+	writeTestExecutable(t, systemBin, "pyright-langserver")
+	t.Setenv("PATH", systemBin)
+
+	config, err := r.ServerConfigFor("python", projectRoot)
+	if err != nil {
+		t.Fatalf("ServerConfigFor(python): %v", err)
+	}
+
+	if config.Command != pyrightPath {
+		t.Errorf("Command = %q, want project-local %q", config.Command, pyrightPath)
+	}
+	if config.Dir != projectRoot {
+		t.Errorf("Dir = %q, want detected project root %q", config.Dir, projectRoot)
 	}
 }
 
@@ -1076,11 +1125,10 @@ func TestManager_ProjectRootForPath_TypeScriptUsesNearestMarker(t *testing.T) {
 	}
 }
 
-func TestManager_ProjectRootForPath_GoReturnsWorkspaceUnchanged(t *testing.T) {
-	// Go nearest-go.mod detection is deferred to #75. This ticket keeps Go
-	// behavior identical: project root == active workspace root.
+func TestManager_ProjectRootForPath_GoUsesNearestGoMod(t *testing.T) {
 	mgr, _ := newTestManager(t)
 	ws := t.TempDir()
+	touch(t, filepath.Join(ws, "go.mod"))
 	touch(t, filepath.Join(ws, "cmd", "tool", "go.mod"))
 	file := filepath.Join(ws, "cmd", "tool", "main.go")
 	touch(t, file)
@@ -1090,26 +1138,33 @@ func TestManager_ProjectRootForPath_GoReturnsWorkspaceUnchanged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if root != ws {
-		t.Errorf("Go project root = %q, want workspace %q (Go detection lands with #75)", root, ws)
+	want := filepath.Join(ws, "cmd", "tool")
+	if root != want {
+		t.Errorf("Go project root = %q, want nearest go.mod root %q", root, want)
 	}
 }
 
-func TestManager_ProjectRootForPath_PythonReturnsWorkspaceUnchanged(t *testing.T) {
-	// Python nearest-pyproject.toml detection is deferred to #76.
-	mgr, _ := newTestManager(t)
-	ws := t.TempDir()
-	touch(t, filepath.Join(ws, "service", "pyproject.toml"))
-	file := filepath.Join(ws, "service", "src", "app.py")
-	touch(t, file)
-	mgr.SetWorkspaceRoot(ws)
+func TestManager_ProjectRootForPath_PythonUsesNearestProjectMarker(t *testing.T) {
+	for _, marker := range []string{"pyproject.toml", "requirements.txt", "setup.py"} {
+		t.Run(marker, func(t *testing.T) {
+			mgr, _ := newTestManager(t)
+			ws := t.TempDir()
+			touch(t, filepath.Join(ws, "pyproject.toml"))
 
-	root, err := mgr.projectRootForPath("python", file)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if root != ws {
-		t.Errorf("Python project root = %q, want workspace %q (Python detection lands with #76)", root, ws)
+			project := filepath.Join(ws, "service")
+			touch(t, filepath.Join(project, marker))
+			file := filepath.Join(project, "src", "app.py")
+			touch(t, file)
+			mgr.SetWorkspaceRoot(ws)
+
+			root, err := mgr.projectRootForPath("python", file)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if root != project {
+				t.Errorf("Python project root = %q, want nearest %s root %q", root, marker, project)
+			}
+		})
 	}
 }
 

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -71,6 +71,10 @@ func writeTestExecutable(t *testing.T, dir, name string) string {
 		name += ".cmd"
 	}
 
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", dir, err)
+	}
+
 	path := filepath.Join(dir, name)
 	content := []byte("#!/bin/sh\nexit 0\n")
 	if runtime.GOOS == "windows" {
@@ -179,6 +183,7 @@ func TestRegistry_GoServerConfigReportsMissingGopls(t *testing.T) {
 
 func TestRegistry_PythonServerConfigPrefersWorkspaceLocalPyright(t *testing.T) {
 	r := NewRegistry()
+	t.Setenv("VIRTUAL_ENV", "")
 	workspace := t.TempDir()
 	localBin := filepath.Join(workspace, "node_modules", ".bin")
 	if err := os.MkdirAll(localBin, 0755); err != nil {
@@ -206,8 +211,61 @@ func TestRegistry_PythonServerConfigPrefersWorkspaceLocalPyright(t *testing.T) {
 	}
 }
 
+func TestRegistry_PythonServerConfigPrefersActiveVirtualEnvPyright(t *testing.T) {
+	r := NewRegistry()
+	projectRoot := t.TempDir()
+
+	venvPath := t.TempDir()
+	venvPyrightPath := writeTestExecutable(t, pythonVirtualEnvScriptDir(venvPath), "pyright-langserver")
+	t.Setenv("VIRTUAL_ENV", venvPath)
+
+	localBin := filepath.Join(projectRoot, "node_modules", ".bin")
+	if err := os.MkdirAll(localBin, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	writeTestExecutable(t, localBin, "pyright-langserver")
+
+	systemBin := t.TempDir()
+	writeTestExecutable(t, systemBin, "pyright-langserver")
+	t.Setenv("PATH", systemBin)
+
+	config, err := r.ServerConfigFor("python", projectRoot)
+	if err != nil {
+		t.Fatalf("ServerConfigFor(python): %v", err)
+	}
+
+	if config.Command != venvPyrightPath {
+		t.Errorf("Command = %q, want active virtualenv %q", config.Command, venvPyrightPath)
+	}
+	if config.Dir != projectRoot {
+		t.Errorf("Dir = %q, want detected project root %q", config.Dir, projectRoot)
+	}
+}
+
+func TestRegistry_PythonServerConfigUsesProjectVirtualEnvBeforePath(t *testing.T) {
+	r := NewRegistry()
+	projectRoot := t.TempDir()
+
+	venvPath := filepath.Join(projectRoot, ".venv")
+	venvPyrightPath := writeTestExecutable(t, pythonVirtualEnvScriptDir(venvPath), "pyright-langserver")
+
+	systemBin := t.TempDir()
+	writeTestExecutable(t, systemBin, "pyright-langserver")
+	t.Setenv("PATH", systemBin)
+
+	config, err := r.ServerConfigFor("python", projectRoot)
+	if err != nil {
+		t.Fatalf("ServerConfigFor(python): %v", err)
+	}
+
+	if config.Command != venvPyrightPath {
+		t.Errorf("Command = %q, want project virtualenv %q", config.Command, venvPyrightPath)
+	}
+}
+
 func TestRegistry_PythonServerConfigPrefersDetectedProjectLocalPyright(t *testing.T) {
 	r := NewRegistry()
+	t.Setenv("VIRTUAL_ENV", "")
 	repoRoot := t.TempDir()
 	projectRoot := filepath.Join(repoRoot, "services", "api")
 	localBin := filepath.Join(projectRoot, "node_modules", ".bin")
@@ -236,6 +294,7 @@ func TestRegistry_PythonServerConfigPrefersDetectedProjectLocalPyright(t *testin
 func TestRegistry_PythonServerConfigReportsMissingPyright(t *testing.T) {
 	r := NewRegistry()
 	t.Setenv("PATH", "")
+	t.Setenv("VIRTUAL_ENV", filepath.Join(t.TempDir(), "missing-venv"))
 
 	_, err := r.ServerConfigFor("python", t.TempDir())
 	if err == nil {
@@ -244,6 +303,13 @@ func TestRegistry_PythonServerConfigReportsMissingPyright(t *testing.T) {
 	if !contains(err.Error(), "npm install -g pyright") {
 		t.Errorf("error should include install instructions, got: %s", err.Error())
 	}
+}
+
+func pythonVirtualEnvScriptDir(venvPath string) string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(venvPath, "Scripts")
+	}
+	return filepath.Join(venvPath, "bin")
 }
 
 func TestRegistry_CaseInsensitive(t *testing.T) {

--- a/internal/lsp/registry.go
+++ b/internal/lsp/registry.go
@@ -183,6 +183,15 @@ func (r *Registry) resolveGoServer(projectRoot string) (*ServerConfig, error) {
 func (r *Registry) resolvePythonServer(projectRoot string) (*ServerConfig, error) {
 	binary := "pyright-langserver"
 
+	if path, ok := resolvePythonVirtualEnvBinary(projectRoot, binary); ok {
+		return &ServerConfig{
+			LanguageFamily: "python",
+			Command:        path,
+			Args:           []string{"--stdio"},
+			Dir:            projectRoot,
+		}, nil
+	}
+
 	if path, err := exec.LookPath(projectLocalNodeBin(projectRoot, binary)); err == nil {
 		return &ServerConfig{
 			LanguageFamily: "python",
@@ -196,8 +205,8 @@ func (r *Registry) resolvePythonServer(projectRoot string) (*ServerConfig, error
 	if err != nil {
 		return nil, fmt.Errorf(
 			"pyright-langserver not found: install it with " +
-				"\"npm install -g pyright\" " +
-				"or add pyright as a project dependency",
+				"\"npm install -g pyright\", add pyright as a project dependency, " +
+				"or activate a virtual environment that provides pyright-langserver",
 		)
 	}
 
@@ -207,4 +216,42 @@ func (r *Registry) resolvePythonServer(projectRoot string) (*ServerConfig, error
 		Args:           []string{"--stdio"},
 		Dir:            projectRoot,
 	}, nil
+}
+
+func resolvePythonVirtualEnvBinary(projectRoot, binary string) (string, bool) {
+	for _, venv := range pythonVirtualEnvDirs(projectRoot) {
+		for _, candidate := range pythonVirtualEnvBinaryCandidates(venv, binary) {
+			if path, err := exec.LookPath(candidate); err == nil {
+				return path, true
+			}
+		}
+	}
+	return "", false
+}
+
+func pythonVirtualEnvDirs(projectRoot string) []string {
+	dirs := make([]string, 0, 3)
+	if active := os.Getenv("VIRTUAL_ENV"); active != "" {
+		dirs = append(dirs, active)
+	}
+	if projectRoot != "" {
+		dirs = append(dirs,
+			filepath.Join(projectRoot, ".venv"),
+			filepath.Join(projectRoot, "venv"),
+		)
+	}
+	return dirs
+}
+
+func pythonVirtualEnvBinaryCandidates(venv, binary string) []string {
+	if runtime.GOOS == "windows" {
+		scriptsDir := filepath.Join(venv, "Scripts")
+		return []string{
+			filepath.Join(scriptsDir, binary+".exe"),
+			filepath.Join(scriptsDir, binary+".cmd"),
+			filepath.Join(scriptsDir, binary+".bat"),
+			filepath.Join(scriptsDir, binary),
+		}
+	}
+	return []string{filepath.Join(venv, "bin", binary)}
 }

--- a/internal/lsp/registry.go
+++ b/internal/lsp/registry.go
@@ -76,7 +76,8 @@ func (r *Registry) FamilyForExtension(ext string) string {
 // family and project root. The project root is whatever the caller has
 // resolved for the file being opened — for TypeScript that's the nearest
 // directory with tsconfig.json / jsconfig.json / package.json bounded by the
-// active workspace; for other families it remains the active workspace root.
+// active workspace; for Go/Python it is the nearest go.mod / Python project
+// marker, falling back to the active workspace root when no marker exists.
 //
 // Binary lookups (e.g. node_modules/.bin/typescript-language-server) and
 // local-TypeScript discovery use this project root, so monorepo packages get
@@ -161,7 +162,7 @@ func (r *Registry) resolveTypeScriptServer(projectRoot string) (*ServerConfig, e
 }
 
 // resolveGoServer finds and configures gopls.
-func (r *Registry) resolveGoServer(workspaceRoot string) (*ServerConfig, error) {
+func (r *Registry) resolveGoServer(projectRoot string) (*ServerConfig, error) {
 	path, err := exec.LookPath("gopls")
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -174,20 +175,20 @@ func (r *Registry) resolveGoServer(workspaceRoot string) (*ServerConfig, error) 
 	return &ServerConfig{
 		LanguageFamily: "go",
 		Command:        path,
-		Dir:            workspaceRoot,
+		Dir:            projectRoot,
 	}, nil
 }
 
 // resolvePythonServer finds and configures pyright-langserver.
-func (r *Registry) resolvePythonServer(workspaceRoot string) (*ServerConfig, error) {
+func (r *Registry) resolvePythonServer(projectRoot string) (*ServerConfig, error) {
 	binary := "pyright-langserver"
 
-	if path, err := exec.LookPath(projectLocalNodeBin(workspaceRoot, binary)); err == nil {
+	if path, err := exec.LookPath(projectLocalNodeBin(projectRoot, binary)); err == nil {
 		return &ServerConfig{
 			LanguageFamily: "python",
 			Command:        path,
 			Args:           []string{"--stdio"},
-			Dir:            workspaceRoot,
+			Dir:            projectRoot,
 		}, nil
 	}
 
@@ -204,6 +205,6 @@ func (r *Registry) resolvePythonServer(workspaceRoot string) (*ServerConfig, err
 		LanguageFamily: "python",
 		Command:        path,
 		Args:           []string{"--stdio"},
-		Dir:            workspaceRoot,
+		Dir:            projectRoot,
 	}, nil
 }


### PR DESCRIPTION
## Summary
- route Go LSP sessions to the nearest go.mod using the shared ResolveProjectRoot helper
- route Python LSP sessions to the nearest pyproject.toml, requirements.txt, or setup.py marker
- prefer pyright-langserver from VIRTUAL_ENV or project virtualenvs before project-local Node and PATH
- add manager and registry tests for detected roots and Python server resolution order

## Validation
- go test ./internal/lsp
- go test ./...

## Notes
- Addresses #75 and #76 follow-up work after #95.
- #74 and #76 are already closed with completion comments.