### PR TITLE
[codex] Implement run profile environment variants

### DIFF
--- a/app.go
+++ b/app.go
@@ -407,6 +407,26 @@ func (a *App) UnpinRunProfile(id string) error {
 	return nil
 }
 
+// SetActiveVariant selects the env variant for a run profile and emits the updated profile list.
+// This is exposed to the frontend via Wails bindings.
+func (a *App) SetActiveVariant(profileID string, variant string) error {
+	a.profileMu.RLock()
+	if a.profileManager == nil {
+		a.profileMu.RUnlock()
+		return fmt.Errorf("no workspace loaded")
+	}
+
+	if err := a.profileManager.SetActiveVariant(profileID, variant); err != nil {
+		a.profileMu.RUnlock()
+		return err
+	}
+
+	profiles := a.profileManager.GetAllProfiles()
+	a.profileMu.RUnlock()
+	runtime.EventsEmit(a.ctx, "runprofiles:changed", profiles)
+	return nil
+}
+
 // ValidateRunProfile validates a run profile without saving it.
 // This is exposed to the frontend via Wails bindings.
 func (a *App) ValidateRunProfile(profile runprofile.RunProfile) runprofile.ValidationResult {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,7 +25,7 @@ Firn IDE brings the focused, keyboard-first productivity of JetBrains IDEs to a 
 | UI/UX Polish | **COMPLETE** | #35-36 |
 | Milestone 2: Terminal Integration | **IN PROGRESS** | #10-12 complete, #47 open |
 | Milestone 3: Workspace Management | **IN PROGRESS** | #13-15 complete, #53-54 open |
-| Milestone 4: Run Profiles | **IN PROGRESS** | #16, #59-62 complete; #17-18, #63-64, #71 open |
+| Milestone 4: Run Profiles | **IN PROGRESS** | #16, #59-62, #64 complete; #17-18, #63, #71 open |
 | Milestone 5: Language Server Protocol | **COMPLETE** | #19-22, #73-76 complete |
 | Milestone 6: Search | **COMPLETE** | #23-25 |
 | Milestone 7: Git Integration | Not started | #26-27 |
@@ -40,11 +40,10 @@ Firn IDE brings the focused, keyboard-first productivity of JetBrains IDEs to a 
 
 ## Next Priorities
 
-Current status: PR #96 is merged into `develop`; the LSP epic (#74), Go integration (#75), and Python integration (#76) are complete. Run output now supports clickable error links (#62).
+Current status: PR #97 is merged into `develop`, completing Run Profiles clickable error links (#62) with stable run-time working-directory resolution. Run Profiles environment variants (#64) are complete with active variant env-file resolution, persisted selection, and frontend selector support. The LSP epic (#74), Go integration (#75), and Python integration (#76) remain complete from PR #96.
 
-1. **#64: Run Profiles - Environment Variants** — complete `ActiveVariant` env-file resolution and add the frontend variant selector.
-2. **#63: Run Profiles - Compound Profile Execution** — add sequential step execution, stop-on-failure, and per-step UI.
-3. **#53 then #54: Workspace Identity and File Tree Views** — workspace definitions, active accent, selector, then Project/Workspace tree modes.
+1. **#63: Run Profiles - Compound Profile Execution** — add sequential step execution, stop-on-failure, and per-step UI.
+2. **#53 then #54: Workspace Identity and File Tree Views** — workspace definitions, active accent, selector, then Project/Workspace tree modes.
 
 ---
 
@@ -163,9 +162,9 @@ Sub-issues:
 - [x] #59: Core Process Runner — `os/exec` implementation, env/cwd/envFile, start/stop bindings
 - [x] #60: Output Streaming — pipe stdout/stderr, Wails events, output panel
 - [x] #61: Process Lifecycle UI — play/stop/restart controls, state indicators
-- [x] #62: Clickable Error Links — `file:line:col` parsing, jump-to-error
+- [x] #62: Clickable Error Links — `file:line:col` parsing, stable run-time working-dir resolution, jump-to-error
 - [ ] #63: Compound Profile Execution — sequential steps, stop-on-failure
-- [ ] #64: Environment Variants — env file swapping by active variant
+- [x] #64: Environment Variants — env file swapping by active variant
 
 ### #71: Run Profiles - Activated State, Section Reorganization, and Selection Persistence
 - [ ] Activated profile working set
@@ -178,9 +177,9 @@ Sub-issues:
 - [x] Play/stop/restart controls in run profile cards
 - [x] Running status indicators and status badges
 - [x] Output panel with streaming logs
-- [x] Clickable file:line:col output links
+- [x] Clickable file:line:col output links with historical working-dir stability
 - [ ] Compound execution view with stage indicators
-- [ ] Environment variant selector (`[env: dev ▾]`)
+- [x] Environment variant selector (`[env: dev ▾]`)
 - [ ] Edit profile form (create/modify saved profiles)
 - [ ] Profiles grouped by workspace with accent colors (depends on #53)
 - [x] Status bar / output focus integration for running profiles

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -40,6 +40,7 @@ jest.mock('../../wailsjs/go/main/App', () => ({
   ListRecentWorkspaces: jest.fn(() => Promise.resolve([])),
   LoadRunProfiles: jest.fn(() => Promise.resolve()),
   GetAllRunProfiles: jest.fn(() => Promise.resolve([])),
+  SetActiveVariant: jest.fn(() => Promise.resolve()),
   LSPDidOpen: (...args: unknown[]) => mockDidOpen(...args),
   LSPDidChange: (...args: unknown[]) => mockDidChange(...args),
   LSPDidSave: (...args: unknown[]) => mockDidSave(...args),

--- a/frontend/src/__tests__/components/RunProfileCard.test.tsx
+++ b/frontend/src/__tests__/components/RunProfileCard.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { RunProfileCard } from '../../components/RunProfiles/RunProfileCard';
+import { useIDEStore } from '../../stores/ideStore';
+import type { RunProfile } from '../../types/runProfile';
+
+const mockSetActiveVariant = jest.fn<Promise<void>, [string, string]>();
+
+jest.mock('../../../wailsjs/go/main/App', () => ({
+  StartRunProfile: jest.fn(() => Promise.resolve()),
+  StopRunProfile: jest.fn(() => Promise.resolve()),
+  RestartRunProfile: jest.fn(() => Promise.resolve()),
+  PinRunProfile: jest.fn(() => Promise.resolve()),
+  UnpinRunProfile: jest.fn(() => Promise.resolve()),
+  SetActiveVariant: (...args: [string, string]) => mockSetActiveVariant(...args),
+}));
+
+const profileWithVariants: RunProfile = {
+  id: 'web',
+  name: 'Web',
+  type: 'single',
+  source: 'user',
+  command: 'npm run dev',
+  envVariants: [
+    { name: 'dev', envFile: '.env.dev' },
+    { name: 'staging', envFile: '.env.staging' },
+  ],
+  activeVariant: 'dev',
+};
+
+const baseProps = {
+  visualState: 'idle' as const,
+  runOutput: undefined,
+  runHistory: [],
+  isDormant: true,
+  isDuplicate: false,
+  onFocusOutput: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSetActiveVariant.mockResolvedValue(undefined);
+  useIDEStore.setState({
+    runProfiles: [],
+    toast: null,
+  });
+});
+
+describe('RunProfileCard environment variants', () => {
+  it('renders active variant selector for profiles with env variants', () => {
+    render(<RunProfileCard profile={profileWithVariants} {...baseProps} />);
+
+    const selector = screen.getByLabelText('Web environment variant') as HTMLSelectElement;
+    expect(selector.value).toBe('dev');
+    expect(screen.getByRole('option', { name: 'base' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'staging' })).toBeInTheDocument();
+  });
+
+  it('persists variant selection through the Wails binding and local store', async () => {
+    render(<RunProfileCard profile={profileWithVariants} {...baseProps} />);
+
+    fireEvent.change(screen.getByLabelText('Web environment variant'), {
+      target: { value: 'staging' },
+    });
+
+    await waitFor(() => {
+      expect(mockSetActiveVariant).toHaveBeenCalledWith('web', 'staging');
+    });
+    await waitFor(() => {
+      expect(useIDEStore.getState().runProfiles[0].activeVariant).toBe('staging');
+    });
+  });
+});

--- a/frontend/src/components/RunProfiles/RunProfileCard.module.css
+++ b/frontend/src/components/RunProfiles/RunProfileCard.module.css
@@ -210,6 +210,8 @@
 .tags {
   display: flex;
   gap: 3px;
+  min-width: 0;
+  flex-wrap: wrap;
 }
 
 .tag {
@@ -221,6 +223,38 @@
   background: rgba(255, 255, 255, 0.04);
   color: #3a3a3a;
   letter-spacing: 0.03em;
+}
+
+.variantSelector {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  margin-left: auto;
+  color: #686868;
+  font-size: 10px;
+}
+
+.variantLabel {
+  flex-shrink: 0;
+  font-family: 'SF Mono', 'Fira Code', var(--font-mono), monospace;
+}
+
+.variantSelect {
+  max-width: 96px;
+  height: 22px;
+  border: 1px solid #292929;
+  border-radius: 6px;
+  background: #101010;
+  color: #b7b7b7;
+  font-size: 11px;
+  line-height: 1;
+  padding: 0 20px 0 7px;
+}
+
+.variantSelect:focus {
+  outline: 1px solid rgba(56, 189, 248, 0.45);
+  outline-offset: 1px;
 }
 
 /* ── State: Running ─────────────────────────────────────────── */

--- a/frontend/src/components/RunProfiles/RunProfileCard.tsx
+++ b/frontend/src/components/RunProfiles/RunProfileCard.tsx
@@ -10,6 +10,7 @@ import {
   RestartRunProfile,
   PinRunProfile,
   UnpinRunProfile,
+  SetActiveVariant,
 } from '../../../wailsjs/go/main/App';
 import { useIDEStore } from '../../stores/ideStore';
 import type { RunProfile } from '../../types/runProfile';
@@ -108,6 +109,7 @@ export function RunProfileCard({
   const clearProfileStopping = useIDEStore((s) => s.clearProfileStopping);
   const setProfileRestarting = useIDEStore((s) => s.setProfileRestarting);
   const clearProfileRestarting = useIDEStore((s) => s.clearProfileRestarting);
+  const addOrUpdateProfile = useIDEStore((s) => s.addOrUpdateProfile);
   const showToast = useIDEStore((s) => s.showToast);
 
   const startTs = useIDEStore((s) => s.runStartTimestamps[profile.id]);
@@ -161,6 +163,23 @@ export function RunProfileCard({
 
   const handleHide = () => {
     useIDEStore.getState().hideProfile(profile.id);
+  };
+
+  const envVariants = (profile.envVariants ?? []).filter((variant) => variant.name);
+  const hasEnvVariants = envVariants.length > 0;
+
+  const handleVariantChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    e.stopPropagation();
+    const nextVariant = e.currentTarget.value;
+
+    SetActiveVariant(profile.id, nextVariant)
+      .then(() => {
+        addOrUpdateProfile({ ...profile, activeVariant: nextVariant });
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        showToast(`Failed to switch "${profile.name}" env: ${message}`, 'error');
+      });
   };
 
   const isActiveState =
@@ -292,23 +311,47 @@ export function RunProfileCard({
         </div>
       )}
 
-      {/* Row 3: tags */}
-      {profile.tags && profile.tags.length > 0 && (
+      {/* Row 3: tags and env selector */}
+      {((profile.tags && profile.tags.length > 0) || hasEnvVariants) && (
         <div className={styles.rowBottom}>
-          <div className={styles.tags}>
-            {profile.tags.map((tag) => {
-              const color = getTagColor(tag);
-              return (
-                <span
-                  key={tag}
-                  className={styles.tag}
-                  style={{ background: color.background, color: color.text }}
-                >
-                  {tag}
-                </span>
-              );
-            })}
-          </div>
+          {profile.tags && profile.tags.length > 0 && (
+            <div className={styles.tags}>
+              {profile.tags.map((tag) => {
+                const color = getTagColor(tag);
+                return (
+                  <span
+                    key={tag}
+                    className={styles.tag}
+                    style={{ background: color.background, color: color.text }}
+                  >
+                    {tag}
+                  </span>
+                );
+              })}
+            </div>
+          )}
+          {hasEnvVariants && (
+            <label
+              className={styles.variantSelector}
+              onClick={(e) => e.stopPropagation()}
+              onPointerDown={(e) => e.stopPropagation()}
+            >
+              <span className={styles.variantLabel}>env</span>
+              <select
+                className={styles.variantSelect}
+                value={profile.activeVariant ?? ''}
+                onChange={handleVariantChange}
+                aria-label={`${profile.name} environment variant`}
+              >
+                <option value="">base</option>
+                {envVariants.map((variant) => (
+                  <option key={variant.name} value={variant.name}>
+                    {variant.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
         </div>
       )}
 

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -71,6 +71,8 @@ export function SaveWorkspaceState(arg1:workspace.State):Promise<void>;
 
 export function SearchWorkspace(arg1:search.SearchRequest):Promise<search.SearchResponse>;
 
+export function SetActiveVariant(arg1:string,arg2:string):Promise<void>;
+
 export function SetLSPWorkspaceRoot(arg1:string):Promise<void>;
 
 export function StartRunProfile(arg1:string):Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -130,6 +130,10 @@ export function SearchWorkspace(arg1) {
   return window['go']['main']['App']['SearchWorkspace'](arg1);
 }
 
+export function SetActiveVariant(arg1, arg2) {
+  return window['go']['main']['App']['SetActiveVariant'](arg1, arg2);
+}
+
 export function SetLSPWorkspaceRoot(arg1) {
   return window['go']['main']['App']['SetLSPWorkspaceRoot'](arg1);
 }

--- a/internal/runprofile/executor.go
+++ b/internal/runprofile/executor.go
@@ -55,7 +55,7 @@ type Executor struct {
 type runningProcess struct {
 	cmd      *exec.Cmd
 	status   RunStatus
-	stopped  bool         // set by Stop — tells Wait goroutine to use RunStateStopped
+	stopped  bool          // set by Stop — tells Wait goroutine to use RunStateStopped
 	done     chan struct{} // closed when process exits and cleanup is complete
 	stopOnce sync.Once
 }
@@ -105,7 +105,7 @@ func (e *Executor) Start(workspaceRoot string, profile RunProfile) error {
 	delete(e.lastStatus, profile.ID)
 
 	// Build environment
-	env, err := buildEnv(profile.Env, profile.EnvFile, effectiveDir)
+	env, err := buildEnv(profile, effectiveDir)
 	if err != nil {
 		e.mu.Unlock()
 		return err
@@ -359,9 +359,9 @@ func resolveWorkingDir(workspaceRoot, workingDir string) (string, error) {
 }
 
 // buildEnv merges environment sources in precedence order:
-// os.Environ() (base) → EnvFile values → profile.Env map (inline wins).
-// Relative envFilePath values are resolved against effectiveWorkingDir.
-func buildEnv(profileEnv map[string]string, envFilePath string, effectiveWorkingDir string) ([]string, error) {
+// os.Environ() → profile.Env → profile.EnvFile → active variant env file.
+// Relative env file paths are resolved against effectiveWorkingDir.
+func buildEnv(profile RunProfile, effectiveWorkingDir string) ([]string, error) {
 	// Start with current environment
 	envMap := make(map[string]string)
 	for _, entry := range os.Environ() {
@@ -370,24 +370,23 @@ func buildEnv(profileEnv map[string]string, envFilePath string, effectiveWorking
 		}
 	}
 
-	// Layer 2: env file (if specified)
-	if envFilePath != "" {
-		resolved := envFilePath
-		if !filepath.IsAbs(resolved) {
-			resolved = filepath.Join(effectiveWorkingDir, resolved)
-		}
-		fileEnv, err := ParseEnvFile(resolved)
-		if err != nil {
-			return nil, err
-		}
-		for k, v := range fileEnv {
-			envMap[k] = v
-		}
+	// Layer 2: inline profile env
+	for k, v := range profile.Env {
+		envMap[k] = v
 	}
 
-	// Layer 3: inline env vars (highest precedence)
-	for k, v := range profileEnv {
-		envMap[k] = v
+	// Layer 3: base env file
+	if err := mergeEnvFile(envMap, profile.EnvFile, effectiveWorkingDir); err != nil {
+		return nil, err
+	}
+
+	// Layer 4: active variant env file
+	variantEnvFile, err := activeVariantEnvFile(profile)
+	if err != nil {
+		return nil, err
+	}
+	if err := mergeEnvFile(envMap, variantEnvFile, effectiveWorkingDir); err != nil {
+		return nil, err
 	}
 
 	// Convert back to slice
@@ -396,6 +395,35 @@ func buildEnv(profileEnv map[string]string, envFilePath string, effectiveWorking
 		result = append(result, k+"="+v)
 	}
 	return result, nil
+}
+
+func mergeEnvFile(envMap map[string]string, envFilePath string, effectiveWorkingDir string) error {
+	if strings.TrimSpace(envFilePath) == "" {
+		return nil
+	}
+	resolved := envFilePath
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(effectiveWorkingDir, resolved)
+	}
+	fileEnv, err := ParseEnvFile(resolved)
+	if err != nil {
+		return err
+	}
+	for k, v := range fileEnv {
+		envMap[k] = v
+	}
+	return nil
+}
+
+func activeVariantEnvFile(profile RunProfile) (string, error) {
+	if strings.TrimSpace(profile.ActiveVariant) == "" {
+		return "", nil
+	}
+	variant, ok := findEnvVariant(profile.EnvVariants, profile.ActiveVariant)
+	if !ok {
+		return "", fmt.Errorf("env variant %q not found for profile %s", profile.ActiveVariant, profile.ID)
+	}
+	return variant.EnvFile, nil
 }
 
 // waitExitCode waits for the command to finish and extracts the exit code.

--- a/internal/runprofile/executor_test.go
+++ b/internal/runprofile/executor_test.go
@@ -356,7 +356,7 @@ func TestExecutor_EnvFileMerge(t *testing.T) {
 	exec := NewExecutor(spy.emit, out.receive)
 	dir := t.TempDir()
 
-	// Create .env file with SHARED_VAR and FILE_VAR
+	// Create .env file with SHARED_VAR and FILE_VAR.
 	envContent := "SHARED_VAR=from_file\nFILE_VAR=file_only\n"
 	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(envContent), 0644); err != nil {
 		t.Fatal(err)
@@ -365,7 +365,7 @@ func TestExecutor_EnvFileMerge(t *testing.T) {
 	profile := newTestProfile("test-env-merge", "env")
 	profile.EnvFile = ".env"
 	profile.Env = map[string]string{
-		"SHARED_VAR": "from_inline", // inline should win over file
+		"SHARED_VAR": "from_inline",
 		"INLINE_VAR": "inline_only",
 	}
 	if err := exec.Start(dir, profile); err != nil {
@@ -377,15 +377,115 @@ func TestExecutor_EnvFileMerge(t *testing.T) {
 	}
 
 	output := out.combined()
-	// Inline wins over file
-	if !strings.Contains(output, "SHARED_VAR=from_inline") {
-		t.Errorf("SHARED_VAR should be from_inline (inline wins), output:\n%s", output)
+	if !strings.Contains(output, "SHARED_VAR=from_file") {
+		t.Errorf("SHARED_VAR should be from_file (env file wins over inline env), output:\n%s", output)
 	}
 	if !strings.Contains(output, "FILE_VAR=file_only") {
 		t.Errorf("FILE_VAR should be present from env file, output:\n%s", output)
 	}
 	if !strings.Contains(output, "INLINE_VAR=inline_only") {
 		t.Errorf("INLINE_VAR should be present from inline env, output:\n%s", output)
+	}
+}
+
+func TestExecutor_ActiveVariantEnvFileMerge(t *testing.T) {
+	spy := &emitSpy{}
+	out := &outputSpy{}
+	exec := NewExecutor(spy.emit, out.receive)
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("SHARED_VAR=from_base_file\nBASE_ONLY=base\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".env.staging"), []byte("SHARED_VAR=from_variant\nVARIANT_ONLY=staging\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	profile := newTestProfile("test-env-variant", "env")
+	profile.Env = map[string]string{
+		"SHARED_VAR": "from_inline",
+		"INLINE_VAR": "inline",
+	}
+	profile.EnvFile = ".env"
+	profile.EnvVariants = []EnvVariant{
+		{Name: "staging", EnvFile: ".env.staging"},
+	}
+	profile.ActiveVariant = "staging"
+
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := spy.waitForState(RunStateSuccess, 5*time.Second); !ok {
+		t.Fatal("timed out waiting for success state")
+	}
+
+	output := out.combined()
+	if !strings.Contains(output, "SHARED_VAR=from_variant") {
+		t.Errorf("SHARED_VAR should come from active variant env file, output:\n%s", output)
+	}
+	if !strings.Contains(output, "BASE_ONLY=base") {
+		t.Errorf("BASE_ONLY should come from base env file, output:\n%s", output)
+	}
+	if !strings.Contains(output, "VARIANT_ONLY=staging") {
+		t.Errorf("VARIANT_ONLY should come from active variant env file, output:\n%s", output)
+	}
+	if !strings.Contains(output, "INLINE_VAR=inline") {
+		t.Errorf("INLINE_VAR should come from profile env, output:\n%s", output)
+	}
+}
+
+func TestExecutor_ActiveVariantEnvFileRelativeToWorkingDir(t *testing.T) {
+	spy := &emitSpy{}
+	out := &outputSpy{}
+	exec := NewExecutor(spy.emit, out.receive)
+	dir := t.TempDir()
+
+	subdir := filepath.Join(dir, "frontend")
+	if err := os.MkdirAll(subdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subdir, ".env.dev"), []byte("WORKDIR_VARIANT=dev\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	profile := newTestProfile("test-env-variant-workdir", "env")
+	profile.WorkingDir = "frontend"
+	profile.EnvVariants = []EnvVariant{
+		{Name: "dev", EnvFile: ".env.dev"},
+	}
+	profile.ActiveVariant = "dev"
+
+	if err := exec.Start(dir, profile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := spy.waitForState(RunStateSuccess, 5*time.Second); !ok {
+		t.Fatal("timed out waiting for success state")
+	}
+
+	output := out.combined()
+	if !strings.Contains(output, "WORKDIR_VARIANT=dev") {
+		t.Errorf("WORKDIR_VARIANT should be loaded relative to effective working dir, output:\n%s", output)
+	}
+}
+
+func TestExecutor_ActiveVariantMissing(t *testing.T) {
+	exec := NewExecutor(nil, nil)
+	dir := t.TempDir()
+
+	profile := newTestProfile("test-env-variant-missing", "echo hello")
+	profile.EnvVariants = []EnvVariant{
+		{Name: "dev", EnvFile: ".env.dev"},
+	}
+	profile.ActiveVariant = "staging"
+
+	err := exec.Start(dir, profile)
+	if err == nil {
+		t.Fatal("expected error for missing active env variant")
+	}
+	if !strings.Contains(err.Error(), `env variant "staging" not found`) {
+		t.Errorf("error = %q, want missing variant message", err.Error())
 	}
 }
 

--- a/internal/runprofile/manager.go
+++ b/internal/runprofile/manager.go
@@ -4,6 +4,7 @@ import (
 	"firn/internal/filesystem"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 )
 
@@ -120,6 +121,39 @@ func (m *Manager) UnpinProfile(id string) error {
 	return nil
 }
 
+// SetActiveVariant updates a profile's active environment variant. Saved
+// profiles are persisted; detected profiles are updated in memory for the
+// current detection snapshot.
+func (m *Manager) SetActiveVariant(id string, variant string) error {
+	activeVariant := strings.TrimSpace(variant)
+
+	for _, profile := range m.store.GetAll() {
+		if profile.ID != id {
+			continue
+		}
+		if err := ensureActiveVariantAllowed(profile, activeVariant); err != nil {
+			return err
+		}
+		profile.ActiveVariant = activeVariant
+		return m.store.Save(profile)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i := range m.detected {
+		if m.detected[i].ID != id {
+			continue
+		}
+		if err := ensureActiveVariantAllowed(m.detected[i], activeVariant); err != nil {
+			return err
+		}
+		m.detected[i].ActiveVariant = activeVariant
+		return nil
+	}
+
+	return fmt.Errorf("profile not found: %s", id)
+}
+
 // ReDetect re-runs detection and returns the new detected profiles.
 func (m *Manager) ReDetect() []RunProfile {
 	detected := m.detector.DetectAll()
@@ -152,4 +186,14 @@ func (m *Manager) SetWorkspaceRoot(root string) {
 	m.detector = NewDetector(m.fs, root)
 	m.detected = []RunProfile{}
 	m.mu.Unlock()
+}
+
+func ensureActiveVariantAllowed(profile RunProfile, activeVariant string) error {
+	if activeVariant == "" {
+		return nil
+	}
+	if _, ok := findEnvVariant(profile.EnvVariants, activeVariant); !ok {
+		return fmt.Errorf("env variant %q not found for profile %s", activeVariant, profile.ID)
+	}
+	return nil
 }

--- a/internal/runprofile/manager_test.go
+++ b/internal/runprofile/manager_test.go
@@ -1,6 +1,7 @@
 package runprofile
 
 import (
+	"encoding/json"
 	"firn/internal/filesystem"
 	"io/fs"
 	"testing"
@@ -171,9 +172,102 @@ func TestManagerDeleteProfile(t *testing.T) {
 	}
 }
 
+func TestManagerSetActiveVariantPersistsSavedProfile(t *testing.T) {
+	files := map[string][]byte{}
+	mockFS := newManagerTestFS(files)
+	mgr := NewManager(mockFS, "/workspace")
+	_ = mgr.Load()
+
+	_, err := mgr.SaveProfile(RunProfile{
+		ID:      "p1",
+		Name:    "Web",
+		Type:    ProfileTypeSingle,
+		Command: "npm run dev",
+		EnvVariants: []EnvVariant{
+			{Name: "dev", EnvFile: ".env.dev"},
+			{Name: "staging", EnvFile: ".env.staging"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SaveProfile() error: %v", err)
+	}
+
+	if err := mgr.SetActiveVariant("p1", "staging"); err != nil {
+		t.Fatalf("SetActiveVariant() error: %v", err)
+	}
+
+	all := mgr.GetAllProfiles()
+	if len(all) != 1 {
+		t.Fatalf("expected 1 profile, got %d", len(all))
+	}
+	if all[0].ActiveVariant != "staging" {
+		t.Fatalf("ActiveVariant = %q, want staging", all[0].ActiveVariant)
+	}
+
+	var persisted ProfilesFile
+	if err := json.Unmarshal(files["/workspace/.firn/run-profiles.json"], &persisted); err != nil {
+		t.Fatalf("persisted JSON did not decode: %v", err)
+	}
+	if persisted.Profiles[0].ActiveVariant != "staging" {
+		t.Errorf("persisted ActiveVariant = %q, want staging", persisted.Profiles[0].ActiveVariant)
+	}
+}
+
+func TestManagerSetActiveVariantCanClearSelection(t *testing.T) {
+	mockFS := newManagerTestFS(map[string][]byte{})
+	mgr := NewManager(mockFS, "/workspace")
+	_ = mgr.Load()
+
+	_, err := mgr.SaveProfile(RunProfile{
+		ID:            "p1",
+		Name:          "Web",
+		Type:          ProfileTypeSingle,
+		Command:       "npm run dev",
+		ActiveVariant: "dev",
+		EnvVariants: []EnvVariant{
+			{Name: "dev", EnvFile: ".env.dev"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SaveProfile() error: %v", err)
+	}
+
+	if err := mgr.SetActiveVariant("p1", ""); err != nil {
+		t.Fatalf("SetActiveVariant() error: %v", err)
+	}
+
+	all := mgr.GetAllProfiles()
+	if all[0].ActiveVariant != "" {
+		t.Errorf("ActiveVariant = %q, want empty", all[0].ActiveVariant)
+	}
+}
+
+func TestManagerSetActiveVariantRejectsUnknownVariant(t *testing.T) {
+	mockFS := newManagerTestFS(map[string][]byte{})
+	mgr := NewManager(mockFS, "/workspace")
+	_ = mgr.Load()
+
+	_, err := mgr.SaveProfile(RunProfile{
+		ID:      "p1",
+		Name:    "Web",
+		Type:    ProfileTypeSingle,
+		Command: "npm run dev",
+		EnvVariants: []EnvVariant{
+			{Name: "dev", EnvFile: ".env.dev"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SaveProfile() error: %v", err)
+	}
+
+	if err := mgr.SetActiveVariant("p1", "prod"); err == nil {
+		t.Fatal("expected error for unknown variant")
+	}
+}
+
 func TestManagerSetWorkspaceRoot(t *testing.T) {
 	files := map[string][]byte{
-		"/workspace-a/go.mod": []byte("module a\ngo 1.21\n"),
+		"/workspace-a/go.mod":       []byte("module a\ngo 1.21\n"),
 		"/workspace-b/package.json": []byte(`{"scripts": {"start": "node ."}}`),
 	}
 	mockFS := newManagerTestFS(files)

--- a/internal/runprofile/store.go
+++ b/internal/runprofile/store.go
@@ -166,7 +166,7 @@ func deepCopyProfile(p RunProfile) RunProfile {
 		p.Env = env
 	}
 	if p.EnvVariants != nil {
-		variants := make([]EnvVariant, len(p.EnvVariants))
+		variants := make(EnvVariants, len(p.EnvVariants))
 		copy(variants, p.EnvVariants)
 		p.EnvVariants = variants
 	}

--- a/internal/runprofile/types.go
+++ b/internal/runprofile/types.go
@@ -2,6 +2,12 @@
 // Run profiles are first-class build/lint/test/deploy configurations per workspace.
 package runprofile
 
+import (
+	"bytes"
+	"encoding/json"
+	"sort"
+)
+
 // ProfileType distinguishes single-command profiles from compound (multi-step) profiles.
 type ProfileType string
 
@@ -44,6 +50,48 @@ type EnvVariant struct {
 	EnvFile string `json:"envFile"`
 }
 
+// EnvVariants stores environment variants in the canonical array shape while
+// still accepting the issue #64 map shape from hand-written profile files.
+type EnvVariants []EnvVariant
+
+// UnmarshalJSON accepts either:
+//   - [{"name":"dev","envFile":".env.dev"}]
+//   - {"dev":".env.dev"}
+func (v *EnvVariants) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		*v = nil
+		return nil
+	}
+
+	if trimmed[0] != '{' {
+		var variants []EnvVariant
+		if err := json.Unmarshal(trimmed, &variants); err != nil {
+			return err
+		}
+		*v = variants
+		return nil
+	}
+
+	var variantMap map[string]string
+	if err := json.Unmarshal(trimmed, &variantMap); err != nil {
+		return err
+	}
+
+	names := make([]string, 0, len(variantMap))
+	for name := range variantMap {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	variants := make([]EnvVariant, 0, len(names))
+	for _, name := range names {
+		variants = append(variants, EnvVariant{Name: name, EnvFile: variantMap[name]})
+	}
+	*v = variants
+	return nil
+}
+
 // RunProfile represents a single run configuration.
 type RunProfile struct {
 	ID            string            `json:"id"`
@@ -54,7 +102,7 @@ type RunProfile struct {
 	WorkingDir    string            `json:"workingDir,omitempty"`
 	Env           map[string]string `json:"env,omitempty"`
 	EnvFile       string            `json:"envFile,omitempty"`
-	EnvVariants   []EnvVariant      `json:"envVariants,omitempty"`
+	EnvVariants   EnvVariants       `json:"envVariants,omitempty"`
 	ActiveVariant string            `json:"activeVariant,omitempty"`
 	Tags          []ProfileTag      `json:"tags,omitempty"`
 	Steps         []string          `json:"steps,omitempty"`

--- a/internal/runprofile/types_test.go
+++ b/internal/runprofile/types_test.go
@@ -103,6 +103,39 @@ func TestCompoundProfileJSONRoundTrip(t *testing.T) {
 	}
 }
 
+func TestRunProfileEnvVariantsAcceptsMapJSON(t *testing.T) {
+	data := []byte(`{
+		"id": "test-1",
+		"name": "Build",
+		"type": "single",
+		"source": "user",
+		"command": "make build",
+		"envVariants": {
+			"staging": ".env.staging",
+			"dev": ".env.dev"
+		},
+		"activeVariant": "staging"
+	}`)
+
+	var decoded RunProfile
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if len(decoded.EnvVariants) != 2 {
+		t.Fatalf("EnvVariants length = %d, want 2", len(decoded.EnvVariants))
+	}
+	if decoded.EnvVariants[0] != (EnvVariant{Name: "dev", EnvFile: ".env.dev"}) {
+		t.Errorf("first variant = %#v, want dev variant", decoded.EnvVariants[0])
+	}
+	if decoded.EnvVariants[1] != (EnvVariant{Name: "staging", EnvFile: ".env.staging"}) {
+		t.Errorf("second variant = %#v, want staging variant", decoded.EnvVariants[1])
+	}
+	if decoded.ActiveVariant != "staging" {
+		t.Errorf("ActiveVariant = %q, want staging", decoded.ActiveVariant)
+	}
+}
+
 func TestOmitemptyFieldsExcludedFromJSON(t *testing.T) {
 	profile := RunProfile{
 		ID:     "minimal",

--- a/internal/runprofile/validator.go
+++ b/internal/runprofile/validator.go
@@ -60,6 +60,15 @@ func Validate(profile RunProfile) ValidationResult {
 		}
 	}
 
+	if strings.TrimSpace(profile.ActiveVariant) != "" {
+		if _, ok := findEnvVariant(profile.EnvVariants, profile.ActiveVariant); !ok {
+			errs = append(errs, ValidationError{
+				Field:   "activeVariant",
+				Message: "activeVariant must match a configured env variant",
+			})
+		}
+	}
+
 	for _, tag := range profile.Tags {
 		if !ValidTags[tag] {
 			errs = append(errs, ValidationError{
@@ -75,3 +84,15 @@ func Validate(profile RunProfile) ValidationResult {
 	}
 }
 
+func findEnvVariant(variants []EnvVariant, name string) (EnvVariant, bool) {
+	active := strings.TrimSpace(name)
+	if active == "" {
+		return EnvVariant{}, false
+	}
+	for _, variant := range variants {
+		if strings.TrimSpace(variant.Name) == active {
+			return variant, true
+		}
+	}
+	return EnvVariant{}, false
+}

--- a/internal/runprofile/validator_test.go
+++ b/internal/runprofile/validator_test.go
@@ -161,6 +161,41 @@ func TestValidateEnvVariantsMissingEnvFile(t *testing.T) {
 	assertHasFieldError(t, result, "envVariants")
 }
 
+func TestValidateActiveVariantMustMatchConfiguredVariant(t *testing.T) {
+	p := RunProfile{
+		ID:            "test-1",
+		Name:          "Build",
+		Type:          ProfileTypeSingle,
+		Command:       "echo hello",
+		ActiveVariant: "prod",
+		EnvVariants: []EnvVariant{
+			{Name: "staging", EnvFile: ".env.staging"},
+		},
+	}
+	result := Validate(p)
+	if result.Valid {
+		t.Fatal("expected invalid for active variant without matching env variant")
+	}
+	assertHasFieldError(t, result, "activeVariant")
+}
+
+func TestValidateActiveVariantAllowsConfiguredVariant(t *testing.T) {
+	p := RunProfile{
+		ID:            "test-1",
+		Name:          "Build",
+		Type:          ProfileTypeSingle,
+		Command:       "echo hello",
+		ActiveVariant: "staging",
+		EnvVariants: []EnvVariant{
+			{Name: "staging", EnvFile: ".env.staging"},
+		},
+	}
+	result := Validate(p)
+	if !result.Valid {
+		t.Fatalf("expected valid active variant, got errors: %v", result.Errors)
+	}
+}
+
 func TestValidateMultipleErrors(t *testing.T) {
 	p := RunProfile{
 		Type: "bad",


### PR DESCRIPTION
## Summary

Implements Run Profiles environment variants for issue #64.

- Resolves `ActiveVariant` to its configured env file at execution time.
- Merges env sources in the issue-required order: profile `Env` -> base `EnvFile` -> active variant env file, with later sources winning.
- Adds `SetActiveVariant(profileId, variant)` so the frontend can select and persist variants.
- Adds a compact run profile card env selector.
- Accepts both canonical array-shaped `envVariants` and the issue-described map-shaped JSON for hand-written profile files.
- Updates the roadmap tracker to mark #64 complete and move #63 next.

## Issue #64 Checklist

- [x] Dotenv file parser is present and covered by existing tests.
- [x] `EnvVariants` map support is implemented through JSON unmarshalling compatibility.
- [x] `ActiveVariant` selects the variant env file during execution.
- [x] Merge precedence is implemented as `Env` -> `EnvFile` -> active variant env file.
- [x] Frontend variant selector is available in the run profile card.
- [x] `SetActiveVariant(profileId, variant string)` Wails binding is added.
- [x] Selected variant persists for saved profiles.

Closes #64.

## Validation

- `go test ./...`
- `go test -race ./internal/runprofile`
- `npm test -- --runInBand`
- `npm run build`