### PR TITLE
[codex] Add Firn Go gopher file icon

### DIFF
--- a/frontend/src/__tests__/components/FileExplorer/FileIcon.test.tsx
+++ b/frontend/src/__tests__/components/FileExplorer/FileIcon.test.tsx
@@ -30,9 +30,12 @@ describe('FileIcon', () => {
       expect(screen.getByTestId('file-icon')).toHaveAttribute('data-type', 'react');
     });
 
-    it('renders go icon for .go files', () => {
+    it('renders custom Firn gopher icon for .go files', () => {
       render(<FileIcon name="main.go" isDir={false} />);
-      expect(screen.getByTestId('file-icon')).toHaveAttribute('data-type', 'go');
+      const icon = screen.getByTestId('file-icon');
+      expect(icon).toHaveAttribute('data-type', 'go');
+      expect(icon).toHaveAttribute('data-icon', 'firn-go-gopher');
+      expect(icon.tagName.toLowerCase()).toBe('svg');
     });
 
     it('renders python icon for .py files', () => {

--- a/frontend/src/__tests__/components/FileExplorer/FileIcon.test.tsx
+++ b/frontend/src/__tests__/components/FileExplorer/FileIcon.test.tsx
@@ -1,11 +1,11 @@
 import { render, screen } from '@testing-library/react';
+import { FileIcon } from '../../../components/FileExplorer/FileIcon';
 import {
-  FileIcon,
   getFileIconColor,
   getFolderIconColor,
   getFileType,
   getFolderType,
-} from '../../../components/FileExplorer/FileIcon';
+} from '../../../components/FileExplorer/fileIconUtils';
 
 describe('FileIcon', () => {
   describe('file icons', () => {

--- a/frontend/src/components/FileExplorer/FileIcon.tsx
+++ b/frontend/src/components/FileExplorer/FileIcon.tsx
@@ -23,57 +23,14 @@ import ReactOriginal from 'devicons-react/icons/ReactOriginal';
 import GitOriginal from 'devicons-react/icons/GitOriginal';
 import YamlOriginal from 'devicons-react/icons/YamlOriginal';
 import XmlOriginal from 'devicons-react/icons/XmlOriginal';
-
-/** File type identifier for icon styling */
-export type FileType =
-  | 'typescript'
-  | 'javascript'
-  | 'react'
-  | 'go'
-  | 'python'
-  | 'json'
-  | 'markdown'
-  | 'css'
-  | 'html'
-  | 'yaml'
-  | 'rust'
-  | 'image'
-  | 'git'
-  | 'text'
-  | 'xml'
-  | 'executable'
-  | 'library'
-  | 'compiled'
-  | 'binary'
-  | 'archive'
-  | 'default';
-
-/** Special folder type identifier */
-export type FolderType =
-  | 'src'
-  | 'components'
-  | 'hooks'
-  | 'node_modules'
-  | 'test'
-  | 'docs'
-  | 'public'
-  | 'dist'
-  | 'hidden'
-  | 'default';
-
-/** Folder color mapping — warm, high-contrast palette */
-const FOLDER_TYPE_COLORS: Record<FolderType, string> = {
-  src: '#3B82F6',
-  components: '#a855f7',
-  hooks: '#ec4899',
-  node_modules: '#78716c',
-  test: '#22c55e',
-  docs: '#06b6d4',
-  public: '#f97316',
-  dist: '#737373',
-  hidden: '#3f3f46',
-  default: '#d97706',
-};
+import {
+  type FileType,
+  type FolderType,
+  getFileIconColor,
+  getFileType,
+  getFolderIconColor,
+  getFolderType,
+} from './fileIconUtils';
 
 /** Open folder colors — lighter variant per folder type */
 const FOLDER_TYPE_OPEN_COLORS: Record<FolderType, string> = {
@@ -87,113 +44,6 @@ const FOLDER_TYPE_OPEN_COLORS: Record<FolderType, string> = {
   dist: '#a3a3a3',
   hidden: '#52525b',
   default: '#f59e0b',
-};
-
-/** Extension to file type mapping */
-const EXTENSION_MAP: Record<string, FileType> = {
-  ts: 'typescript',
-  tsx: 'react',
-  js: 'javascript',
-  jsx: 'react',
-  mjs: 'javascript',
-  cjs: 'javascript',
-  go: 'go',
-  py: 'python',
-  pyi: 'python',
-  json: 'json',
-  md: 'markdown',
-  mdx: 'markdown',
-  css: 'css',
-  scss: 'css',
-  sass: 'css',
-  less: 'css',
-  html: 'html',
-  htm: 'html',
-  yaml: 'yaml',
-  yml: 'yaml',
-  rs: 'rust',
-  svg: 'image',
-  png: 'image',
-  jpg: 'image',
-  jpeg: 'image',
-  gif: 'image',
-  ico: 'image',
-  webp: 'image',
-  bmp: 'image',
-  gitignore: 'git',
-  gitattributes: 'git',
-  gitmodules: 'git',
-  txt: 'text',
-  log: 'text',
-  env: 'text',
-  xml: 'xml',
-  xsl: 'xml',
-  xslt: 'xml',
-  plist: 'xml',
-  exe: 'executable',
-  app: 'executable',
-  dll: 'library',
-  so: 'library',
-  dylib: 'library',
-  a: 'library',
-  lib: 'library',
-  o: 'compiled',
-  obj: 'compiled',
-  class: 'compiled',
-  pyc: 'compiled',
-  pyo: 'compiled',
-  bin: 'binary',
-  dat: 'binary',
-  wasm: 'binary',
-  zip: 'archive',
-  tar: 'archive',
-  gz: 'archive',
-  tgz: 'archive',
-  bz2: 'archive',
-  xz: 'archive',
-  rar: 'archive',
-  '7z': 'archive',
-  jar: 'archive',
-  dmg: 'archive',
-  iso: 'archive',
-};
-
-/** Known extensionless filenames → file type */
-const FILENAME_MAP: Record<string, FileType> = {
-  makefile: 'executable',
-  dockerfile: 'executable',
-  procfile: 'executable',
-  rakefile: 'executable',
-  vagrantfile: 'executable',
-  gemfile: 'text',
-  readme: 'text',
-  license: 'text',
-  licence: 'text',
-  authors: 'text',
-  changelog: 'text',
-  contributing: 'text',
-  copying: 'text',
-  notice: 'text',
-};
-
-/** Special folder name mapping */
-const FOLDER_NAME_MAP: Record<string, FolderType> = {
-  src: 'src',
-  source: 'src',
-  components: 'components',
-  hooks: 'hooks',
-  node_modules: 'node_modules',
-  test: 'test',
-  tests: 'test',
-  __tests__: 'test',
-  docs: 'docs',
-  documentation: 'docs',
-  public: 'public',
-  static: 'public',
-  assets: 'public',
-  dist: 'dist',
-  build: 'dist',
-  out: 'dist',
 };
 
 /** File type to devicon component mapping */
@@ -231,67 +81,6 @@ const DEVICON_FILTERS: Partial<Record<FileType, string>> = {
   yaml: 'invert(1)',
   xml: 'invert(1)',
 };
-
-/**
- * Gets the file type from a filename based on its extension.
- */
-export function getFileType(name: string): FileType {
-  // No dot at all → check known filenames, then fall back to default icon
-  if (!name.includes('.')) {
-    return FILENAME_MAP[name.toLowerCase()] ?? 'default';
-  }
-  const ext = name.split('.').pop()?.toLowerCase() ?? '';
-  return EXTENSION_MAP[ext] ?? 'default';
-}
-
-/**
- * Gets the folder type from a folder name.
- */
-export function getFolderType(name: string): FolderType {
-  const mapped = FOLDER_NAME_MAP[name.toLowerCase()];
-  if (mapped) return mapped;
-  if (name.startsWith('.')) return 'hidden';
-  return 'default';
-}
-
-/** File type to color mapping */
-const FILE_TYPE_COLORS: Record<FileType, string> = {
-  typescript: '#3178C6',
-  javascript: '#F7DF1E',
-  react: '#61DAFB',
-  go: '#00ADD8',
-  python: '#3776AB',
-  json: '#F59E0B',
-  markdown: '#8b9cae',
-  css: '#1572B6',
-  html: '#E34F26',
-  yaml: '#ef4444',
-  rust: '#DEA584',
-  image: '#a855f7',
-  git: '#F05032',
-  text: '#9ca3af',
-  xml: '#e36209',
-  executable: '#10b981',
-  library: '#8b5cf6',
-  compiled: '#f59e0b',
-  binary: '#ef4444',
-  archive: '#0ea5e9',
-  default: '#6B7280',
-};
-
-/**
- * Gets the color for a file type per design specification.
- */
-export function getFileIconColor(fileType: FileType | string): string {
-  return FILE_TYPE_COLORS[fileType as FileType] ?? FILE_TYPE_COLORS.default;
-}
-
-/**
- * Gets the color for a folder type per design specification.
- */
-export function getFolderIconColor(folderType: FolderType): string {
-  return FOLDER_TYPE_COLORS[folderType] ?? FOLDER_TYPE_COLORS.default;
-}
 
 /** Custom SVG icons for specific file types */
 const CUSTOM_ICONS: Partial<Record<FileType, React.ComponentType<React.SVGProps<SVGSVGElement>>>> =

--- a/frontend/src/components/FileExplorer/FileIcon.tsx
+++ b/frontend/src/components/FileExplorer/FileIcon.tsx
@@ -2,6 +2,7 @@ import {
   FileIcon as FileIconSvg,
   FolderIcon,
   FolderOpenIcon,
+  FirnGoGopherIcon,
   ImageIcon,
   TextFileIcon,
   ExecutableIcon,
@@ -12,7 +13,6 @@ import {
 } from '../icons';
 import TypescriptOriginal from 'devicons-react/icons/TypescriptOriginal';
 import JavascriptOriginal from 'devicons-react/icons/JavascriptOriginal';
-import GoOriginal from 'devicons-react/icons/GoOriginal';
 import PythonOriginal from 'devicons-react/icons/PythonOriginal';
 import JsonOriginal from 'devicons-react/icons/JsonOriginal';
 import MarkdownOriginal from 'devicons-react/icons/MarkdownOriginal';
@@ -202,7 +202,7 @@ const FILE_TYPE_ICONS: Record<FileType, React.ComponentType<any> | null> = {
   typescript: TypescriptOriginal,
   javascript: JavascriptOriginal,
   react: ReactOriginal,
-  go: GoOriginal,
+  go: null,
   python: PythonOriginal,
   json: JsonOriginal,
   markdown: MarkdownOriginal,
@@ -224,14 +224,12 @@ const FILE_TYPE_ICONS: Record<FileType, React.ComponentType<any> | null> = {
 
 /**
  * CSS filters for devicons that don't render well on dark backgrounds.
- * - markdown/yaml: dark fills → invert to white
- * - go: bright blue/white clash → reduce brightness slightly
+ * - markdown/yaml/xml: dark fills → invert to white
  */
 const DEVICON_FILTERS: Partial<Record<FileType, string>> = {
   markdown: 'invert(1)',
   yaml: 'invert(1)',
   xml: 'invert(1)',
-  go: 'brightness(0.8) saturate(0.7)',
 };
 
 /**
@@ -295,9 +293,10 @@ export function getFolderIconColor(folderType: FolderType): string {
   return FOLDER_TYPE_COLORS[folderType] ?? FOLDER_TYPE_COLORS.default;
 }
 
-/** Custom SVG icons for types without devicons */
+/** Custom SVG icons for specific file types */
 const CUSTOM_ICONS: Partial<Record<FileType, React.ComponentType<React.SVGProps<SVGSVGElement>>>> =
   {
+    go: FirnGoGopherIcon,
     image: ImageIcon,
     text: TextFileIcon,
     executable: ExecutableIcon,

--- a/frontend/src/components/FileExplorer/TreeNode.tsx
+++ b/frontend/src/components/FileExplorer/TreeNode.tsx
@@ -1,5 +1,6 @@
 import { ChevronRightIcon, ChevronDownIcon } from '../icons';
-import { FileIcon, getFolderType } from './FileIcon';
+import { FileIcon } from './FileIcon';
+import { getFolderType } from './fileIconUtils';
 import type { filesystem } from '../../../wailsjs/go/models';
 import styles from './TreeNode.module.css';
 

--- a/frontend/src/components/FileExplorer/fileIconUtils.ts
+++ b/frontend/src/components/FileExplorer/fileIconUtils.ts
@@ -1,0 +1,218 @@
+/** File type identifier for icon styling */
+export type FileType =
+  | 'typescript'
+  | 'javascript'
+  | 'react'
+  | 'go'
+  | 'python'
+  | 'json'
+  | 'markdown'
+  | 'css'
+  | 'html'
+  | 'yaml'
+  | 'rust'
+  | 'image'
+  | 'git'
+  | 'text'
+  | 'xml'
+  | 'executable'
+  | 'library'
+  | 'compiled'
+  | 'binary'
+  | 'archive'
+  | 'default';
+
+/** Special folder type identifier */
+export type FolderType =
+  | 'src'
+  | 'components'
+  | 'hooks'
+  | 'node_modules'
+  | 'test'
+  | 'docs'
+  | 'public'
+  | 'dist'
+  | 'hidden'
+  | 'default';
+
+/** Folder color mapping - warm, high-contrast palette */
+const FOLDER_TYPE_COLORS: Record<FolderType, string> = {
+  src: '#3B82F6',
+  components: '#a855f7',
+  hooks: '#ec4899',
+  node_modules: '#78716c',
+  test: '#22c55e',
+  docs: '#06b6d4',
+  public: '#f97316',
+  dist: '#737373',
+  hidden: '#3f3f46',
+  default: '#d97706',
+};
+
+/** Extension to file type mapping */
+const EXTENSION_MAP: Record<string, FileType> = {
+  ts: 'typescript',
+  tsx: 'react',
+  js: 'javascript',
+  jsx: 'react',
+  mjs: 'javascript',
+  cjs: 'javascript',
+  go: 'go',
+  py: 'python',
+  pyi: 'python',
+  json: 'json',
+  md: 'markdown',
+  mdx: 'markdown',
+  css: 'css',
+  scss: 'css',
+  sass: 'css',
+  less: 'css',
+  html: 'html',
+  htm: 'html',
+  yaml: 'yaml',
+  yml: 'yaml',
+  rs: 'rust',
+  svg: 'image',
+  png: 'image',
+  jpg: 'image',
+  jpeg: 'image',
+  gif: 'image',
+  ico: 'image',
+  webp: 'image',
+  bmp: 'image',
+  gitignore: 'git',
+  gitattributes: 'git',
+  gitmodules: 'git',
+  txt: 'text',
+  log: 'text',
+  env: 'text',
+  xml: 'xml',
+  xsl: 'xml',
+  xslt: 'xml',
+  plist: 'xml',
+  exe: 'executable',
+  app: 'executable',
+  dll: 'library',
+  so: 'library',
+  dylib: 'library',
+  a: 'library',
+  lib: 'library',
+  o: 'compiled',
+  obj: 'compiled',
+  class: 'compiled',
+  pyc: 'compiled',
+  pyo: 'compiled',
+  bin: 'binary',
+  dat: 'binary',
+  wasm: 'binary',
+  zip: 'archive',
+  tar: 'archive',
+  gz: 'archive',
+  tgz: 'archive',
+  bz2: 'archive',
+  xz: 'archive',
+  rar: 'archive',
+  '7z': 'archive',
+  jar: 'archive',
+  dmg: 'archive',
+  iso: 'archive',
+};
+
+/** Known extensionless filenames to file type */
+const FILENAME_MAP: Record<string, FileType> = {
+  makefile: 'executable',
+  dockerfile: 'executable',
+  procfile: 'executable',
+  rakefile: 'executable',
+  vagrantfile: 'executable',
+  gemfile: 'text',
+  readme: 'text',
+  license: 'text',
+  licence: 'text',
+  authors: 'text',
+  changelog: 'text',
+  contributing: 'text',
+  copying: 'text',
+  notice: 'text',
+};
+
+/** Special folder name mapping */
+const FOLDER_NAME_MAP: Record<string, FolderType> = {
+  src: 'src',
+  source: 'src',
+  components: 'components',
+  hooks: 'hooks',
+  node_modules: 'node_modules',
+  test: 'test',
+  tests: 'test',
+  __tests__: 'test',
+  docs: 'docs',
+  documentation: 'docs',
+  public: 'public',
+  static: 'public',
+  assets: 'public',
+  dist: 'dist',
+  build: 'dist',
+  out: 'dist',
+};
+
+/** File type to color mapping */
+const FILE_TYPE_COLORS: Record<FileType, string> = {
+  typescript: '#3178C6',
+  javascript: '#F7DF1E',
+  react: '#61DAFB',
+  go: '#00ADD8',
+  python: '#3776AB',
+  json: '#F59E0B',
+  markdown: '#8b9cae',
+  css: '#1572B6',
+  html: '#E34F26',
+  yaml: '#ef4444',
+  rust: '#DEA584',
+  image: '#a855f7',
+  git: '#F05032',
+  text: '#9ca3af',
+  xml: '#e36209',
+  executable: '#10b981',
+  library: '#8b5cf6',
+  compiled: '#f59e0b',
+  binary: '#ef4444',
+  archive: '#0ea5e9',
+  default: '#6B7280',
+};
+
+/**
+ * Gets the file type from a filename based on its extension.
+ */
+export function getFileType(name: string): FileType {
+  // No dot at all: check known filenames, then fall back to default icon
+  if (!name.includes('.')) {
+    return FILENAME_MAP[name.toLowerCase()] ?? 'default';
+  }
+  const ext = name.split('.').pop()?.toLowerCase() ?? '';
+  return EXTENSION_MAP[ext] ?? 'default';
+}
+
+/**
+ * Gets the folder type from a folder name.
+ */
+export function getFolderType(name: string): FolderType {
+  const mapped = FOLDER_NAME_MAP[name.toLowerCase()];
+  if (mapped) return mapped;
+  if (name.startsWith('.')) return 'hidden';
+  return 'default';
+}
+
+/**
+ * Gets the color for a file type per design specification.
+ */
+export function getFileIconColor(fileType: FileType | string): string {
+  return FILE_TYPE_COLORS[fileType as FileType] ?? FILE_TYPE_COLORS.default;
+}
+
+/**
+ * Gets the color for a folder type per design specification.
+ */
+export function getFolderIconColor(folderType: FolderType): string {
+  return FOLDER_TYPE_COLORS[folderType] ?? FOLDER_TYPE_COLORS.default;
+}

--- a/frontend/src/components/FileExplorer/index.ts
+++ b/frontend/src/components/FileExplorer/index.ts
@@ -1,4 +1,5 @@
 export { FileExplorer } from './FileExplorer';
 export { TreeNode } from './TreeNode';
-export { FileIcon, getFileType, getFolderType, getFileIconColor } from './FileIcon';
+export { FileIcon } from './FileIcon';
+export { getFileType, getFolderType, getFileIconColor } from './fileIconUtils';
 export { useDirectoryTree } from './useDirectoryTree';

--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -217,6 +217,69 @@ export function TextFileIcon(props: IconProps) {
   );
 }
 
+export function FirnGoGopherIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 80 92" fill="none" {...props} data-icon="firn-go-gopher">
+      <path d="M17 25c4-15 13-22 24-22 10 0 18 7 22 21-14-6-33-6-46 1z" fill="#0284c7" />
+      <path
+        d="M22 14c7-5 14-7 22-7"
+        fill="none"
+        stroke="#38bdf8"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+      <circle cx="62" cy="13" r="6" fill="#eefcff" />
+      <ellipse cx="40" cy="50" rx="25" ry="34" fill="#5ed3e3" stroke="#0f172a" strokeWidth="1.5" />
+      <circle cx="19" cy="27" r="5.6" fill="#5ed3e3" stroke="#0f172a" strokeWidth="1.4" />
+      <circle cx="61" cy="27" r="5.6" fill="#5ed3e3" stroke="#0f172a" strokeWidth="1.4" />
+      <path d="M17 27c12-7 32-7 46 0" stroke="#eefcff" strokeWidth="8" strokeLinecap="round" />
+      <path
+        d="M19 27c11-4 29-4 42 0"
+        stroke="#bae6fd"
+        strokeWidth="2"
+        strokeLinecap="round"
+        opacity="0.95"
+      />
+      <circle cx="31" cy="35" r="10" fill="#fff" stroke="#0f172a" strokeWidth="1.5" />
+      <circle cx="49" cy="35" r="10" fill="#fff" stroke="#0f172a" strokeWidth="1.5" />
+      <circle cx="31" cy="35" r="2.5" fill="#0f172a" />
+      <circle cx="49" cy="35" r="2.5" fill="#0f172a" />
+      <ellipse cx="40" cy="47" rx="4.2" ry="3" fill="#0f172a" />
+      <path
+        d="M35 51c2 4 8 4 10 0"
+        fill="none"
+        stroke="#0f172a"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <rect x="36" y="51" width="4" height="7" rx="1" fill="#fff4de" stroke="#0f172a" />
+      <rect x="40" y="51" width="4" height="7" rx="1" fill="#fff4de" stroke="#0f172a" />
+      <path
+        d="M16 54 7 58M64 54 73 58M24 81 17 89M56 81 63 89"
+        stroke="#f2c08f"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+      <path
+        d="M17 62c12 6 31 6 46 0"
+        fill="none"
+        stroke="#eefcff"
+        strokeWidth="8"
+        strokeLinecap="round"
+      />
+      <path
+        d="M18 62c11 5 30 5 44 0"
+        fill="none"
+        stroke="#38bdf8"
+        strokeWidth="5"
+        strokeLinecap="round"
+      />
+      <path d="M51 64 62 76" stroke="#38bdf8" strokeWidth="6" strokeLinecap="round" />
+      <path d="M51 64 62 76" stroke="#eefcff" strokeWidth="2" strokeLinecap="round" opacity="0.9" />
+    </svg>
+  );
+}
+
 export function ExecutableIcon(props: IconProps) {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>


### PR DESCRIPTION
## Summary
- Adds the approved Firn-themed full-body Go gopher SVG icon with front beanie brim and scarf.
- Routes `.go` files through the custom local icon while preserving file type detection and colors.
- Adds regression coverage that `.go` files render `data-icon="firn-go-gopher"`.

## Validation
- `npm test -- --runInBand`
- `npm run format:check`
- `npm run lint` (exits 0 with existing warnings)
- `npm run build`
