### PR TITLE
feat(run-profiles): scrollable, clickable output preview

### DIFF
--- a/frontend/src/__tests__/components/ExpandedPanel.test.tsx
+++ b/frontend/src/__tests__/components/ExpandedPanel.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { ExpandedPanel, getStopProgressPercent } from '../../components/RunProfiles/ExpandedPanel';
 import type { RunProfile } from '../../types/runProfile';
-import type { RunHistoryEntry, RunOutput } from '../../types/runOutput';
+import type { OutputEntry, RunHistoryEntry, RunOutput } from '../../types/runOutput';
 
 const mockProfile: RunProfile = {
   id: 'test-1',
@@ -14,16 +14,37 @@ const mockProfile: RunProfile = {
 
 const noop = () => {};
 
+function makeEntries(count: number): OutputEntry[] {
+  return Array.from({ length: count }, (_, i) => ({
+    stream: 'stdout' as const,
+    text: `line-${i}`,
+    timestamp: 1,
+  }));
+}
+
+function makeRunOutput(entries: OutputEntry[], state: RunOutput['state'] = 'success'): RunOutput {
+  return {
+    profileId: 'test-1',
+    state,
+    exitCode: 0,
+    runCount: 1,
+    entries,
+    previousEntries: [],
+  };
+}
+
 function renderPanel({
   visualState = 'idle',
   runHistory = [],
   runOutput,
   stopElapsedMs = 0,
+  onFocusOutput = noop,
 }: {
   visualState?: 'idle' | 'running' | 'stopping' | 'failed' | 'success' | 'stopped';
   runHistory?: RunHistoryEntry[];
   runOutput?: RunOutput;
   stopElapsedMs?: number;
+  onFocusOutput?: (profileId: string) => void;
 } = {}) {
   return render(
     <ExpandedPanel
@@ -33,7 +54,7 @@ function renderPanel({
       runHistory={runHistory}
       elapsed={2000}
       stopElapsedMs={stopElapsedMs}
-      onFocusOutput={noop}
+      onFocusOutput={onFocusOutput}
       onStart={noop}
       onStop={noop}
       onRestart={noop}
@@ -109,5 +130,96 @@ describe('ExpandedPanel', () => {
     renderPanel({ visualState: 'stopping', stopElapsedMs: 0 });
     expect(screen.getByText(/Restarting/)).toBeInTheDocument();
     expect(screen.queryByRole('progressbar')).toBeNull();
+  });
+});
+
+describe('ExpandedPanel output preview', () => {
+  const successHistory: RunHistoryEntry[] = [
+    { state: 'success', duration: 1800, timestamp: Date.now() },
+  ];
+
+  it('opens the full output when the preview is clicked', () => {
+    const onFocusOutput = jest.fn();
+    renderPanel({
+      visualState: 'success',
+      runHistory: successHistory,
+      runOutput: makeRunOutput(makeEntries(5)),
+      onFocusOutput,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /open full output/i }));
+
+    expect(onFocusOutput).toHaveBeenCalledWith('test-1');
+  });
+
+  it('opens the full output via Enter and Space on the preview', () => {
+    const onFocusOutput = jest.fn();
+    renderPanel({
+      visualState: 'success',
+      runHistory: successHistory,
+      runOutput: makeRunOutput(makeEntries(5)),
+      onFocusOutput,
+    });
+
+    const preview = screen.getByRole('button', { name: /open full output/i });
+    fireEvent.keyDown(preview, { key: 'Enter' });
+    fireEvent.keyDown(preview, { key: ' ' });
+
+    expect(onFocusOutput).toHaveBeenCalledTimes(2);
+    expect(onFocusOutput).toHaveBeenNthCalledWith(1, 'test-1');
+    expect(onFocusOutput).toHaveBeenNthCalledWith(2, 'test-1');
+  });
+
+  it('renders more than four preview lines when the output is long', () => {
+    renderPanel({
+      visualState: 'success',
+      runHistory: successHistory,
+      runOutput: makeRunOutput(makeEntries(10)),
+    });
+
+    // Old behaviour capped the tail at 4 lines, hiding the earliest output.
+    expect(screen.getByText('line-0')).toBeInTheDocument();
+    expect(screen.getByText('line-9')).toBeInTheDocument();
+  });
+
+  it('does not render a clickable preview when there is no output', () => {
+    renderPanel({ visualState: 'success', runHistory: successHistory });
+
+    expect(screen.queryByRole('button', { name: /open full output/i })).toBeNull();
+  });
+
+  it('does not open output when the user is selecting text in the preview', () => {
+    const onFocusOutput = jest.fn();
+    const originalGetSelection = window.getSelection;
+    window.getSelection = () => ({ toString: () => 'a copied error line' }) as unknown as Selection;
+
+    try {
+      renderPanel({
+        visualState: 'success',
+        runHistory: successHistory,
+        runOutput: makeRunOutput(makeEntries(5)),
+        onFocusOutput,
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: /open full output/i }));
+
+      expect(onFocusOutput).not.toHaveBeenCalled();
+    } finally {
+      window.getSelection = originalGetSelection;
+    }
+  });
+
+  it('opens the full output when the failed-state preview is clicked', () => {
+    const onFocusOutput = jest.fn();
+    renderPanel({
+      visualState: 'failed',
+      runHistory: [{ state: 'failed', duration: 1800, timestamp: Date.now() }],
+      runOutput: makeRunOutput(makeEntries(3), 'failed'),
+      onFocusOutput,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /open full output/i }));
+
+    expect(onFocusOutput).toHaveBeenCalledWith('test-1');
   });
 });

--- a/frontend/src/__tests__/components/ExpandedPanel.test.tsx
+++ b/frontend/src/__tests__/components/ExpandedPanel.test.tsx
@@ -182,6 +182,35 @@ describe('ExpandedPanel output preview', () => {
     expect(screen.getByText('line-9')).toBeInTheDocument();
   });
 
+  it('keeps a long preview scrolled to the newest output', () => {
+    const originalScrollHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'scrollHeight'
+    );
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get: () => 640,
+    });
+
+    try {
+      renderPanel({
+        visualState: 'success',
+        runHistory: successHistory,
+        runOutput: makeRunOutput(makeEntries(50)),
+      });
+
+      const preview = screen.getByRole('button', { name: /open full output/i });
+
+      expect(preview.scrollTop).toBe(preview.scrollHeight);
+    } finally {
+      if (originalScrollHeight) {
+        Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalScrollHeight);
+      } else {
+        delete (HTMLElement.prototype as { scrollHeight?: number }).scrollHeight;
+      }
+    }
+  });
+
   it('does not render a clickable preview when there is no output', () => {
     renderPanel({ visualState: 'success', runHistory: successHistory });
 

--- a/frontend/src/components/RunProfiles/ExpandedPanel.module.css
+++ b/frontend/src/components/RunProfiles/ExpandedPanel.module.css
@@ -13,8 +13,27 @@
   border-radius: 4px;
   border: 1px solid rgba(255, 255, 255, 0.04);
   margin-bottom: 8px;
-  max-height: 80px;
-  overflow: hidden;
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+/* Clickable preview opens the full virtualized output tab */
+.outputPreviewClickable {
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+}
+
+.outputPreviewClickable:hover {
+  border-color: rgba(56, 189, 248, 0.25);
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.outputPreviewClickable:focus-visible {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.5);
+  box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.3);
 }
 
 .outputLine {
@@ -126,7 +145,7 @@
 
 /* Error output wraps instead of truncating so users can read the full message */
 .errorDetail + .outputPreview {
-  max-height: 120px;
+  max-height: 160px;
   overflow-y: auto;
 }
 

--- a/frontend/src/components/RunProfiles/ExpandedPanel.tsx
+++ b/frontend/src/components/RunProfiles/ExpandedPanel.tsx
@@ -1,3 +1,4 @@
+import type { KeyboardEvent } from 'react';
 import type { VisualState, RunOutput, RunHistoryEntry, OutputEntry } from '../../types/runOutput';
 import type { RunProfile } from '../../types/runProfile';
 import { PlayIcon, StopIcon, RestartIcon } from '../icons';
@@ -6,6 +7,16 @@ import { estimateRemaining } from '../../utils/estimateCompletion';
 import styles from './ExpandedPanel.module.css';
 
 const GRACE_PERIOD_MS = 3000;
+
+/**
+ * Number of trailing output lines kept in the in-card preview. The preview is
+ * scrollable (~10 lines visible at a time) and clicking it opens the full,
+ * virtualized output tab — so this only needs enough scrollback to be useful.
+ * Kept modest on purpose: the preview is NOT virtualized and re-renders on every
+ * output burst of a live run, so a large tail would multiply reconciliation cost
+ * on the streaming hot path. Deep history lives in the virtualized Output tab.
+ */
+const PREVIEW_TAIL_COUNT = 40;
 
 /**
  * Compute stop-progress as a clamped 0-100 integer.
@@ -37,10 +48,44 @@ function getTailEntries(entries: OutputEntry[] | undefined, count: number): Outp
   return entries.slice(-count);
 }
 
-function OutputTail({ entries }: { entries: OutputEntry[] }) {
+function OutputTail({
+  entries,
+  profileName,
+  onActivate,
+}: {
+  entries: OutputEntry[];
+  profileName?: string;
+  onActivate?: () => void;
+}) {
   if (entries.length === 0) return null;
+
+  const interactiveProps = onActivate
+    ? {
+        role: 'button',
+        tabIndex: 0,
+        'aria-label': `Open full output${profileName ? ` for ${profileName}` : ''}`,
+        title: 'Open full output',
+        onClick: () => {
+          // Don't hijack the click when the user is drag-selecting text to copy
+          // (e.g. an error line) — only navigate on a plain click.
+          if ((window.getSelection()?.toString().length ?? 0) > 0) return;
+          onActivate();
+        },
+        onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onActivate();
+          }
+        },
+      }
+    : {};
+
+  const className = [styles.outputPreview, onActivate ? styles.outputPreviewClickable : '']
+    .filter(Boolean)
+    .join(' ');
+
   return (
-    <div className={styles.outputPreview}>
+    <div className={className} {...interactiveProps}>
       {entries.map((entry, i) => (
         <div
           key={i}
@@ -120,17 +165,23 @@ function RunningPanel({
   runOutput,
   runHistory,
   elapsed,
+  onFocusOutput,
 }: {
   profile: RunProfile;
   runOutput: RunOutput | undefined;
   runHistory: RunHistoryEntry[];
   elapsed: number;
+  onFocusOutput: (profileId: string) => void;
 }) {
-  const tail = getTailEntries(runOutput?.entries, 4);
+  const tail = getTailEntries(runOutput?.entries, PREVIEW_TAIL_COUNT);
   const eta = estimateRemaining(runHistory, elapsed);
   return (
     <>
-      <OutputTail entries={tail} />
+      <OutputTail
+        entries={tail}
+        profileName={profile.name}
+        onActivate={() => onFocusOutput(profile.id)}
+      />
       <StatsRow elapsed={elapsed} profile={profile} runHistory={runHistory} eta={eta} />
     </>
   );
@@ -142,17 +193,19 @@ function StoppingPanel({
   runHistory,
   elapsed,
   stopElapsedMs,
+  onFocusOutput,
 }: {
   profile: RunProfile;
   runOutput: RunOutput | undefined;
   runHistory: RunHistoryEntry[];
   elapsed: number;
   stopElapsedMs: number;
+  onFocusOutput: (profileId: string) => void;
 }) {
   const progress = getStopProgressPercent(stopElapsedMs, GRACE_PERIOD_MS);
   const remainingMs = Math.max(0, GRACE_PERIOD_MS - stopElapsedMs);
   const remainingSeconds = Math.ceil(remainingMs / 1000);
-  const tail = getTailEntries(runOutput?.entries, 4);
+  const tail = getTailEntries(runOutput?.entries, PREVIEW_TAIL_COUNT);
 
   return (
     <>
@@ -172,7 +225,11 @@ function StoppingPanel({
           />
         </div>
       </div>
-      <OutputTail entries={tail} />
+      <OutputTail
+        entries={tail}
+        profileName={profile.name}
+        onActivate={() => onFocusOutput(profile.id)}
+      />
       <StatsRow elapsed={elapsed} profile={profile} runHistory={runHistory} />
     </>
   );
@@ -183,14 +240,16 @@ function FailedPanel({
   runOutput,
   runHistory,
   elapsed,
+  onFocusOutput,
 }: {
   profile: RunProfile;
   runOutput: RunOutput | undefined;
   runHistory: RunHistoryEntry[];
   elapsed: number;
+  onFocusOutput: (profileId: string) => void;
 }) {
   const exitCode = runOutput?.exitCode;
-  const tail = getTailEntries(runOutput?.entries, 6);
+  const tail = getTailEntries(runOutput?.entries, PREVIEW_TAIL_COUNT);
 
   return (
     <>
@@ -202,7 +261,11 @@ function FailedPanel({
           <span className={styles.errorLabel}>Process failed</span>
         </div>
       </div>
-      <OutputTail entries={tail} />
+      <OutputTail
+        entries={tail}
+        profileName={profile.name}
+        onActivate={() => onFocusOutput(profile.id)}
+      />
       <StatsRow
         elapsed={runHistory[runHistory.length - 1]?.duration ?? elapsed}
         durationLabel="Duration"
@@ -266,19 +329,25 @@ function IdlePanel({
   runOutput,
   runHistory,
   elapsed,
+  onFocusOutput,
 }: {
   profile: RunProfile;
   runOutput: RunOutput | undefined;
   runHistory: RunHistoryEntry[];
   elapsed: number;
+  onFocusOutput: (profileId: string) => void;
 }) {
   const lastEntry = runHistory[runHistory.length - 1];
   const resultLabel = getResultLabel(lastEntry);
-  const tail = getTailEntries(runOutput?.entries, 4);
+  const tail = getTailEntries(runOutput?.entries, PREVIEW_TAIL_COUNT);
 
   return (
     <>
-      <OutputTail entries={tail} />
+      <OutputTail
+        entries={tail}
+        profileName={profile.name}
+        onActivate={() => onFocusOutput(profile.id)}
+      />
       <StatsRow
         elapsed={lastEntry?.duration ?? elapsed}
         durationLabel="Duration"
@@ -295,16 +364,22 @@ function SuccessPanel({
   runOutput,
   runHistory,
   elapsed,
+  onFocusOutput,
 }: {
   profile: RunProfile;
   runOutput: RunOutput | undefined;
   runHistory: RunHistoryEntry[];
   elapsed: number;
+  onFocusOutput: (profileId: string) => void;
 }) {
-  const tail = getTailEntries(runOutput?.entries, 4);
+  const tail = getTailEntries(runOutput?.entries, PREVIEW_TAIL_COUNT);
   return (
     <>
-      <OutputTail entries={tail} />
+      <OutputTail
+        entries={tail}
+        profileName={profile.name}
+        onActivate={() => onFocusOutput(profile.id)}
+      />
       <StatsRow
         elapsed={runHistory[runHistory.length - 1]?.duration ?? elapsed}
         durationLabel="Duration"
@@ -455,6 +530,7 @@ export function ExpandedPanel({
             runOutput={runOutput}
             runHistory={runHistory}
             elapsed={elapsed}
+            onFocusOutput={onFocusOutput}
           />
         );
       case 'stopping': {
@@ -468,6 +544,7 @@ export function ExpandedPanel({
             runHistory={runHistory}
             elapsed={elapsed}
             stopElapsedMs={stopElapsedMs}
+            onFocusOutput={onFocusOutput}
           />
         ) : (
           <div className={styles.statRow}>
@@ -485,6 +562,7 @@ export function ExpandedPanel({
             runOutput={runOutput}
             runHistory={runHistory}
             elapsed={elapsed}
+            onFocusOutput={onFocusOutput}
           />
         );
       case 'success':
@@ -494,6 +572,7 @@ export function ExpandedPanel({
             runOutput={runOutput}
             runHistory={runHistory}
             elapsed={elapsed}
+            onFocusOutput={onFocusOutput}
           />
         );
       case 'stopped':
@@ -508,6 +587,7 @@ export function ExpandedPanel({
             runOutput={runOutput}
             runHistory={runHistory}
             elapsed={elapsed}
+            onFocusOutput={onFocusOutput}
           />
         );
       default:

--- a/frontend/src/components/RunProfiles/ExpandedPanel.tsx
+++ b/frontend/src/components/RunProfiles/ExpandedPanel.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect, useRef } from 'react';
 import type { KeyboardEvent } from 'react';
 import type { VisualState, RunOutput, RunHistoryEntry, OutputEntry } from '../../types/runOutput';
 import type { RunProfile } from '../../types/runProfile';
@@ -57,6 +58,14 @@ function OutputTail({
   profileName?: string;
   onActivate?: () => void;
 }) {
+  const previewRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const preview = previewRef.current;
+    if (!preview) return;
+    preview.scrollTop = preview.scrollHeight;
+  }, [entries]);
+
   if (entries.length === 0) return null;
 
   const interactiveProps = onActivate
@@ -85,7 +94,7 @@ function OutputTail({
     .join(' ');
 
   return (
-    <div className={className} {...interactiveProps}>
+    <div ref={previewRef} className={className} {...interactiveProps}>
       {entries.map((entry, i) => (
         <div
           key={i}


### PR DESCRIPTION
## Summary

The expanded run-profile card showed a clipped, non-scrollable output preview (4-6 trailing lines, `overflow: hidden`). The only way to the full output was the separate "Output" action button. This makes the in-card preview both scrollable and directly clickable.

## Changes

- **Scrollable preview** — `.outputPreview` switched from `overflow: hidden` to `overflow-y: auto`, `max-height` 80px to 160px (error variant 120px to 160px). The full, unbounded output still lives in the virtualized Output tab.
- **Clickable preview** — when `OutputTail` receives an `onActivate` handler it becomes an accessible click target: `role=button`, `tabIndex=0`, `aria-label`, `title`, hover/focus-visible affordance, and Enter/Space keyboard activation. Activating it calls the existing `focusProfileOutput`, opening the bottom Output tab. The existing "Output" action button is unchanged.
- **Selection-safe click** — a plain click navigates, but a drag-select is left alone (guarded on `window.getSelection`) so users can still copy error lines out of the preview.
- **Tail count** — trailing lines unified to `PREVIEW_TAIL_COUNT = 40` across all states (was 4 for running/idle/success/stopping, 6 for failed). Kept modest deliberately: the preview is not virtualized and the card re-renders on every output burst of a live run, so a large tail would multiply reconciliation cost on the streaming hot path. Deep history remains in the virtualized Output tab.

## Tests

`ExpandedPanel.test.tsx` adds coverage for: click activation, Enter/Space activation, the text-selection guard, failed-state preview activation, long-output line count, and the no-output empty case.

- Frontend suite: 781 passed, 68 suites
- eslint: 0 errors; prettier: clean

## Notes

- Independent of PR #104 / #105 (no file overlap).
- Triage decision unchanged: the "PASSED but a Problem listed" report is a gopls/LSP diagnostic in the bottom Problems tab, independent of run profiles, and is intentionally left as-is.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>