### PR TITLE
[codex] Add clickable run output error links

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,8 +25,8 @@ Firn IDE brings the focused, keyboard-first productivity of JetBrains IDEs to a 
 | UI/UX Polish | **COMPLETE** | #35-36 |
 | Milestone 2: Terminal Integration | **IN PROGRESS** | #10-12 complete, #47 open |
 | Milestone 3: Workspace Management | **IN PROGRESS** | #13-15 complete, #53-54 open |
-| Milestone 4: Run Profiles | **IN PROGRESS** | #16, #59-61 complete; #17-18, #62-64, #71 open |
-| Milestone 5: Language Server Protocol | **IN PROGRESS** | #19-22, #73 complete; #74-76 open |
+| Milestone 4: Run Profiles | **IN PROGRESS** | #16, #59-62 complete; #17-18, #63-64, #71 open |
+| Milestone 5: Language Server Protocol | **COMPLETE** | #19-22, #73-76 complete |
 | Milestone 6: Search | **COMPLETE** | #23-25 |
 | Milestone 7: Git Integration | Not started | #26-27 |
 | Performance | Not started | #37-39 |
@@ -40,11 +40,11 @@ Firn IDE brings the focused, keyboard-first productivity of JetBrains IDEs to a 
 
 ## Next Priorities
 
-1. **#75 / #76: Finish LSP epic** — apply the `ResolveProjectRoot(filePath, workspaceRoot, markers)` helper landed for #20 to nearest-`go.mod` (Go) and nearest-`pyproject.toml` / `requirements.txt` / `setup.py` (Python) detection. Closes epic #74.
-2. **#62: Run Profiles - Clickable Error Links** — parse common `file:line:col` output formats and jump from run output to source.
-3. **#64: Run Profiles - Environment Variants** — complete `ActiveVariant` env-file resolution and add the frontend variant selector.
-4. **#63: Run Profiles - Compound Profile Execution** — add sequential step execution, stop-on-failure, and per-step UI.
-5. **#53 then #54: Workspace Identity and File Tree Views** — workspace definitions, active accent, selector, then Project/Workspace tree modes.
+Current status: PR #96 is merged into `develop`; the LSP epic (#74), Go integration (#75), and Python integration (#76) are complete. Run output now supports clickable error links (#62).
+
+1. **#64: Run Profiles - Environment Variants** — complete `ActiveVariant` env-file resolution and add the frontend variant selector.
+2. **#63: Run Profiles - Compound Profile Execution** — add sequential step execution, stop-on-failure, and per-step UI.
+3. **#53 then #54: Workspace Identity and File Tree Views** — workspace definitions, active accent, selector, then Project/Workspace tree modes.
 
 ---
 
@@ -163,7 +163,7 @@ Sub-issues:
 - [x] #59: Core Process Runner — `os/exec` implementation, env/cwd/envFile, start/stop bindings
 - [x] #60: Output Streaming — pipe stdout/stderr, Wails events, output panel
 - [x] #61: Process Lifecycle UI — play/stop/restart controls, state indicators
-- [ ] #62: Clickable Error Links — `file:line:col` parsing, jump-to-error
+- [x] #62: Clickable Error Links — `file:line:col` parsing, jump-to-error
 - [ ] #63: Compound Profile Execution — sequential steps, stop-on-failure
 - [ ] #64: Environment Variants — env file swapping by active variant
 
@@ -178,7 +178,7 @@ Sub-issues:
 - [x] Play/stop/restart controls in run profile cards
 - [x] Running status indicators and status badges
 - [x] Output panel with streaming logs
-- [ ] Clickable file:line:col output links
+- [x] Clickable file:line:col output links
 - [ ] Compound execution view with stage indicators
 - [ ] Environment variant selector (`[env: dev ▾]`)
 - [ ] Edit profile form (create/modify saved profiles)
@@ -189,15 +189,16 @@ Sub-issues:
 
 ---
 
-## Milestone 5: Language Server Protocol (IN PROGRESS)
+## Milestone 5: Language Server Protocol (COMPLETE)
 
-### #74: LSP - Language Intelligence [Epic]
+### #74: LSP - Language Intelligence [Epic] ✅
 Epic for Firn's production LSP foundation and TypeScript vertical slice.
 - [x] Backend LSP foundation
 - [x] Frontend document sync
 - [x] Diagnostics UX and Problems panel
 - [x] Completion, hover, and definition UX
 - [x] TypeScript project-root detection completion (#20)
+- [x] Go/Python project-root detection completion (#75/#76 via PR #96)
 
 ### #19: LSP - Client Foundation ✅
 - [x] JSON-RPC 2.0 message handling
@@ -221,6 +222,7 @@ Epic for Firn's production LSP foundation and TypeScript vertical slice.
 - [x] Surface backend LSP status/errors through frontend events
 
 ### #20: LSP - TypeScript Integration ✅
+- [x] PR #95 merged into `develop` with per-package TypeScript project-root detection and nested-root reconnect handling
 - [x] Auto-detect TypeScript/JavaScript projects by nearest `tsconfig.json`, `jsconfig.json`, or `package.json` (bounded by active workspace)
 - [x] Resolve `typescript-language-server` from project-local install first, then PATH
 - [x] Launch `typescript-language-server --stdio`
@@ -244,15 +246,15 @@ Epic for Firn's production LSP foundation and TypeScript vertical slice.
 - [x] F12 and Cmd/Ctrl-click go-to-definition
 - [x] Cross-file definition navigation through the existing editor open flow
 
-### #75: LSP - Go Integration
-- [ ] Auto-detect Go workspaces by nearest `go.mod`
+### #75: LSP - Go Integration ✅
+- [x] Auto-detect Go workspaces by nearest `go.mod`
 - [x] Resolve and launch `gopls` through the shared LSP client
 - [x] Use shared diagnostics, hover, definition, and completion plumbing
-- [ ] Handle multi-module edge cases explicitly
+- [x] Handle multi-module edge cases explicitly through nearest-module root routing
 
-### #76: LSP - Python Integration
-- [ ] Auto-detect Python projects by nearest `pyproject.toml`, `requirements.txt`, or `setup.py`
-- [ ] Resolve `pyright-langserver` from active virtual environment before PATH
+### #76: LSP - Python Integration ✅
+- [x] Auto-detect Python projects by nearest `pyproject.toml`, `requirements.txt`, or `setup.py`
+- [x] Resolve `pyright-langserver` from active virtual environment before PATH
 - [x] Resolve and launch `pyright-langserver --stdio` through the shared LSP client
 - [x] Use shared diagnostics, hover, definition, and completion plumbing
 

--- a/frontend/src/__tests__/components/RunOutput/OutputLine.test.tsx
+++ b/frontend/src/__tests__/components/RunOutput/OutputLine.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { OutputLine } from '../../../components/RunOutput/OutputLine';
 import { useIDEStore } from '../../../stores/ideStore';
 
@@ -57,6 +57,23 @@ describe('OutputLine', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith('/repo/app.py', 12, 1, {
       shouldApply: expect.any(Function),
+    });
+  });
+
+  it('shows a toast when navigation rejects unexpectedly', async () => {
+    mockNavigate.mockRejectedValueOnce(new Error('boom'));
+
+    render(
+      <OutputLine text="src/App.tsx:7:11 - error TS2322" className="line" workspacePath="/repo" />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open src/App.tsx at line 7, column 11' }));
+
+    await waitFor(() => {
+      expect(useIDEStore.getState().toast).toEqual({
+        message: 'Failed to open linked output location: boom',
+        type: 'error',
+      });
     });
   });
 });

--- a/frontend/src/__tests__/components/RunOutput/OutputLine.test.tsx
+++ b/frontend/src/__tests__/components/RunOutput/OutputLine.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { OutputLine } from '../../../components/RunOutput/OutputLine';
+import { useIDEStore } from '../../../stores/ideStore';
+
+const mockNavigate = jest.fn();
+jest.mock('../../../utils/editorNavigation', () => ({
+  navigateToEditorLocation: (...args: unknown[]) => mockNavigate(...args),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useIDEStore.setState(useIDEStore.getInitialState());
+  useIDEStore.setState({ workspace: { name: 'Repo', path: '/repo' } });
+});
+
+describe('OutputLine', () => {
+  it('renders output without links when no file reference is present', () => {
+    render(<OutputLine text="build completed" className="line" />);
+
+    expect(screen.getByText('build completed')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('opens a referenced file at the parsed line and column', () => {
+    render(
+      <OutputLine
+        text="src/App.tsx:7:11 - error TS2322"
+        className="line"
+        workingDir="frontend"
+        workspacePath="/repo"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open src/App.tsx at line 7, column 11' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/repo/frontend/src/App.tsx', 7, 11, {
+      shouldApply: expect.any(Function),
+    });
+
+    const options = mockNavigate.mock.calls[0][3] as { shouldApply: () => boolean };
+    expect(options.shouldApply()).toBe(true);
+
+    useIDEStore.setState({ workspace: { name: 'Other', path: '/other' } });
+    expect(options.shouldApply()).toBe(false);
+  });
+
+  it('uses the workspace root when the profile working directory is empty', () => {
+    render(
+      <OutputLine
+        text='File "app.py", line 12, in <module>'
+        className="line"
+        workspacePath="/repo"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open app.py at line 12, column 1' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/repo/app.py', 12, 1, {
+      shouldApply: expect.any(Function),
+    });
+  });
+});

--- a/frontend/src/__tests__/stores/lifecycleStore.test.ts
+++ b/frontend/src/__tests__/stores/lifecycleStore.test.ts
@@ -1,5 +1,6 @@
 import { useIDEStore } from '../../stores/ideStore';
 import type { RunHistoryEntry } from '../../types/runOutput';
+import type { RunProfile } from '../../types/runProfile';
 
 // Reset lifecycle state between tests
 beforeEach(() => {
@@ -309,6 +310,64 @@ describe('lifecycleStore - stopRequestTimestamps', () => {
     const { handleRunStatus } = useIDEStore.getState();
     handleRunStatus('profile-1', 'running', 0, 11000);
     expect(useIDEStore.getState().stopRequestTimestamps['profile-1']).toBeUndefined();
+  });
+});
+
+describe('lifecycleStore - run output working directory snapshots', () => {
+  const makeProfile = (workingDir: string): RunProfile => ({
+    id: 'profile-1',
+    name: 'test',
+    type: 'single',
+    source: 'user',
+    command: 'npm test',
+    workingDir,
+  });
+
+  beforeEach(() => {
+    useIDEStore.setState({
+      runProfiles: [makeProfile('frontend')],
+      runOutputs: {},
+      activeRunOutputId: null,
+    });
+  });
+
+  it('keeps existing output links tied to the working directory from run start', () => {
+    const store = useIDEStore.getState();
+
+    store.handleRunStatus('profile-1', 'running', 0, 1000);
+    store.appendRunOutput({
+      profileId: 'profile-1',
+      stream: 'stderr',
+      data: 'src/App.tsx:7:11\n',
+      timestamp: 1001,
+    });
+
+    useIDEStore.setState({ runProfiles: [makeProfile('packages/web')] });
+
+    const output = useIDEStore.getState().runOutputs['profile-1'];
+    expect(output.workingDir).toBe('frontend');
+    expect(output.entries[0].text).toBe('src/App.tsx:7:11');
+  });
+
+  it('preserves previous run working directory separately when a profile is rerun', () => {
+    const store = useIDEStore.getState();
+
+    store.handleRunStatus('profile-1', 'running', 0, 1000);
+    store.appendRunOutput({
+      profileId: 'profile-1',
+      stream: 'stderr',
+      data: 'src/old.ts:1:1\n',
+      timestamp: 1001,
+    });
+    store.handleRunStatus('profile-1', 'failed', 1, 2000);
+
+    useIDEStore.setState({ runProfiles: [makeProfile('packages/web')] });
+    store.handleRunStatus('profile-1', 'running', 0, 3000);
+
+    const output = useIDEStore.getState().runOutputs['profile-1'];
+    expect(output.workingDir).toBe('packages/web');
+    expect(output.previousWorkingDir).toBe('frontend');
+    expect(output.previousEntries[0].text).toBe('src/old.ts:1:1');
   });
 });
 

--- a/frontend/src/__tests__/utils/parseFileReferences.test.ts
+++ b/frontend/src/__tests__/utils/parseFileReferences.test.ts
@@ -1,0 +1,109 @@
+import { parseFileReferences, resolveFileReferencePath } from '../../utils/parseFileReferences';
+
+describe('parseFileReferences', () => {
+  it('parses Go file:line:column output', () => {
+    const references = parseFileReferences('main.go:42:5: undefined: value');
+
+    expect(references).toEqual([
+      {
+        path: 'main.go',
+        line: 42,
+        column: 5,
+        startIndex: 0,
+        endIndex: 'main.go:42:5'.length,
+        text: 'main.go:42:5',
+      },
+    ]);
+  });
+
+  it('parses Node and TypeScript stack frames inside parentheses', () => {
+    const line = '    at Object.<anonymous> (src/index.ts:15:3)';
+    const references = parseFileReferences(line);
+
+    expect(references).toHaveLength(1);
+    expect(references[0]).toMatchObject({
+      path: 'src/index.ts',
+      line: 15,
+      column: 3,
+      text: 'src/index.ts:15:3',
+    });
+    expect(references[0].startIndex).toBe(line.indexOf('src/index.ts'));
+  });
+
+  it('parses parenthesized stack paths that contain spaces', () => {
+    const line = '    at main (/repo/My Project/src/index.ts:15:3)';
+    const references = parseFileReferences(line);
+
+    expect(references).toHaveLength(1);
+    expect(references[0]).toMatchObject({
+      path: '/repo/My Project/src/index.ts',
+      line: 15,
+      column: 3,
+      text: '/repo/My Project/src/index.ts:15:3',
+    });
+  });
+
+  it('parses bare TSX diagnostics', () => {
+    const references = parseFileReferences(
+      'src/components/Button.tsx:42:5 - error TS2741: Property missing'
+    );
+
+    expect(references).toHaveLength(1);
+    expect(references[0]).toMatchObject({
+      path: 'src/components/Button.tsx',
+      line: 42,
+      column: 5,
+      text: 'src/components/Button.tsx:42:5',
+    });
+  });
+
+  it('parses Python traceback frames with a default column', () => {
+    const line = '  File "app.py", line 42, in <module>';
+    const references = parseFileReferences(line);
+
+    expect(references).toEqual([
+      {
+        path: 'app.py',
+        line: 42,
+        column: 1,
+        startIndex: 2,
+        endIndex: 24,
+        text: 'File "app.py", line 42',
+      },
+    ]);
+  });
+
+  it('parses multiple references in one line', () => {
+    const references = parseFileReferences('src/a.ts:1:2 -> src/b.ts:3:4');
+
+    expect(references.map((reference) => reference.path)).toEqual(['src/a.ts', 'src/b.ts']);
+    expect(references.map((reference) => [reference.line, reference.column])).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+});
+
+describe('resolveFileReferencePath', () => {
+  it('resolves relative references against a relative profile working directory', () => {
+    expect(resolveFileReferencePath('src/App.tsx', 'frontend', '/repo')).toBe(
+      '/repo/frontend/src/App.tsx'
+    );
+  });
+
+  it('falls back to the workspace path when the profile has no working directory', () => {
+    expect(resolveFileReferencePath('main.go', undefined, '/repo')).toBe('/repo/main.go');
+  });
+
+  it('keeps absolute references absolute', () => {
+    expect(resolveFileReferencePath('/tmp/project/main.go', 'frontend', '/repo')).toBe(
+      '/tmp/project/main.go'
+    );
+  });
+
+  it('normalizes dot segments while resolving', () => {
+    expect(resolveFileReferencePath('../pkg/main.go', 'cmd/server', '/repo/app')).toBe(
+      '/repo/app/cmd/pkg/main.go'
+    );
+  });
+});

--- a/frontend/src/__tests__/utils/parseFileReferences.test.ts
+++ b/frontend/src/__tests__/utils/parseFileReferences.test.ts
@@ -57,6 +57,20 @@ describe('parseFileReferences', () => {
     });
   });
 
+  it('parses TypeScript and MSBuild-style parenthesized diagnostics', () => {
+    const references = parseFileReferences(
+      'src/components/Button.tsx(42,5): error TS2741: Property missing'
+    );
+
+    expect(references).toHaveLength(1);
+    expect(references[0]).toMatchObject({
+      path: 'src/components/Button.tsx',
+      line: 42,
+      column: 5,
+      text: 'src/components/Button.tsx(42,5)',
+    });
+  });
+
   it('parses Python traceback frames with a default column', () => {
     const line = '  File "app.py", line 42, in <module>';
     const references = parseFileReferences(line);

--- a/frontend/src/components/RunOutput/DiffView.tsx
+++ b/frontend/src/components/RunOutput/DiffView.tsx
@@ -2,14 +2,17 @@ import { useRef, useMemo } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { OutputEntry } from '../../types/runOutput';
 import { diffOutputLines } from '../../utils/diffOutput';
+import { OutputLine } from './OutputLine';
 import styles from './RunOutput.module.css';
 
 interface DiffViewProps {
   entries: OutputEntry[];
   previousEntries: OutputEntry[];
+  workingDir?: string;
+  workspacePath?: string;
 }
 
-export function DiffView({ entries, previousEntries }: DiffViewProps) {
+export function DiffView({ entries, previousEntries, workingDir, workspacePath }: DiffViewProps) {
   const parentRef = useRef<HTMLDivElement>(null);
 
   const diffLines = useMemo(() => {
@@ -75,7 +78,12 @@ export function DiffView({ entries, previousEntries }: DiffViewProps) {
               <span className={styles.diffMarker}>
                 {line.type === 'added' ? '+' : line.type === 'removed' ? '−' : ' '}
               </span>
-              {line.text}
+              <OutputLine
+                text={line.text}
+                className={styles.diffText}
+                workingDir={workingDir}
+                workspacePath={workspacePath}
+              />
             </div>
           );
         })}

--- a/frontend/src/components/RunOutput/DiffView.tsx
+++ b/frontend/src/components/RunOutput/DiffView.tsx
@@ -9,10 +9,17 @@ interface DiffViewProps {
   entries: OutputEntry[];
   previousEntries: OutputEntry[];
   workingDir?: string;
+  previousWorkingDir?: string;
   workspacePath?: string;
 }
 
-export function DiffView({ entries, previousEntries, workingDir, workspacePath }: DiffViewProps) {
+export function DiffView({
+  entries,
+  previousEntries,
+  workingDir,
+  previousWorkingDir,
+  workspacePath,
+}: DiffViewProps) {
   const parentRef = useRef<HTMLDivElement>(null);
 
   const diffLines = useMemo(() => {
@@ -81,7 +88,7 @@ export function DiffView({ entries, previousEntries, workingDir, workspacePath }
               <OutputLine
                 text={line.text}
                 className={styles.diffText}
-                workingDir={workingDir}
+                workingDir={line.type === 'removed' ? previousWorkingDir : workingDir}
                 workspacePath={workspacePath}
               />
             </div>

--- a/frontend/src/components/RunOutput/LanesView.tsx
+++ b/frontend/src/components/RunOutput/LanesView.tsx
@@ -1,11 +1,14 @@
 import { useRef, useEffect, useMemo } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { OutputEntry } from '../../types/runOutput';
+import { OutputLine } from './OutputLine';
 import styles from './RunOutput.module.css';
 
 interface LanesViewProps {
   entries: OutputEntry[];
   autoScroll: boolean;
+  workingDir?: string;
+  workspacePath?: string;
 }
 
 interface LaneRow {
@@ -13,7 +16,7 @@ interface LaneRow {
   stderr: string | null;
 }
 
-export function LanesView({ entries, autoScroll }: LanesViewProps) {
+export function LanesView({ entries, autoScroll, workingDir, workspacePath }: LanesViewProps) {
   const parentRef = useRef<HTMLDivElement>(null);
 
   const rows = useMemo(() => {
@@ -75,10 +78,18 @@ export function LanesView({ entries, autoScroll }: LanesViewProps) {
               ref={virtualizer.measureElement}
               data-index={virtualRow.index}
             >
-              <div className={styles.laneLine}>{row.stdout ?? ''}</div>
-              <div className={`${styles.laneLine} ${row.stderr != null ? styles.stderr : ''}`}>
-                {row.stderr ?? ''}
-              </div>
+              <OutputLine
+                text={row.stdout ?? ''}
+                className={styles.laneLine}
+                workingDir={workingDir}
+                workspacePath={workspacePath}
+              />
+              <OutputLine
+                text={row.stderr ?? ''}
+                className={`${styles.laneLine} ${row.stderr != null ? styles.stderr : ''}`}
+                workingDir={workingDir}
+                workspacePath={workspacePath}
+              />
             </div>
           );
         })}

--- a/frontend/src/components/RunOutput/MergedView.tsx
+++ b/frontend/src/components/RunOutput/MergedView.tsx
@@ -4,6 +4,7 @@ import type { OutputEntry } from '../../types/runOutput';
 import { isFoldedRegion } from '../../types/runOutput';
 import { foldOutput } from '../../utils/foldOutput';
 import { SmartFold } from './SmartFold';
+import { OutputLine } from './OutputLine';
 import styles from './RunOutput.module.css';
 
 interface MergedViewProps {
@@ -11,9 +12,18 @@ interface MergedViewProps {
   autoScroll: boolean;
   expandedFolds: Set<string>;
   onToggleFold: (foldId: string) => void;
+  workingDir?: string;
+  workspacePath?: string;
 }
 
-export function MergedView({ entries, autoScroll, expandedFolds, onToggleFold }: MergedViewProps) {
+export function MergedView({
+  entries,
+  autoScroll,
+  expandedFolds,
+  onToggleFold,
+  workingDir,
+  workspacePath,
+}: MergedViewProps) {
   const parentRef = useRef<HTMLDivElement>(null);
   const items = useMemo(() => foldOutput(entries), [entries]);
 
@@ -63,9 +73,16 @@ export function MergedView({ entries, autoScroll, expandedFolds, onToggleFold }:
                   fold={item}
                   isExpanded={expandedFolds.has(item.id)}
                   onToggle={onToggleFold}
+                  workingDir={workingDir}
+                  workspacePath={workspacePath}
                 />
               ) : (
-                <div className={`${styles.outputLine} ${styles[item.stream]}`}>{item.text}</div>
+                <OutputLine
+                  text={item.text}
+                  className={`${styles.outputLine} ${styles[item.stream]}`}
+                  workingDir={workingDir}
+                  workspacePath={workspacePath}
+                />
               )}
             </div>
           );

--- a/frontend/src/components/RunOutput/OutputLine.tsx
+++ b/frontend/src/components/RunOutput/OutputLine.tsx
@@ -27,7 +27,14 @@ export function OutputLine({ text, className, workingDir, workspacePath }: Outpu
           }
         : undefined;
 
-      await navigateToEditorLocation(path, reference.line, reference.column, options);
+      try {
+        await navigateToEditorLocation(path, reference.line, reference.column, options);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        useIDEStore
+          .getState()
+          .showToast(`Failed to open linked output location: ${message}`, 'error');
+      }
     },
     [workingDir, workspacePath]
   );

--- a/frontend/src/components/RunOutput/OutputLine.tsx
+++ b/frontend/src/components/RunOutput/OutputLine.tsx
@@ -1,0 +1,70 @@
+import { useCallback, useMemo, type ReactNode } from 'react';
+import { useIDEStore } from '../../stores/ideStore';
+import {
+  parseFileReferences,
+  resolveFileReferencePath,
+  type FileReference,
+} from '../../utils/parseFileReferences';
+import { navigateToEditorLocation } from '../../utils/editorNavigation';
+import styles from './RunOutput.module.css';
+
+interface OutputLineProps {
+  text: string;
+  className: string;
+  workingDir?: string;
+  workspacePath?: string;
+}
+
+export function OutputLine({ text, className, workingDir, workspacePath }: OutputLineProps) {
+  const references = useMemo(() => parseFileReferences(text), [text]);
+
+  const openReference = useCallback(
+    async (reference: FileReference) => {
+      const path = resolveFileReferencePath(reference.path, workingDir, workspacePath);
+      const options = workspacePath
+        ? {
+            shouldApply: () => useIDEStore.getState().workspace?.path === workspacePath,
+          }
+        : undefined;
+
+      await navigateToEditorLocation(path, reference.line, reference.column, options);
+    },
+    [workingDir, workspacePath]
+  );
+
+  if (references.length === 0) {
+    return <div className={className}>{text}</div>;
+  }
+
+  const parts: ReactNode[] = [];
+  let cursor = 0;
+
+  for (const reference of references) {
+    if (reference.startIndex > cursor) {
+      parts.push(text.slice(cursor, reference.startIndex));
+    }
+
+    parts.push(
+      <button
+        key={`${reference.startIndex}-${reference.endIndex}`}
+        type="button"
+        className={styles.outputLink}
+        title={resolveFileReferencePath(reference.path, workingDir, workspacePath)}
+        aria-label={`Open ${reference.path} at line ${reference.line}, column ${reference.column}`}
+        onClick={() => {
+          void openReference(reference);
+        }}
+      >
+        {text.slice(reference.startIndex, reference.endIndex)}
+      </button>
+    );
+
+    cursor = reference.endIndex;
+  }
+
+  if (cursor < text.length) {
+    parts.push(text.slice(cursor));
+  }
+
+  return <div className={className}>{parts}</div>;
+}

--- a/frontend/src/components/RunOutput/RunOutput.module.css
+++ b/frontend/src/components/RunOutput/RunOutput.module.css
@@ -209,6 +209,34 @@
   padding-left: 8px;
 }
 
+.outputLink {
+  display: inline;
+  padding: 0;
+  margin: 0;
+  color: var(--accent);
+  font: inherit;
+  text-align: left;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--accent) 50%, transparent);
+  text-underline-offset: 2px;
+  white-space: inherit;
+  word-break: inherit;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+}
+
+.outputLink:hover {
+  color: #93c5fd;
+  text-decoration-color: currentColor;
+}
+
+.outputLink:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
 /* ── Lanes View ────────────────────────────────────────── */
 .lanesView {
   display: flex;
@@ -329,11 +357,18 @@
 }
 
 .diffLine {
+  display: flex;
+  align-items: flex-start;
   min-height: 20px;
   white-space: pre-wrap;
   word-break: break-all;
   padding: 0 4px;
   border-radius: 2px;
+}
+
+.diffText {
+  flex: 1;
+  min-width: 0;
 }
 
 .diffLine.unchanged {

--- a/frontend/src/components/RunOutput/RunOutputPanel.tsx
+++ b/frontend/src/components/RunOutput/RunOutputPanel.tsx
@@ -1,10 +1,9 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback } from 'react';
 import {
   useActiveRunOutput,
   useRunOutputViewMode,
   useRunOutputAutoScroll,
   useRunOutputs,
-  useRunProfiles,
   useWorkspace,
 } from '../../stores/ideStore';
 import { RunOutputToolbar } from './RunOutputToolbar';
@@ -20,20 +19,11 @@ export function RunOutputPanel() {
   const viewMode = useRunOutputViewMode();
   const autoScroll = useRunOutputAutoScroll();
   const runOutputs = useRunOutputs();
-  const runProfiles = useRunProfiles();
   const workspace = useWorkspace();
   const [expandedFolds, setExpandedFolds] = useState<Set<string>>(new Set());
 
-  const profileWorkingDirs = useMemo(() => {
-    const workingDirs: Record<string, string | undefined> = {};
-    for (const profile of runProfiles) {
-      workingDirs[profile.id] = profile.workingDir;
-    }
-    return workingDirs;
-  }, [runProfiles]);
-
   const workspacePath = workspace?.path;
-  const activeWorkingDir = activeOutput ? profileWorkingDirs[activeOutput.profileId] : undefined;
+  const activeWorkingDir = activeOutput?.workingDir;
 
   const handleToggleFold = useCallback((foldId: string) => {
     setExpandedFolds((prev) => {
@@ -55,7 +45,6 @@ export function RunOutputPanel() {
         <TimelineView
           runOutputs={runOutputs}
           autoScroll={autoScroll}
-          profileWorkingDirs={profileWorkingDirs}
           workspacePath={workspacePath}
         />
       ) : activeOutput ? (
@@ -83,6 +72,7 @@ export function RunOutputPanel() {
               entries={activeOutput.entries}
               previousEntries={activeOutput.previousEntries}
               workingDir={activeWorkingDir}
+              previousWorkingDir={activeOutput.previousWorkingDir}
               workspacePath={workspacePath}
             />
           )}

--- a/frontend/src/components/RunOutput/RunOutputPanel.tsx
+++ b/frontend/src/components/RunOutput/RunOutputPanel.tsx
@@ -1,9 +1,11 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import {
   useActiveRunOutput,
   useRunOutputViewMode,
   useRunOutputAutoScroll,
   useRunOutputs,
+  useRunProfiles,
+  useWorkspace,
 } from '../../stores/ideStore';
 import { RunOutputToolbar } from './RunOutputToolbar';
 import { RunOutputTabs } from './RunOutputTabs';
@@ -18,7 +20,20 @@ export function RunOutputPanel() {
   const viewMode = useRunOutputViewMode();
   const autoScroll = useRunOutputAutoScroll();
   const runOutputs = useRunOutputs();
+  const runProfiles = useRunProfiles();
+  const workspace = useWorkspace();
   const [expandedFolds, setExpandedFolds] = useState<Set<string>>(new Set());
+
+  const profileWorkingDirs = useMemo(() => {
+    const workingDirs: Record<string, string | undefined> = {};
+    for (const profile of runProfiles) {
+      workingDirs[profile.id] = profile.workingDir;
+    }
+    return workingDirs;
+  }, [runProfiles]);
+
+  const workspacePath = workspace?.path;
+  const activeWorkingDir = activeOutput ? profileWorkingDirs[activeOutput.profileId] : undefined;
 
   const handleToggleFold = useCallback((foldId: string) => {
     setExpandedFolds((prev) => {
@@ -37,7 +52,12 @@ export function RunOutputPanel() {
       <RunOutputTabs />
       <RunOutputToolbar />
       {viewMode === 'timeline' ? (
-        <TimelineView runOutputs={runOutputs} autoScroll={autoScroll} />
+        <TimelineView
+          runOutputs={runOutputs}
+          autoScroll={autoScroll}
+          profileWorkingDirs={profileWorkingDirs}
+          workspacePath={workspacePath}
+        />
       ) : activeOutput ? (
         <>
           {viewMode === 'merged' && (
@@ -46,15 +66,24 @@ export function RunOutputPanel() {
               autoScroll={autoScroll}
               expandedFolds={expandedFolds}
               onToggleFold={handleToggleFold}
+              workingDir={activeWorkingDir}
+              workspacePath={workspacePath}
             />
           )}
           {viewMode === 'lanes' && (
-            <LanesView entries={activeOutput.entries} autoScroll={autoScroll} />
+            <LanesView
+              entries={activeOutput.entries}
+              autoScroll={autoScroll}
+              workingDir={activeWorkingDir}
+              workspacePath={workspacePath}
+            />
           )}
           {viewMode === 'diff' && (
             <DiffView
               entries={activeOutput.entries}
               previousEntries={activeOutput.previousEntries}
+              workingDir={activeWorkingDir}
+              workspacePath={workspacePath}
             />
           )}
         </>

--- a/frontend/src/components/RunOutput/SmartFold.tsx
+++ b/frontend/src/components/RunOutput/SmartFold.tsx
@@ -1,13 +1,22 @@
 import type { FoldedRegion } from '../../types/runOutput';
+import { OutputLine } from './OutputLine';
 import styles from './RunOutput.module.css';
 
 interface SmartFoldProps {
   fold: FoldedRegion;
   isExpanded: boolean;
   onToggle: (foldId: string) => void;
+  workingDir?: string;
+  workspacePath?: string;
 }
 
-export function SmartFold({ fold, isExpanded, onToggle }: SmartFoldProps) {
+export function SmartFold({
+  fold,
+  isExpanded,
+  onToggle,
+  workingDir,
+  workspacePath,
+}: SmartFoldProps) {
   if (!isExpanded) {
     return (
       <div
@@ -52,9 +61,13 @@ export function SmartFold({ fold, isExpanded, onToggle }: SmartFoldProps) {
       </div>
       <div className={styles.foldExpandedBody}>
         {fold.entries.map((entry, idx) => (
-          <div key={idx} className={`${styles.outputLine} ${styles[entry.stream]}`}>
-            {entry.text}
-          </div>
+          <OutputLine
+            key={idx}
+            text={entry.text}
+            className={`${styles.outputLine} ${styles[entry.stream]}`}
+            workingDir={workingDir}
+            workspacePath={workspacePath}
+          />
         ))}
       </div>
     </div>

--- a/frontend/src/components/RunOutput/TimelineView.tsx
+++ b/frontend/src/components/RunOutput/TimelineView.tsx
@@ -7,7 +7,6 @@ import styles from './RunOutput.module.css';
 interface TimelineViewProps {
   runOutputs: Record<string, RunOutput>;
   autoScroll: boolean;
-  profileWorkingDirs: Record<string, string | undefined>;
   workspacePath?: string;
 }
 
@@ -22,12 +21,7 @@ function formatTimestamp(ts: number): string {
   return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}:${d.getSeconds().toString().padStart(2, '0')}.${d.getMilliseconds().toString().padStart(3, '0')}`;
 }
 
-export function TimelineView({
-  runOutputs,
-  autoScroll,
-  profileWorkingDirs,
-  workspacePath,
-}: TimelineViewProps) {
+export function TimelineView({ runOutputs, autoScroll, workspacePath }: TimelineViewProps) {
   const parentRef = useRef<HTMLDivElement>(null);
   const profileIds = useMemo(() => Object.keys(runOutputs), [runOutputs]);
   const profileColorMap = useMemo(() => {
@@ -98,7 +92,7 @@ export function TimelineView({
               <OutputLine
                 text={entry.text}
                 className={`${styles.timelineData} ${entry.stream === 'stderr' ? styles.stderr : ''}`}
-                workingDir={profileWorkingDirs[entry.profileId]}
+                workingDir={runOutputs[entry.profileId]?.workingDir}
                 workspacePath={workspacePath}
               />
             </div>

--- a/frontend/src/components/RunOutput/TimelineView.tsx
+++ b/frontend/src/components/RunOutput/TimelineView.tsx
@@ -1,11 +1,14 @@
 import { useRef, useEffect, useMemo } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { RunOutput, OutputEntry } from '../../types/runOutput';
+import { OutputLine } from './OutputLine';
 import styles from './RunOutput.module.css';
 
 interface TimelineViewProps {
   runOutputs: Record<string, RunOutput>;
   autoScroll: boolean;
+  profileWorkingDirs: Record<string, string | undefined>;
+  workspacePath?: string;
 }
 
 interface TimelineEntry extends OutputEntry {
@@ -19,7 +22,12 @@ function formatTimestamp(ts: number): string {
   return `${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}:${d.getSeconds().toString().padStart(2, '0')}.${d.getMilliseconds().toString().padStart(3, '0')}`;
 }
 
-export function TimelineView({ runOutputs, autoScroll }: TimelineViewProps) {
+export function TimelineView({
+  runOutputs,
+  autoScroll,
+  profileWorkingDirs,
+  workspacePath,
+}: TimelineViewProps) {
   const parentRef = useRef<HTMLDivElement>(null);
   const profileIds = useMemo(() => Object.keys(runOutputs), [runOutputs]);
   const profileColorMap = useMemo(() => {
@@ -87,11 +95,12 @@ export function TimelineView({ runOutputs, autoScroll }: TimelineViewProps) {
               <span className={`${styles.timelineProfile} ${styles[colorClass]}`}>
                 {entry.profileId}
               </span>
-              <span
+              <OutputLine
+                text={entry.text}
                 className={`${styles.timelineData} ${entry.stream === 'stderr' ? styles.stderr : ''}`}
-              >
-                {entry.text}
-              </span>
+                workingDir={profileWorkingDirs[entry.profileId]}
+                workspacePath={workspacePath}
+              />
             </div>
           );
         })}

--- a/frontend/src/stores/ideStore.ts
+++ b/frontend/src/stores/ideStore.ts
@@ -291,6 +291,25 @@ function getOrCreateAssembler(
   return assembler;
 }
 
+function getProfileWorkingDirSnapshot(
+  state: Pick<IDEState, 'runProfiles'>,
+  profileId: string
+): string | undefined {
+  return state.runProfiles.find((profile) => profile.id === profileId)?.workingDir;
+}
+
+function createRunOutput(profileId: string, workingDir?: string): RunOutput {
+  return {
+    profileId,
+    workingDir,
+    state: 'idle',
+    exitCode: 0,
+    runCount: 0,
+    entries: [],
+    previousEntries: [],
+  };
+}
+
 export const useIDEStore = create<IDEStore>()(
   devtools(
     (set, get) => ({
@@ -591,14 +610,10 @@ export const useIDEStore = create<IDEStore>()(
             (state) => ({
               runOutputs: {
                 ...state.runOutputs,
-                [chunk.profileId]: {
-                  profileId: chunk.profileId,
-                  state: 'idle' as RunState,
-                  exitCode: 0,
-                  runCount: 0,
-                  entries: [],
-                  previousEntries: [],
-                },
+                [chunk.profileId]: createRunOutput(
+                  chunk.profileId,
+                  getProfileWorkingDirSnapshot(state, chunk.profileId)
+                ),
               },
             }),
             false,
@@ -662,14 +677,9 @@ export const useIDEStore = create<IDEStore>()(
 
         set(
           (state) => {
-            const existing = state.runOutputs[profileId] ?? {
-              profileId,
-              state: 'idle' as RunState,
-              exitCode: 0,
-              runCount: 0,
-              entries: [],
-              previousEntries: [],
-            };
+            const runWorkingDir = getProfileWorkingDirSnapshot(state, profileId);
+            const existing =
+              state.runOutputs[profileId] ?? createRunOutput(profileId, runWorkingDir);
 
             // Merge any flushed carry-over entries
             const mergedEntries =
@@ -680,6 +690,9 @@ export const useIDEStore = create<IDEStore>()(
             const updated = { ...existing, state: newState, exitCode, entries: mergedEntries };
 
             if (newState === 'running') {
+              const previousWorkingDir = existing.workingDir;
+              updated.workingDir = runWorkingDir;
+              updated.previousWorkingDir = undefined;
               updated.runCount = existing.runCount + 1;
               if (updated.runCount > 1) {
                 let prev = existing.entries;
@@ -687,6 +700,7 @@ export const useIDEStore = create<IDEStore>()(
                   prev = prev.slice(prev.length - MAX_OUTPUT_ENTRIES);
                 }
                 updated.previousEntries = prev;
+                updated.previousWorkingDir = previousWorkingDir;
                 updated.entries = [];
                 lineAssemblers.delete(profileId);
                 assemblerCallbacks.delete(profileId);
@@ -718,14 +732,9 @@ export const useIDEStore = create<IDEStore>()(
         set(
           (state) => {
             // --- RunOutput update (same logic as setRunState) ---
-            const existing = state.runOutputs[profileId] ?? {
-              profileId,
-              state: 'idle' as RunState,
-              exitCode: 0,
-              runCount: 0,
-              entries: [],
-              previousEntries: [],
-            };
+            const runWorkingDir = getProfileWorkingDirSnapshot(state, profileId);
+            const existing =
+              state.runOutputs[profileId] ?? createRunOutput(profileId, runWorkingDir);
 
             const mergedEntries =
               flushedEntries.length > 0
@@ -735,6 +744,9 @@ export const useIDEStore = create<IDEStore>()(
             const updated = { ...existing, state: newState, exitCode, entries: mergedEntries };
 
             if (newState === 'running') {
+              const previousWorkingDir = existing.workingDir;
+              updated.workingDir = runWorkingDir;
+              updated.previousWorkingDir = undefined;
               updated.runCount = existing.runCount + 1;
               if (updated.runCount > 1) {
                 let prev = existing.entries;
@@ -742,6 +754,7 @@ export const useIDEStore = create<IDEStore>()(
                   prev = prev.slice(prev.length - MAX_OUTPUT_ENTRIES);
                 }
                 updated.previousEntries = prev;
+                updated.previousWorkingDir = previousWorkingDir;
                 updated.entries = [];
                 lineAssemblers.delete(profileId);
                 assemblerCallbacks.delete(profileId);
@@ -839,7 +852,12 @@ export const useIDEStore = create<IDEStore>()(
               return {
                 runOutputs: {
                   ...state.runOutputs,
-                  [profileId]: { ...existing, entries: [], previousEntries: [] },
+                  [profileId]: {
+                    ...existing,
+                    entries: [],
+                    previousEntries: [],
+                    previousWorkingDir: undefined,
+                  },
                 },
               };
             }
@@ -870,7 +888,12 @@ export const useIDEStore = create<IDEStore>()(
             const preserved: Record<string, RunOutput> = {};
             for (const [id, output] of Object.entries(state.runOutputs)) {
               if (output.state === 'running') {
-                preserved[id] = { ...output, entries: [], previousEntries: [] };
+                preserved[id] = {
+                  ...output,
+                  entries: [],
+                  previousEntries: [],
+                  previousWorkingDir: undefined,
+                };
               }
             }
             const firstId = Object.keys(preserved)[0] ?? null;
@@ -1017,7 +1040,12 @@ export const useIDEStore = create<IDEStore>()(
             const preserved: Record<string, RunOutput> = {};
             for (const [id, output] of Object.entries(state.runOutputs)) {
               if (output.state === 'running') {
-                preserved[id] = { ...output, entries: [], previousEntries: [] };
+                preserved[id] = {
+                  ...output,
+                  entries: [],
+                  previousEntries: [],
+                  previousWorkingDir: undefined,
+                };
               }
             }
             const firstId = Object.keys(preserved)[0] ?? null;

--- a/frontend/src/types/runOutput.ts
+++ b/frontend/src/types/runOutput.ts
@@ -33,6 +33,8 @@ export type RunOutputViewMode = 'merged' | 'lanes' | 'diff' | 'timeline';
 
 export interface RunOutput {
   profileId: string;
+  workingDir?: string;
+  previousWorkingDir?: string;
   state: RunState;
   exitCode: number;
   runCount: number;

--- a/frontend/src/utils/parseFileReferences.ts
+++ b/frontend/src/utils/parseFileReferences.ts
@@ -73,6 +73,10 @@ const FILE_LINE_COLUMN_PATTERN = new RegExp(
   `(^|[^\\w./\\\\:-])(${FILE_PATH}):(\\d+)(?::(\\d+))?`,
   'gi'
 );
+const PAREN_FILE_LINE_COLUMN_PATTERN = new RegExp(
+  `(^|[^\\w./\\\\:-])(${FILE_PATH})\\((\\d+),(\\d+)\\)`,
+  'gi'
+);
 const WRAPPED_FILE_PATH = `(?:[A-Za-z]:)?[^:\r\n]*?\\.(?:${CODE_EXTENSIONS})`;
 const WRAPPED_FILE_LINE_COLUMN_PATTERN = new RegExp(
   `([\\(\\[\\{"'\`])(${WRAPPED_FILE_PATH}):(\\d+)(?::(\\d+))?(?=[\\)\\]\\}"'\`])`,
@@ -150,6 +154,23 @@ export function parseFileReferences(text: string): FileReference[] {
   }
 
   for (const match of text.matchAll(FILE_LINE_COLUMN_PATTERN)) {
+    const boundary = match[1] ?? '';
+    const referenceText = match[0].slice(boundary.length);
+    const startIndex = (match.index ?? 0) + boundary.length;
+    const reference = createReference(
+      match[2],
+      match[3],
+      match[4],
+      startIndex,
+      startIndex + referenceText.length,
+      referenceText
+    );
+    if (reference) {
+      references.push(reference);
+    }
+  }
+
+  for (const match of text.matchAll(PAREN_FILE_LINE_COLUMN_PATTERN)) {
     const boundary = match[1] ?? '';
     const referenceText = match[0].slice(boundary.length);
     const startIndex = (match.index ?? 0) + boundary.length;

--- a/frontend/src/utils/parseFileReferences.ts
+++ b/frontend/src/utils/parseFileReferences.ts
@@ -1,0 +1,268 @@
+export interface FileReference {
+  path: string;
+  line: number;
+  column: number;
+  startIndex: number;
+  endIndex: number;
+  text: string;
+}
+
+const CODE_EXTENSIONS = [
+  'astro',
+  'bash',
+  'c',
+  'cc',
+  'cjs',
+  'clj',
+  'cljs',
+  'cpp',
+  'cs',
+  'css',
+  'cts',
+  'cxx',
+  'ex',
+  'exs',
+  'fs',
+  'fsx',
+  'go',
+  'h',
+  'hpp',
+  'hs',
+  'html',
+  'java',
+  'js',
+  'json',
+  'jsx',
+  'kt',
+  'kts',
+  'less',
+  'lua',
+  'm',
+  'md',
+  'mdx',
+  'mjs',
+  'mm',
+  'mts',
+  'php',
+  'py',
+  'pyi',
+  'r',
+  'rb',
+  'rs',
+  'sass',
+  'scala',
+  'scss',
+  'sh',
+  'sql',
+  'svelte',
+  'swift',
+  'toml',
+  'ts',
+  'tsx',
+  'vue',
+  'xml',
+  'yaml',
+  'yml',
+  'zsh',
+].join('|');
+
+const PATH_SEGMENT = '[^:\\s()[\\]{}"\'`<>|]+';
+const FILE_PATH = `(?:[A-Za-z]:)?(?:(?:\\.{1,2}|~)?[\\\\/])?(?:${PATH_SEGMENT}[\\\\/])*${PATH_SEGMENT}\\.(?:${CODE_EXTENSIONS})`;
+
+const FILE_LINE_COLUMN_PATTERN = new RegExp(
+  `(^|[^\\w./\\\\:-])(${FILE_PATH}):(\\d+)(?::(\\d+))?`,
+  'gi'
+);
+const WRAPPED_FILE_PATH = `(?:[A-Za-z]:)?[^:\r\n]*?\\.(?:${CODE_EXTENSIONS})`;
+const WRAPPED_FILE_LINE_COLUMN_PATTERN = new RegExp(
+  `([\\(\\[\\{"'\`])(${WRAPPED_FILE_PATH}):(\\d+)(?::(\\d+))?(?=[\\)\\]\\}"'\`])`,
+  'gi'
+);
+const PYTHON_TRACEBACK_PATTERN = /(^|[^\w./\\:-])(File\s+"([^"\r\n]+)",\s+line\s+(\d+))/g;
+
+function toPositiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function createReference(
+  path: string,
+  lineValue: string | undefined,
+  columnValue: string | undefined,
+  startIndex: number,
+  endIndex: number,
+  text: string
+): FileReference | null {
+  const cleanPath = path.trim();
+  if (!cleanPath || cleanPath.includes('\0')) return null;
+
+  const line = toPositiveInteger(lineValue, 1);
+  const column = toPositiveInteger(columnValue, 1);
+
+  return {
+    path: cleanPath,
+    line,
+    column,
+    startIndex,
+    endIndex,
+    text,
+  };
+}
+
+function withoutOverlaps(references: FileReference[]): FileReference[] {
+  const sorted = [...references].sort(
+    (a, b) => a.startIndex - b.startIndex || b.endIndex - a.endIndex
+  );
+  const filtered: FileReference[] = [];
+
+  for (const reference of sorted) {
+    const overlaps = filtered.some(
+      (existing) =>
+        reference.startIndex < existing.endIndex && reference.endIndex > existing.startIndex
+    );
+    if (!overlaps) {
+      filtered.push(reference);
+    }
+  }
+
+  return filtered.sort((a, b) => a.startIndex - b.startIndex);
+}
+
+export function parseFileReferences(text: string): FileReference[] {
+  const references: FileReference[] = [];
+
+  for (const match of text.matchAll(WRAPPED_FILE_LINE_COLUMN_PATTERN)) {
+    const boundary = match[1] ?? '';
+    const referenceText = match[0].slice(boundary.length);
+    const startIndex = (match.index ?? 0) + boundary.length;
+    const reference = createReference(
+      match[2],
+      match[3],
+      match[4],
+      startIndex,
+      startIndex + referenceText.length,
+      referenceText
+    );
+    if (reference) {
+      references.push(reference);
+    }
+  }
+
+  for (const match of text.matchAll(FILE_LINE_COLUMN_PATTERN)) {
+    const boundary = match[1] ?? '';
+    const referenceText = match[0].slice(boundary.length);
+    const startIndex = (match.index ?? 0) + boundary.length;
+    const reference = createReference(
+      match[2],
+      match[3],
+      match[4],
+      startIndex,
+      startIndex + referenceText.length,
+      referenceText
+    );
+    if (reference) {
+      references.push(reference);
+    }
+  }
+
+  for (const match of text.matchAll(PYTHON_TRACEBACK_PATTERN)) {
+    const boundary = match[1] ?? '';
+    const referenceText = match[2];
+    const startIndex = (match.index ?? 0) + boundary.length;
+    const reference = createReference(
+      match[3],
+      match[4],
+      undefined,
+      startIndex,
+      startIndex + referenceText.length,
+      referenceText
+    );
+    if (reference) {
+      references.push(reference);
+    }
+  }
+
+  return withoutOverlaps(references);
+}
+
+function isAbsoluteLocalPath(path: string): boolean {
+  return (
+    /^[A-Za-z]:[\\/]/.test(path) ||
+    path.startsWith('/') ||
+    path.startsWith('\\\\') ||
+    path.startsWith('//') ||
+    path.startsWith('~/') ||
+    path.startsWith('~\\')
+  );
+}
+
+function normalizeLocalPath(path: string): string {
+  if (!path) return path;
+
+  const slashPath = path.replace(/\\/g, '/');
+  let root = '';
+  let rest = slashPath;
+
+  const driveMatch = /^([A-Za-z]:)(?:\/|$)/.exec(slashPath);
+  if (driveMatch) {
+    root = `${driveMatch[1]}/`;
+    rest = slashPath.slice(root.length);
+  } else if (slashPath.startsWith('//')) {
+    root = '//';
+    rest = slashPath.slice(2);
+  } else if (slashPath.startsWith('/')) {
+    root = '/';
+    rest = slashPath.slice(1);
+  }
+
+  const segments: string[] = [];
+  for (const segment of rest.split('/')) {
+    if (!segment || segment === '.') continue;
+    if (segment === '..') {
+      if (segments.length > 0 && segments[segments.length - 1] !== '..') {
+        segments.pop();
+      } else if (!root) {
+        segments.push(segment);
+      }
+      continue;
+    }
+    segments.push(segment);
+  }
+
+  return `${root}${segments.join('/')}`;
+}
+
+function resolveProfileWorkingDir(workingDir?: string, workspacePath?: string): string {
+  const cleanWorkingDir = workingDir?.trim();
+  const cleanWorkspacePath = workspacePath?.trim();
+
+  if (cleanWorkingDir && isAbsoluteLocalPath(cleanWorkingDir)) {
+    return normalizeLocalPath(cleanWorkingDir);
+  }
+  if (cleanWorkingDir && cleanWorkspacePath) {
+    return normalizeLocalPath(`${cleanWorkspacePath}/${cleanWorkingDir}`);
+  }
+  if (cleanWorkingDir) {
+    return normalizeLocalPath(cleanWorkingDir);
+  }
+  return cleanWorkspacePath ? normalizeLocalPath(cleanWorkspacePath) : '';
+}
+
+export function resolveFileReferencePath(
+  referencePath: string,
+  workingDir?: string,
+  workspacePath?: string
+): string {
+  const cleanReferencePath = referencePath.trim();
+  if (isAbsoluteLocalPath(cleanReferencePath)) {
+    return normalizeLocalPath(cleanReferencePath);
+  }
+
+  const basePath = resolveProfileWorkingDir(workingDir, workspacePath);
+  if (!basePath) {
+    return normalizeLocalPath(cleanReferencePath);
+  }
+
+  return normalizeLocalPath(`${basePath}/${cleanReferencePath}`);
+}


### PR DESCRIPTION
## Summary

Implements #62 for Run Profiles clickable error links.

- Parses common run-output source references, including `file:line:col`, Node/TypeScript stack frames, Python traceback frames, and TypeScript/MSBuild-style `file(line,column)` diagnostics.
- Resolves relative output paths against the active run profile working directory and workspace root.
- Renders clickable links across merged, lanes, timeline, diff, and expanded folded output views using the existing editor navigation flow.
- Hardens click handling so unexpected navigation rejections surface as an error toast.
- Updates the roadmap tracker to mark #62 complete.

## Validation

- `npm run format:check`
- `npm run build`
- `npm run lint` (passes with existing warnings)
- `npm test -- --runTestsByPath src/__tests__/utils/parseFileReferences.test.ts src/__tests__/components/RunOutput/OutputLine.test.tsx`
- `npm test -- --runInBand`

## Notes

The local workspace still has unrelated generated Wails file churn under `frontend/wailsjs/...`; those files are not included in this branch's commits.