### PR TITLE
fix(lsp): find gopls when app launched outside a terminal

### DIFF
--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -171,6 +171,9 @@ func TestRegistry_GoServerConfigUsesDetectedProjectRoot(t *testing.T) {
 func TestRegistry_GoServerConfigReportsMissingGopls(t *testing.T) {
 	r := NewRegistry()
 	t.Setenv("PATH", "")
+	// Point HOME at a temp directory so findGoBinary fallback doesn't
+	// accidentally find a real gopls installed on the host machine.
+	t.Setenv("HOME", t.TempDir())
 
 	_, err := r.ServerConfigFor("go", t.TempDir())
 	if err == nil {

--- a/internal/lsp/registry.go
+++ b/internal/lsp/registry.go
@@ -198,7 +198,8 @@ func findGoBinary(name string) string {
 		filepath.Join(homeDir, "go", "bin", name),
 		filepath.Join(homeDir, ".local", "bin", name),
 		"/usr/local/go/bin/" + name,
-		"/usr/local/bin/" + name,
+		"/opt/homebrew/bin/" + name, // Apple Silicon Homebrew
+		"/usr/local/bin/" + name,    // Intel Homebrew / system
 	}
 
 	if runtime.GOOS == "windows" {

--- a/internal/lsp/registry.go
+++ b/internal/lsp/registry.go
@@ -209,12 +209,31 @@ func findGoBinary(name string) string {
 	}
 
 	for _, candidate := range candidates {
-		if info, statErr := os.Stat(candidate); statErr == nil && !info.IsDir() {
+		if isExecutableFile(candidate) {
 			return candidate
 		}
 	}
 
 	return ""
+}
+
+// isExecutableFile reports whether path is a regular, executable file. It
+// mirrors the executability check exec.LookPath performs so the fallback does
+// not return a non-executable candidate (which would fail later at cmd.Start)
+// and skip a genuinely runnable candidate further down the list.
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+
+	// On Windows executability is determined by extension, not mode bits; the
+	// candidate list already appends ".exe", so a regular file is sufficient.
+	if runtime.GOOS == "windows" {
+		return true
+	}
+
+	return info.Mode().Perm()&0o111 != 0
 }
 
 // resolvePythonServer finds and configures pyright-langserver.

--- a/internal/lsp/registry.go
+++ b/internal/lsp/registry.go
@@ -162,14 +162,20 @@ func (r *Registry) resolveTypeScriptServer(projectRoot string) (*ServerConfig, e
 }
 
 // resolveGoServer finds and configures gopls.
+// When the app is launched outside a terminal (e.g. from Finder or Dock),
+// macOS does not populate PATH with shell-specific entries like $HOME/go/bin.
+// We fall back to well-known Go binary directories in that case.
 func (r *Registry) resolveGoServer(projectRoot string) (*ServerConfig, error) {
 	path, err := exec.LookPath("gopls")
 	if err != nil {
-		return nil, fmt.Errorf(
-			"gopls not found: install it with " +
-				"\"go install golang.org/x/tools/gopls@latest\" " +
-				"or add it to PATH",
-		)
+		path = findGoBinary("gopls")
+		if path == "" {
+			return nil, fmt.Errorf(
+				"gopls not found: install it with "+
+					"\"go install golang.org/x/tools/gopls@latest\" "+
+					"or add it to PATH",
+			)
+		}
 	}
 
 	return &ServerConfig{
@@ -177,6 +183,38 @@ func (r *Registry) resolveGoServer(projectRoot string) (*ServerConfig, error) {
 		Command:        path,
 		Dir:            projectRoot,
 	}, nil
+}
+
+// findGoBinary searches common Go binary directories for a given binary name.
+// This covers the case where the app is launched from Finder/Dock on macOS
+// and the user's shell PATH (containing $HOME/go/bin, etc.) is not available.
+func findGoBinary(name string) string {
+	homeDir, homeErr := os.UserHomeDir()
+	if homeErr != nil {
+		return ""
+	}
+
+	candidates := []string{
+		filepath.Join(homeDir, "go", "bin", name),
+		filepath.Join(homeDir, ".local", "bin", name),
+		"/usr/local/go/bin/" + name,
+		"/usr/local/bin/" + name,
+	}
+
+	if runtime.GOOS == "windows" {
+		candidates = []string{
+			filepath.Join(homeDir, "go", "bin", name+".exe"),
+			filepath.Join(homeDir, ".local", "bin", name+".exe"),
+		}
+	}
+
+	for _, candidate := range candidates {
+		if info, statErr := os.Stat(candidate); statErr == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+
+	return ""
 }
 
 // resolvePythonServer finds and configures pyright-langserver.

--- a/internal/lsp/registry_test.go
+++ b/internal/lsp/registry_test.go
@@ -236,6 +236,37 @@ func TestResolveTypeScriptServer_SystemServerUsesPackageLocalTSLib(t *testing.T)
 	}
 }
 
+func TestFindGoBinary_FallbackFindsGoplsInHome(t *testing.T) {
+	homeDir := t.TempDir()
+	goBin := filepath.Join(homeDir, "go", "bin")
+	if err := os.MkdirAll(goBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	goplsPath := filepath.Join(goBin, "gopls")
+	if err := os.WriteFile(goplsPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Point HOME at our temp dir so findGoBinary picks up the fake binary.
+	t.Setenv("HOME", homeDir)
+	t.Setenv("PATH", "")
+
+	found := findGoBinary("gopls")
+	if found != goplsPath {
+		t.Errorf("findGoBinary(gopls) = %q, want %q", found, goplsPath)
+	}
+}
+
+func TestFindGoBinary_ReturnsEmptyWhenNotFound(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", "")
+
+	found := findGoBinary("gopls")
+	if found != "" {
+		t.Errorf("findGoBinary(gopls) = %q, want empty string", found)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }

--- a/internal/lsp/registry_test.go
+++ b/internal/lsp/registry_test.go
@@ -267,6 +267,41 @@ func TestFindGoBinary_ReturnsEmptyWhenNotFound(t *testing.T) {
 	}
 }
 
+func TestFindGoBinary_SkipsNonExecutableAndUsesLaterCandidate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executability is determined by extension on Windows")
+	}
+
+	homeDir := t.TempDir()
+
+	// Earlier candidate ($HOME/go/bin) is a non-executable regular file.
+	goBin := filepath.Join(homeDir, "go", "bin")
+	if err := os.MkdirAll(goBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(goBin, "gopls"), []byte("not executable"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Later candidate ($HOME/.local/bin) is executable and should win.
+	localBin := filepath.Join(homeDir, ".local", "bin")
+	if err := os.MkdirAll(localBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wantPath := filepath.Join(localBin, "gopls")
+	if err := os.WriteFile(wantPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", homeDir)
+	t.Setenv("PATH", "")
+
+	found := findGoBinary("gopls")
+	if found != wantPath {
+		t.Errorf("findGoBinary(gopls) = %q, want %q (non-executable candidate should be skipped)", found, wantPath)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }


### PR DESCRIPTION
## Problem
Opening a `.go` file produced:
> LSP didOpen failed: "gopls not found: install it with \"go install golang.org/x/tools/gopls@latest\" or add it to PATH"

macOS GUI apps launched from Finder/Dock do **not** inherit the shell PATH, so `exec.LookPath("gopls")` fails even when gopls is installed in `$HOME/go/bin`. Works in `wails dev` (terminal) but fails from the bundled `.app`.

## Fix
Add `findGoBinary` fallback that searches well-known Go binary dirs (`$HOME/go/bin`, `$HOME/.local/bin`, `/usr/local/go/bin`, `/usr/local/bin`; `.exe` variants on Windows) before returning the not-found error.

## Tests
- `TestFindGoBinary_FallbackFindsGoplsInHome`
- `TestFindGoBinary_ReturnsEmptyWhenNotFound`
- `manager_test` pins `HOME` to a temp dir so the fallback doesn't pick up a host gopls.
- All 6 LSP go tests pass.

> Note: requires gopls to actually be installed. This only restores discovery when it exists but isn't on the GUI PATH.

Generated with [Claude Code](https://claude.com/claude-code)