### PR TITLE
feat(file-tree): Project & Workspace file tree views (#54)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -136,10 +136,12 @@ Defines workspace identity: type, accent color, and how workspaces are configure
 
 ### #54: Workspace - File Tree Views (NEW)
 Project View (unified) vs Workspace View (focused) with color-coded regions.
-- [ ] Toggle dropdown: "PROJECT" vs "WORKSPACE" at top of file tree panel
-- [ ] Project View: full repo tree with color-coded workspace regions (~4% accent tint)
-- [ ] Workspace View: scoped tree with workspace tabs for switching
-- [ ] File type association for tinting (e.g., `docker-compose.yml` gets Infrastructure tint at root)
+- [x] Segmented PROJECT / WORKSPACE toggle at top of file tree panel
+- [x] Project View: full repo tree with color-coded workspace regions (~6% accent tint)
+- [x] Workspace View: scoped tree with workspace tabs for switching
+- [x] File type association for tinting (e.g., `docker-compose.yml` gets Infrastructure tint at root)
+
+> **Bridge note:** Run Profiles grouping/filtering by view intentionally deferred to #71/#18; the Run Profiles panel behavior is unchanged across tree views.
 
 > **Design spec ref:** Section 4 (File Tree Views)
 

--- a/frontend/src/__tests__/components/FileExplorerViews.test.tsx
+++ b/frontend/src/__tests__/components/FileExplorerViews.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import { FileExplorer } from '../../components/FileExplorer/FileExplorer';
+import { useIDEStore } from '../../stores/ideStore';
+import type { workspace } from '../../../wailsjs/go/models';
+import type { FileEntry } from '../../stores/ideStore';
+
+// Mock Wails bindings (pulled in transitively via layout/IDEShell and useDirectoryTree)
+jest.mock('../../../wailsjs/go/main/App', () => ({
+  ToggleMaximize: jest.fn(),
+  ReadDirectory: jest.fn(),
+  OpenFolderDialog: jest.fn(),
+}));
+
+jest.mock('../../../wailsjs/runtime/runtime', () => ({
+  WindowSetTitle: jest.fn(),
+}));
+
+// Prevent automatic fetching inside useDirectoryTree hook
+jest.mock('../../components/FileExplorer/useDirectoryTree', () => ({
+  useDirectoryTree: () => ({ refetch: jest.fn() }),
+}));
+
+const root = '/repo';
+const defs = [
+  { id: 'project', name: 'Project', relDir: '', type: 'project', accent: 'project' },
+  { id: 'frontend', name: 'Frontend', relDir: 'frontend', type: 'frontend', accent: 'blue' },
+] as workspace.WorkspaceDef[];
+
+const tree: FileEntry[] = [
+  { name: 'README.md', path: `${root}/README.md`, isDir: false } as FileEntry,
+  {
+    name: 'frontend',
+    path: `${root}/frontend`,
+    isDir: true,
+    children: [{ name: 'App.tsx', path: `${root}/frontend/App.tsx`, isDir: false } as FileEntry],
+  } as FileEntry,
+];
+
+function seed(
+  activeWorkspaceId: string,
+  extra: Partial<ReturnType<typeof useIDEStore.getState>> = {}
+) {
+  useIDEStore.setState({
+    workspace: { name: 'repo', path: root },
+    workspaces: defs,
+    activeWorkspaceId,
+    lastFocusedWorkspaceId: activeWorkspaceId !== 'project' ? activeWorkspaceId : null,
+    directoryTree: tree,
+    expandedPaths: new Set([`${root}/frontend`]),
+    isRootExpanded: true,
+    isLoadingTree: false,
+    treeError: null,
+    ...extra,
+  });
+}
+
+describe('FileExplorer views', () => {
+  it('renders the segmented toggle and no tabs in Project View', () => {
+    seed('project');
+    render(<FileExplorer />);
+    expect(screen.getByRole('button', { name: 'Project' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.queryByRole('tablist')).toBeNull();
+  });
+
+  it('shows the workspace tab strip in Workspace View', () => {
+    seed('frontend');
+    render(<FileExplorer />);
+    expect(screen.getByRole('tablist')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Frontend' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('renders the scoped-error state when the workspace folder is missing', () => {
+    seed('frontend', {
+      workspaces: [
+        defs[0],
+        { id: 'frontend', name: 'Frontend', relDir: 'missing', type: 'frontend', accent: 'blue' },
+      ] as workspace.WorkspaceDef[],
+    });
+    render(<FileExplorer />);
+    expect(screen.getByText(/workspace folder not found/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/TreeNodeTint.test.tsx
+++ b/frontend/src/__tests__/components/TreeNodeTint.test.tsx
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/react';
+import { TreeNode } from '../../components/FileExplorer/TreeNode';
+import type { FileEntry, WorkspaceAccent } from '../../stores/ideStore';
+
+const folder: FileEntry = {
+  name: 'frontend',
+  path: '/repo/frontend',
+  isDir: true,
+  children: [{ name: 'App.tsx', path: '/repo/frontend/App.tsx', isDir: false } as FileEntry],
+} as FileEntry;
+
+const noop = () => {};
+
+describe('TreeNode region tinting', () => {
+  it('adds the tinted class and --region-accent var when the resolver returns an accent', () => {
+    const getRegionAccent = (e: FileEntry): WorkspaceAccent | null =>
+      e.path.startsWith('/repo/frontend') ? 'blue' : null;
+    const { container } = render(
+      <TreeNode
+        entry={folder}
+        depth={1}
+        isExpanded
+        expandedPaths={new Set(['/repo/frontend'])}
+        onToggle={noop}
+        onSelect={noop}
+        onOpen={noop}
+        getRegionAccent={getRegionAccent}
+      />
+    );
+    const rows = container.querySelectorAll('.row.tinted');
+    // folder row + visible child row both tinted
+    expect(rows.length).toBe(2);
+    const folderRow = rows[0] as HTMLElement;
+    expect(folderRow.style.getPropertyValue('--region-accent')).toBe('var(--accent-blue)');
+  });
+
+  it('does not tint when no resolver is provided', () => {
+    const { container } = render(
+      <TreeNode entry={folder} depth={1} isExpanded onToggle={noop} onSelect={noop} onOpen={noop} />
+    );
+    expect(container.querySelector('.row.tinted')).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/components/TreeViewToggle.test.tsx
+++ b/frontend/src/__tests__/components/TreeViewToggle.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TreeViewToggle } from '../../components/FileExplorer/TreeViewToggle';
+import { useIDEStore } from '../../stores/ideStore';
+import type { workspace } from '../../../wailsjs/go/models';
+
+const defs = [
+  { id: 'project', name: 'Project', relDir: '', type: 'project', accent: 'project' },
+  { id: 'frontend', name: 'Frontend', relDir: 'frontend', type: 'frontend', accent: 'blue' },
+] as workspace.WorkspaceDef[];
+
+describe('TreeViewToggle', () => {
+  beforeEach(() => {
+    useIDEStore.setState({
+      workspaces: [],
+      activeWorkspaceId: 'project',
+      lastFocusedWorkspaceId: null,
+    });
+  });
+
+  it('disables the Workspace segment when there are no workspaces', () => {
+    render(<TreeViewToggle />);
+    expect(screen.getByRole('button', { name: 'Workspace' })).toBeDisabled();
+  });
+
+  it('marks the active segment with aria-pressed', () => {
+    useIDEStore.setState({ workspaces: defs, activeWorkspaceId: 'project' });
+    render(<TreeViewToggle />);
+    expect(screen.getByRole('button', { name: 'Project' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Workspace' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
+  it('switches to workspace mode on click', () => {
+    useIDEStore.setState({ workspaces: defs, activeWorkspaceId: 'project' });
+    render(<TreeViewToggle />);
+    fireEvent.click(screen.getByRole('button', { name: 'Workspace' }));
+    expect(useIDEStore.getState().activeWorkspaceId).toBe('frontend');
+  });
+});

--- a/frontend/src/__tests__/components/WorkspaceTabs.test.tsx
+++ b/frontend/src/__tests__/components/WorkspaceTabs.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WorkspaceTabs } from '../../components/FileExplorer/WorkspaceTabs';
+import { useIDEStore } from '../../stores/ideStore';
+import type { workspace } from '../../../wailsjs/go/models';
+
+const defs = [
+  { id: 'project', name: 'Project', relDir: '', type: 'project', accent: 'project' },
+  { id: 'frontend', name: 'Frontend', relDir: 'frontend', type: 'frontend', accent: 'blue' },
+  { id: 'go', name: 'Go', relDir: 'backend/go', type: 'go', accent: 'cyan' },
+] as workspace.WorkspaceDef[];
+
+describe('WorkspaceTabs', () => {
+  beforeEach(() => {
+    useIDEStore.setState({
+      workspaces: defs,
+      activeWorkspaceId: 'frontend',
+      lastFocusedWorkspaceId: 'frontend',
+    });
+  });
+
+  it('renders a tab per non-project workspace', () => {
+    render(<WorkspaceTabs />);
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs.map((t) => t.textContent)).toEqual(['Frontend', 'Go']);
+  });
+
+  it('marks the active workspace tab as selected', () => {
+    render(<WorkspaceTabs />);
+    expect(screen.getByRole('tab', { name: 'Frontend' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Go' })).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('switches the active workspace on click', () => {
+    render(<WorkspaceTabs />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Go' }));
+    expect(useIDEStore.getState().activeWorkspaceId).toBe('go');
+  });
+
+  it('moves focus to the next tab with ArrowRight', () => {
+    render(<WorkspaceTabs />);
+    const first = screen.getByRole('tab', { name: 'Frontend' });
+    first.focus();
+    fireEvent.keyDown(first, { key: 'ArrowRight' });
+    expect(screen.getByRole('tab', { name: 'Go' })).toHaveFocus();
+  });
+
+  it('renders nothing when there are no non-project workspaces', () => {
+    useIDEStore.setState({ workspaces: [defs[0]], activeWorkspaceId: 'project' });
+    const { container } = render(<WorkspaceTabs />);
+    expect(container.querySelector('[role="tablist"]')).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/hooks/useFileTreePresentation.test.tsx
+++ b/frontend/src/__tests__/hooks/useFileTreePresentation.test.tsx
@@ -54,16 +54,20 @@ describe('useFileTreePresentation', () => {
     expect(result.current.roots).toHaveLength(3);
     expect(result.current.rootLabel).toBe('repo');
     expect(result.current.scopedError).toBe(false);
+    expect(result.current.treeAccent).toBeUndefined();
     expect(result.current.getRegionAccent?.(tree[1])).toBe('blue');
   });
 
-  it('workspace mode scopes to the workspace children and drops the resolver', () => {
+  it('workspace mode scopes to the children and washes the tree in the workspace accent', () => {
     seed('go');
     const { result } = renderHook(() => useFileTreePresentation());
     expect(result.current.mode).toBe('workspace');
     expect(result.current.rootLabel).toBe('Go');
     expect(result.current.roots.map((e) => e.name)).toEqual(['main.go']);
-    expect(result.current.getRegionAccent).toBeUndefined();
+    // Uniform wash: every entry resolves to the active workspace's accent.
+    expect(result.current.treeAccent).toBe('cyan');
+    expect(result.current.getRegionAccent?.(tree[0])).toBe('cyan');
+    expect(result.current.getRegionAccent?.(tree[1])).toBe('cyan');
     expect(result.current.scopedError).toBe(false);
   });
 

--- a/frontend/src/__tests__/hooks/useFileTreePresentation.test.tsx
+++ b/frontend/src/__tests__/hooks/useFileTreePresentation.test.tsx
@@ -1,0 +1,129 @@
+import { renderHook } from '@testing-library/react';
+import { useIDEStore } from '../../stores/ideStore';
+import { useFileTreePresentation } from '../../hooks/useFileTreePresentation';
+import type { workspace } from '../../../wailsjs/go/models';
+import type { FileEntry } from '../../stores/ideStore';
+
+const root = '/Users/me/repo';
+const defs = [
+  { id: 'project', name: 'Project', relDir: '', type: 'project', accent: 'project' },
+  { id: 'frontend', name: 'Frontend', relDir: 'frontend', type: 'frontend', accent: 'blue' },
+  { id: 'go', name: 'Go', relDir: 'backend/go', type: 'go', accent: 'cyan' },
+] as workspace.WorkspaceDef[];
+
+const tree: FileEntry[] = [
+  { name: 'README.md', path: `${root}/README.md`, isDir: false } as FileEntry,
+  {
+    name: 'frontend',
+    path: `${root}/frontend`,
+    isDir: true,
+    children: [{ name: 'App.tsx', path: `${root}/frontend/App.tsx`, isDir: false } as FileEntry],
+  } as FileEntry,
+  {
+    name: 'backend',
+    path: `${root}/backend`,
+    isDir: true,
+    children: [
+      {
+        name: 'go',
+        path: `${root}/backend/go`,
+        isDir: true,
+        children: [
+          { name: 'main.go', path: `${root}/backend/go/main.go`, isDir: false } as FileEntry,
+        ],
+      } as FileEntry,
+    ],
+  } as FileEntry,
+];
+
+function seed(activeWorkspaceId: string) {
+  useIDEStore.setState({
+    workspace: { name: 'repo', path: root },
+    workspaces: defs,
+    activeWorkspaceId,
+    lastFocusedWorkspaceId: activeWorkspaceId !== 'project' ? activeWorkspaceId : null,
+    directoryTree: tree,
+  });
+}
+
+describe('useFileTreePresentation', () => {
+  it('project mode exposes the full tree + a region resolver', () => {
+    seed('project');
+    const { result } = renderHook(() => useFileTreePresentation());
+    expect(result.current.mode).toBe('project');
+    expect(result.current.roots).toHaveLength(3);
+    expect(result.current.rootLabel).toBe('repo');
+    expect(result.current.scopedError).toBe(false);
+    expect(result.current.tabs.map((t) => t.id)).toEqual(['frontend', 'go']);
+    expect(result.current.getRegionAccent?.(tree[1])).toBe('blue');
+  });
+
+  it('workspace mode scopes to the workspace children and drops the resolver', () => {
+    seed('go');
+    const { result } = renderHook(() => useFileTreePresentation());
+    expect(result.current.mode).toBe('workspace');
+    expect(result.current.rootLabel).toBe('Go');
+    expect(result.current.roots.map((e) => e.name)).toEqual(['main.go']);
+    expect(result.current.getRegionAccent).toBeUndefined();
+    expect(result.current.scopedError).toBe(false);
+  });
+
+  it('workspace mode scopes through normalized absolute paths, including Windows paths', () => {
+    useIDEStore.setState({
+      workspace: { name: 'repo', path: 'c:/repo' },
+      workspaces: [
+        { id: 'project', name: 'Project', relDir: '', type: 'project', accent: 'project' },
+        { id: 'frontend', name: 'Frontend', relDir: 'frontend', type: 'frontend', accent: 'blue' },
+      ] as workspace.WorkspaceDef[],
+      activeWorkspaceId: 'frontend',
+      lastFocusedWorkspaceId: 'frontend',
+      directoryTree: [
+        {
+          name: 'frontend',
+          path: 'C:\\Repo\\frontend',
+          isDir: true,
+          children: [
+            { name: 'App.tsx', path: 'C:\\Repo\\frontend\\App.tsx', isDir: false } as FileEntry,
+          ],
+        } as FileEntry,
+      ],
+    });
+
+    const { result } = renderHook(() => useFileTreePresentation());
+    expect(result.current.roots.map((e) => e.name)).toEqual(['App.tsx']);
+    expect(result.current.rootPath).toBe('C:\\Repo\\frontend');
+    expect(result.current.scopedError).toBe(false);
+  });
+
+  it('root workspace (relDir "") scopes to the whole tree', () => {
+    useIDEStore.setState({
+      workspace: { name: 'repo', path: root },
+      workspaces: [
+        { id: 'project', name: 'Project', relDir: '', type: 'project', accent: 'project' },
+        { id: 'root:go', name: 'Go', relDir: '', type: 'go', accent: 'cyan' },
+      ] as workspace.WorkspaceDef[],
+      activeWorkspaceId: 'root:go',
+      lastFocusedWorkspaceId: 'root:go',
+      directoryTree: tree,
+    });
+    const { result } = renderHook(() => useFileTreePresentation());
+    expect(result.current.roots).toHaveLength(3);
+    expect(result.current.scopedError).toBe(false);
+  });
+
+  it('sets scopedError when the workspace folder is missing from the tree', () => {
+    useIDEStore.setState({
+      workspace: { name: 'repo', path: root },
+      workspaces: [
+        { id: 'project', name: 'Project', relDir: '', type: 'project', accent: 'project' },
+        { id: 'ghost', name: 'Ghost', relDir: 'does/not/exist', type: 'go', accent: 'cyan' },
+      ] as workspace.WorkspaceDef[],
+      activeWorkspaceId: 'ghost',
+      lastFocusedWorkspaceId: 'ghost',
+      directoryTree: tree,
+    });
+    const { result } = renderHook(() => useFileTreePresentation());
+    expect(result.current.scopedError).toBe(true);
+    expect(result.current.roots).toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/hooks/useFileTreePresentation.test.tsx
+++ b/frontend/src/__tests__/hooks/useFileTreePresentation.test.tsx
@@ -54,7 +54,6 @@ describe('useFileTreePresentation', () => {
     expect(result.current.roots).toHaveLength(3);
     expect(result.current.rootLabel).toBe('repo');
     expect(result.current.scopedError).toBe(false);
-    expect(result.current.tabs.map((t) => t.id)).toEqual(['frontend', 'go']);
     expect(result.current.getRegionAccent?.(tree[1])).toBe('blue');
   });
 

--- a/frontend/src/__tests__/stores/treeView.test.ts
+++ b/frontend/src/__tests__/stores/treeView.test.ts
@@ -1,0 +1,40 @@
+import { useIDEStore } from '../../stores/ideStore';
+import type { workspace } from '../../../wailsjs/go/models';
+
+const defs = [
+  { id: 'project', name: 'Project', relDir: '', type: 'project', accent: 'project' },
+  { id: 'frontend', name: 'Frontend', relDir: 'frontend', type: 'frontend', accent: 'blue' },
+  { id: 'go', name: 'Go', relDir: 'backend/go', type: 'go', accent: 'cyan' },
+] as workspace.WorkspaceDef[];
+
+describe('treeView store — setActiveWorkspace + lastFocusedWorkspaceId', () => {
+  beforeEach(() => {
+    useIDEStore.setState({
+      workspaces: [],
+      activeWorkspaceId: 'project',
+      lastFocusedWorkspaceId: null,
+    });
+  });
+
+  it('records lastFocusedWorkspaceId when a real workspace is selected', () => {
+    useIDEStore.getState().setWorkspaces(defs);
+    useIDEStore.getState().setActiveWorkspace('frontend');
+    expect(useIDEStore.getState().activeWorkspaceId).toBe('frontend');
+    expect(useIDEStore.getState().lastFocusedWorkspaceId).toBe('frontend');
+  });
+
+  it('keeps lastFocusedWorkspaceId when switching to project', () => {
+    useIDEStore.getState().setWorkspaces(defs);
+    useIDEStore.getState().setActiveWorkspace('frontend');
+    useIDEStore.getState().setActiveWorkspace('project');
+    expect(useIDEStore.getState().activeWorkspaceId).toBe('project');
+    expect(useIDEStore.getState().lastFocusedWorkspaceId).toBe('frontend');
+  });
+
+  it('does not record an invalid id as lastFocused', () => {
+    useIDEStore.getState().setWorkspaces(defs);
+    useIDEStore.getState().setActiveWorkspace('nope');
+    expect(useIDEStore.getState().activeWorkspaceId).toBe('project');
+    expect(useIDEStore.getState().lastFocusedWorkspaceId).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/stores/treeView.test.ts
+++ b/frontend/src/__tests__/stores/treeView.test.ts
@@ -98,3 +98,37 @@ describe('treeView store — setTreeViewMode', () => {
     expect(useIDEStore.getState().activeWorkspaceId).toBe('project');
   });
 });
+
+describe('treeView store — setWorkspaces invalidation', () => {
+  beforeEach(() => {
+    useIDEStore.setState({
+      workspaces: [],
+      activeWorkspaceId: 'project',
+      lastFocusedWorkspaceId: null,
+    });
+  });
+
+  it('clears lastFocusedWorkspaceId when it disappears from the new list', () => {
+    useIDEStore.getState().setWorkspaces(defs);
+    useIDEStore.getState().setActiveWorkspace('frontend');
+    useIDEStore.getState().setActiveWorkspace('project'); // active=project, lastFocused=frontend
+    useIDEStore.getState().setWorkspaces([defs[0], defs[2]]); // frontend gone, go stays
+    expect(useIDEStore.getState().lastFocusedWorkspaceId).toBeNull();
+  });
+
+  it('keeps a still-valid lastFocusedWorkspaceId', () => {
+    useIDEStore.getState().setWorkspaces(defs);
+    useIDEStore.getState().setActiveWorkspace('go');
+    useIDEStore.getState().setActiveWorkspace('project'); // lastFocused=go
+    useIDEStore.getState().setWorkspaces(defs); // go still present
+    expect(useIDEStore.getState().lastFocusedWorkspaceId).toBe('go');
+  });
+
+  it('makes lastFocusedWorkspaceId follow a non-project active id (restore path)', () => {
+    // Simulates persistence restore: raw-set active id before workspaces arrive.
+    useIDEStore.setState({ activeWorkspaceId: 'frontend', lastFocusedWorkspaceId: null });
+    useIDEStore.getState().setWorkspaces(defs);
+    expect(useIDEStore.getState().activeWorkspaceId).toBe('frontend');
+    expect(useIDEStore.getState().lastFocusedWorkspaceId).toBe('frontend');
+  });
+});

--- a/frontend/src/__tests__/stores/treeView.test.ts
+++ b/frontend/src/__tests__/stores/treeView.test.ts
@@ -132,3 +132,35 @@ describe('treeView store — setWorkspaces invalidation', () => {
     expect(useIDEStore.getState().lastFocusedWorkspaceId).toBe('frontend');
   });
 });
+
+import { renderHook } from '@testing-library/react';
+import { useTreeViewMode, useCanFocusWorkspace } from '../../stores/ideStore';
+
+describe('treeView store — selectors', () => {
+  beforeEach(() => {
+    useIDEStore.setState({
+      workspaces: [],
+      activeWorkspaceId: 'project',
+      lastFocusedWorkspaceId: null,
+    });
+  });
+
+  it('useTreeViewMode is project when active id is project, else workspace', () => {
+    const { result, rerender } = renderHook(() => useTreeViewMode());
+    expect(result.current).toBe('project');
+    useIDEStore.setState({
+      workspaces: defs,
+      activeWorkspaceId: 'frontend',
+    });
+    rerender();
+    expect(result.current).toBe('workspace');
+  });
+
+  it('useCanFocusWorkspace reflects presence of a non-project workspace', () => {
+    const { result, rerender } = renderHook(() => useCanFocusWorkspace());
+    expect(result.current).toBe(false);
+    useIDEStore.setState({ workspaces: defs });
+    rerender();
+    expect(result.current).toBe(true);
+  });
+});

--- a/frontend/src/__tests__/stores/treeView.test.ts
+++ b/frontend/src/__tests__/stores/treeView.test.ts
@@ -38,3 +38,63 @@ describe('treeView store — setActiveWorkspace + lastFocusedWorkspaceId', () =>
     expect(useIDEStore.getState().lastFocusedWorkspaceId).toBeNull();
   });
 });
+
+describe('treeView store — setTreeViewMode', () => {
+  const rootGoDefs = [
+    { id: 'project', name: 'Project', relDir: '', type: 'project', accent: 'project' },
+    { id: 'root:go', name: 'Go', relDir: '', type: 'go', accent: 'cyan' },
+  ] as workspace.WorkspaceDef[];
+
+  beforeEach(() => {
+    useIDEStore.setState({
+      workspaces: [],
+      activeWorkspaceId: 'project',
+      lastFocusedWorkspaceId: null,
+    });
+  });
+
+  it("'project' mode sets activeWorkspaceId to project, keeps lastFocused", () => {
+    useIDEStore.getState().setWorkspaces(defs);
+    useIDEStore.getState().setActiveWorkspace('frontend');
+    useIDEStore.getState().setTreeViewMode('project');
+    expect(useIDEStore.getState().activeWorkspaceId).toBe('project');
+    expect(useIDEStore.getState().lastFocusedWorkspaceId).toBe('frontend');
+  });
+
+  it("'workspace' mode restores lastFocusedWorkspaceId when still valid", () => {
+    useIDEStore.getState().setWorkspaces(defs);
+    useIDEStore.getState().setActiveWorkspace('go');
+    useIDEStore.getState().setTreeViewMode('project');
+    useIDEStore.getState().setTreeViewMode('workspace');
+    expect(useIDEStore.getState().activeWorkspaceId).toBe('go');
+  });
+
+  it("'workspace' mode falls back to first non-root workspace when no lastFocused", () => {
+    useIDEStore.getState().setWorkspaces(defs); // frontend (relDir frontend) is first non-root
+    useIDEStore.getState().setTreeViewMode('workspace');
+    expect(useIDEStore.getState().activeWorkspaceId).toBe('frontend');
+  });
+
+  it("'workspace' mode prefers a non-root workspace over a root-typed one", () => {
+    const mixed = [
+      { id: 'project', name: 'Project', relDir: '', type: 'project', accent: 'project' },
+      { id: 'root:go', name: 'Go', relDir: '', type: 'go', accent: 'cyan' },
+      { id: 'frontend', name: 'Frontend', relDir: 'frontend', type: 'frontend', accent: 'blue' },
+    ] as workspace.WorkspaceDef[];
+    useIDEStore.getState().setWorkspaces(mixed);
+    useIDEStore.getState().setTreeViewMode('workspace');
+    expect(useIDEStore.getState().activeWorkspaceId).toBe('frontend');
+  });
+
+  it("'workspace' mode falls back to a root-typed workspace when no non-root exists", () => {
+    useIDEStore.getState().setWorkspaces(rootGoDefs);
+    useIDEStore.getState().setTreeViewMode('workspace');
+    expect(useIDEStore.getState().activeWorkspaceId).toBe('root:go');
+  });
+
+  it("'workspace' mode stays project when there are no real workspaces", () => {
+    useIDEStore.getState().setWorkspaces([defs[0]]); // project only
+    useIDEStore.getState().setTreeViewMode('workspace');
+    expect(useIDEStore.getState().activeWorkspaceId).toBe('project');
+  });
+});

--- a/frontend/src/__tests__/utils/workspaceRegions.test.ts
+++ b/frontend/src/__tests__/utils/workspaceRegions.test.ts
@@ -1,0 +1,36 @@
+import { relativePathFromRoot } from '../../utils/workspaceRegions';
+
+describe('relativePathFromRoot', () => {
+  const root = '/Users/me/repo';
+
+  it('returns "" for the repo root itself', () => {
+    expect(relativePathFromRoot(root, root)).toBe('');
+  });
+
+  it('returns the forward-slash relative path for a nested file', () => {
+    expect(relativePathFromRoot('/Users/me/repo/frontend/src/App.tsx', root)).toBe(
+      'frontend/src/App.tsx'
+    );
+  });
+
+  it('tolerates a trailing slash on the root', () => {
+    expect(relativePathFromRoot('/Users/me/repo/go.mod', '/Users/me/repo/')).toBe('go.mod');
+  });
+
+  it('returns null for a path outside the root', () => {
+    expect(relativePathFromRoot('/Users/me/other/x.ts', root)).toBeNull();
+  });
+
+  it('does not treat a sibling prefix as inside the root', () => {
+    expect(relativePathFromRoot('/Users/me/repo-2/x.ts', root)).toBeNull();
+  });
+
+  it('normalizes Windows backslashes and drive-letter case', () => {
+    expect(relativePathFromRoot('C:\\Repo\\frontend\\App.tsx', 'c:/repo')).toBe('frontend/App.tsx');
+  });
+
+  it('returns null for empty inputs', () => {
+    expect(relativePathFromRoot('', root)).toBeNull();
+    expect(relativePathFromRoot(root, '')).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/utils/workspaceRegions.test.ts
+++ b/frontend/src/__tests__/utils/workspaceRegions.test.ts
@@ -34,3 +34,79 @@ describe('relativePathFromRoot', () => {
     expect(relativePathFromRoot(root, '')).toBeNull();
   });
 });
+
+import { createRegionAccentResolver } from '../../utils/workspaceRegions';
+import type { workspace } from '../../../wailsjs/go/models';
+import type { FileEntry } from '../../stores/ideStore';
+
+function ws(partial: Partial<workspace.WorkspaceDef>): workspace.WorkspaceDef {
+  return {
+    id: '',
+    name: '',
+    relDir: '',
+    type: '',
+    accent: '',
+    ...partial,
+  } as workspace.WorkspaceDef;
+}
+function entry(path: string, isDir = false, name?: string): FileEntry {
+  return { path, isDir, name: name ?? path.split('/').pop()! } as FileEntry;
+}
+
+describe('createRegionAccentResolver', () => {
+  const root = '/Users/me/repo';
+  const workspaces = [
+    ws({ id: 'project', relDir: '', accent: 'project' }),
+    ws({ id: 'frontend', relDir: 'frontend', accent: 'blue' }),
+    ws({ id: 'backend', relDir: 'backend', accent: 'cyan' }),
+    ws({ id: 'backend/api', relDir: 'backend/api', accent: 'green' }),
+  ];
+
+  it('tints a workspace folder and its descendants with the workspace accent', () => {
+    const resolve = createRegionAccentResolver(root, workspaces);
+    expect(resolve(entry('/Users/me/repo/frontend', true))).toBe('blue');
+    expect(resolve(entry('/Users/me/repo/frontend/src/App.tsx'))).toBe('blue');
+  });
+
+  it('prefers the longest matching relDir for nested workspaces', () => {
+    const resolve = createRegionAccentResolver(root, workspaces);
+    expect(resolve(entry('/Users/me/repo/backend/api/main.go'))).toBe('green');
+    expect(resolve(entry('/Users/me/repo/backend/db/x.go'))).toBe('cyan');
+  });
+
+  it('does NOT match a sibling whose name shares a prefix', () => {
+    const resolve = createRegionAccentResolver(root, workspaces);
+    // "backend/apiary" must not match "backend/api"
+    expect(resolve(entry('/Users/me/repo/backend/apiary/x.go'))).toBe('cyan');
+  });
+
+  it('skips region tint for root workspaces (relDir === "")', () => {
+    const resolve = createRegionAccentResolver(root, [
+      ws({ id: 'project', relDir: '', accent: 'project' }),
+      ws({ id: 'root:go', relDir: '', accent: 'cyan' }),
+    ]);
+    expect(resolve(entry('/Users/me/repo/main.go'))).toBeNull();
+  });
+
+  it('tints loose root files by file-type association', () => {
+    const resolve = createRegionAccentResolver(root, workspaces);
+    expect(resolve(entry('/Users/me/repo/docker-compose.yml'))).toBe('purple');
+    expect(resolve(entry('/Users/me/repo/Dockerfile'))).toBe('purple');
+    expect(resolve(entry('/Users/me/repo/main.tf'))).toBe('purple');
+  });
+
+  it('does NOT tint a nested .tf outside any workspace', () => {
+    const resolve = createRegionAccentResolver(root, workspaces);
+    expect(resolve(entry('/Users/me/repo/scripts/main.tf'))).toBeNull();
+  });
+
+  it('does NOT tint an untyped loose root file', () => {
+    const resolve = createRegionAccentResolver(root, workspaces);
+    expect(resolve(entry('/Users/me/repo/README.md'))).toBeNull();
+  });
+
+  it('returns null for paths outside the repo root', () => {
+    const resolve = createRegionAccentResolver(root, workspaces);
+    expect(resolve(entry('/Users/me/other/App.tsx'))).toBeNull();
+  });
+});

--- a/frontend/src/components/FileExplorer/FileExplorer.module.css
+++ b/frontend/src/components/FileExplorer/FileExplorer.module.css
@@ -146,3 +146,15 @@
   outline: 2px solid var(--status-error);
   outline-offset: 2px;
 }
+
+/* Workspace-View scoped folder missing from the loaded tree */
+.scopedError {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 20px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 12px;
+}

--- a/frontend/src/components/FileExplorer/FileExplorer.tsx
+++ b/frontend/src/components/FileExplorer/FileExplorer.tsx
@@ -1,27 +1,24 @@
 import { useCallback, useEffect } from 'react';
 import { Panel, PanelAction } from '../layout';
+import { ChevronDownIcon, ChevronRightIcon, MinusIcon, FolderOpenIcon, FolderIcon } from '../icons';
 import {
-  HomeIcon,
-  ChevronDownIcon,
-  ChevronRightIcon,
-  MinusIcon,
-  FolderOpenIcon,
-  FolderIcon,
-} from '../icons';
-import {
-  useWorkspace,
   useIDEStore,
-  useDirectoryTree,
   useExpandedPaths,
   useSelectedPath,
   useIsRootExpanded,
+} from '../../stores/ideStore';
+import {
   useIsLoadingTree,
   useTreeError,
   useActiveFileId,
+  useWorkspace,
 } from '../../stores/ideStore';
 import { useDirectoryTree as useFetchDirectoryTree } from './useDirectoryTree';
+import { useFileTreePresentation } from '../../hooks/useFileTreePresentation';
 import { useOpenFolder } from '../../hooks/useOpenFolder';
 import { TreeNode } from './TreeNode';
+import { TreeViewToggle } from './TreeViewToggle';
+import { WorkspaceTabs } from './WorkspaceTabs';
 import type { filesystem } from '../../../wailsjs/go/models';
 import { ensureEditorFileOpen } from '../../utils/editorNavigation';
 import styles from './FileExplorer.module.css';
@@ -42,7 +39,6 @@ function shortenPath(path: string): string {
 
 export function FileExplorer() {
   const workspace = useWorkspace();
-  const directoryTree = useDirectoryTree();
   const expandedPaths = useExpandedPaths();
   const selectedPath = useSelectedPath();
   const isRootExpanded = useIsRootExpanded();
@@ -50,19 +46,20 @@ export function FileExplorer() {
   const treeError = useTreeError();
   const activeFileId = useActiveFileId();
 
+  const presentation = useFileTreePresentation();
+  const { mode, rootLabel, rootPath, roots, scopedError, getRegionAccent } = presentation;
+
   const toggleExpanded = useIDEStore((state) => state.toggleExpanded);
   const toggleRootExpanded = useIDEStore((state) => state.toggleRootExpanded);
   const setSelectedPath = useIDEStore((state) => state.setSelectedPath);
   const toggleLeftPanel = useIDEStore((state) => state.toggleLeftPanel);
 
-  // Sync active file in editor to file tree selection.
-  // Only depends on activeFileId — reads expandedPaths from store snapshot
-  // to avoid a dependency cycle (Set references change on every update).
+  // Sync active file in editor to file tree selection. Reads expandedPaths from
+  // the store snapshot to avoid a dependency cycle (Set refs change each update).
   useEffect(() => {
     if (activeFileId && activeFileId !== useIDEStore.getState().selectedPath) {
       setSelectedPath(activeFileId);
 
-      // Expand all parent folders to reveal the file
       const ws = useIDEStore.getState().workspace;
       if (ws) {
         const currentExpanded = useIDEStore.getState().expandedPaths;
@@ -84,63 +81,41 @@ export function FileExplorer() {
   }, [activeFileId, setSelectedPath]);
 
   const { openFolder } = useOpenFolder();
-
-  // Fetch directory tree on workspace change
   const { refetch } = useFetchDirectoryTree();
 
-  const handleToggle = useCallback(
-    (path: string) => {
-      toggleExpanded(path);
-    },
-    [toggleExpanded]
-  );
-
-  // Single click: just select the entry
+  const handleToggle = useCallback((path: string) => toggleExpanded(path), [toggleExpanded]);
   const handleSelect = useCallback(
-    (entry: filesystem.FileEntry) => {
-      setSelectedPath(entry.path);
-    },
+    (entry: filesystem.FileEntry) => setSelectedPath(entry.path),
     [setSelectedPath]
   );
-
-  // Double click: open file in editor
   const handleOpen = useCallback(async (entry: filesystem.FileEntry) => {
     if (entry.isDir) return;
     await ensureEditorFileOpen(entry.path);
   }, []);
-
-  const handleHidePanel = useCallback(() => {
-    toggleLeftPanel();
-  }, [toggleLeftPanel]);
+  const handleHidePanel = useCallback(() => toggleLeftPanel(), [toggleLeftPanel]);
 
   const renderContent = () => {
-    // Loading state
-    if (isLoadingTree) {
-      return <FileExplorerSkeleton />;
-    }
-
-    // Error state
-    if (treeError) {
-      return <FileExplorerError message={treeError} onRetry={refetch} />;
-    }
-
-    // No workspace
+    if (isLoadingTree) return <FileExplorerSkeleton />;
+    if (treeError) return <FileExplorerError message={treeError} onRetry={refetch} />;
     if (!workspace) {
       return <FileExplorerEmpty message="Open a folder to get started" onOpenFolder={openFolder} />;
     }
-
-    // Empty workspace
-    if (directoryTree.length === 0) {
+    if (scopedError) {
+      return (
+        <div className={styles.scopedError} role="status">
+          <p>Workspace folder not found</p>
+        </div>
+      );
+    }
+    if (roots.length === 0) {
       return <FileExplorerEmpty message="No files in workspace" onOpenFolder={openFolder} />;
     }
 
-    // Render tree with root folder
     const FolderIconComponent = isRootExpanded ? FolderOpenIcon : FolderIcon;
     const ChevronIcon = isRootExpanded ? ChevronDownIcon : ChevronRightIcon;
 
     return (
       <div role="tree" aria-label="File explorer">
-        {/* Root folder entry */}
         <div
           className={`${treeStyles.row} ${treeStyles.root}`}
           onClick={toggleRootExpanded}
@@ -161,7 +136,7 @@ export function FileExplorer() {
               e.stopPropagation();
               toggleRootExpanded();
             }}
-            aria-label={`Toggle ${workspace.name}`}
+            aria-label={`Toggle ${rootLabel}`}
           >
             <ChevronIcon aria-hidden="true" />
           </button>
@@ -170,14 +145,13 @@ export function FileExplorer() {
             style={{ color: isRootExpanded ? '#6A9AB0' : '#4A7080' }}
             aria-hidden="true"
           />
-          <span className={treeStyles.name}>{workspace.name}</span>
-          <span className={treeStyles.path}>{shortenPath(workspace.path)}</span>
+          <span className={treeStyles.name}>{rootLabel}</span>
+          <span className={treeStyles.path}>{shortenPath(rootPath)}</span>
         </div>
 
-        {/* Children when root is expanded */}
         {isRootExpanded && (
           <div role="group">
-            {directoryTree.map((entry) => (
+            {roots.map((entry) => (
               <TreeNode
                 key={entry.path}
                 entry={entry}
@@ -188,6 +162,7 @@ export function FileExplorer() {
                 onToggle={handleToggle}
                 onSelect={handleSelect}
                 onOpen={handleOpen}
+                getRegionAccent={getRegionAccent}
               />
             ))}
           </div>
@@ -198,19 +173,7 @@ export function FileExplorer() {
 
   return (
     <Panel
-      title={
-        <button
-          type="button"
-          className={styles.viewToggle}
-          aria-haspopup="listbox"
-          aria-expanded="false"
-          aria-label="Switch file tree view"
-        >
-          <HomeIcon aria-hidden="true" />
-          <span>PROJECT</span>
-          <ChevronDownIcon aria-hidden="true" />
-        </button>
-      }
+      title={<TreeViewToggle />}
       actions={
         <PanelAction
           icon={<MinusIcon />}
@@ -220,6 +183,7 @@ export function FileExplorer() {
         />
       }
     >
+      {mode === 'workspace' && <WorkspaceTabs />}
       <div className={styles.tree}>{renderContent()}</div>
     </Panel>
   );

--- a/frontend/src/components/FileExplorer/FileExplorer.tsx
+++ b/frontend/src/components/FileExplorer/FileExplorer.tsx
@@ -47,7 +47,8 @@ export function FileExplorer() {
   const activeFileId = useActiveFileId();
 
   const presentation = useFileTreePresentation();
-  const { mode, rootLabel, rootPath, roots, scopedError, getRegionAccent } = presentation;
+  const { mode, rootLabel, rootPath, roots, scopedError, getRegionAccent, treeAccent } =
+    presentation;
 
   const toggleExpanded = useIDEStore((state) => state.toggleExpanded);
   const toggleRootExpanded = useIDEStore((state) => state.toggleRootExpanded);
@@ -184,7 +185,12 @@ export function FileExplorer() {
       }
     >
       {mode === 'workspace' && <WorkspaceTabs />}
-      <div className={styles.tree}>{renderContent()}</div>
+      <div
+        className={styles.tree}
+        style={treeAccent ? { boxShadow: `inset 3px 0 0 var(--accent-${treeAccent})` } : undefined}
+      >
+        {renderContent()}
+      </div>
     </Panel>
   );
 }

--- a/frontend/src/components/FileExplorer/FileExplorer.tsx
+++ b/frontend/src/components/FileExplorer/FileExplorer.tsx
@@ -116,7 +116,15 @@ export function FileExplorer() {
     const ChevronIcon = isRootExpanded ? ChevronDownIcon : ChevronRightIcon;
 
     return (
-      <div role="tree" aria-label="File explorer">
+      <div
+        role="tree"
+        aria-label="File explorer"
+        style={
+          treeAccent
+            ? { boxShadow: `inset 3px 0 0 var(--accent-${treeAccent})`, minHeight: '100%' }
+            : undefined
+        }
+      >
         <div
           className={`${treeStyles.row} ${treeStyles.root}`}
           onClick={toggleRootExpanded}
@@ -185,12 +193,7 @@ export function FileExplorer() {
       }
     >
       {mode === 'workspace' && <WorkspaceTabs />}
-      <div
-        className={styles.tree}
-        style={treeAccent ? { boxShadow: `inset 3px 0 0 var(--accent-${treeAccent})` } : undefined}
-      >
-        {renderContent()}
-      </div>
+      <div className={styles.tree}>{renderContent()}</div>
     </Panel>
   );
 }

--- a/frontend/src/components/FileExplorer/TreeNode.module.css
+++ b/frontend/src/components/FileExplorer/TreeNode.module.css
@@ -1,4 +1,5 @@
 .row {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -17,14 +18,25 @@
 }
 
 /*
- * Region tint: faint accent wash + a 3px left rail. Because a workspace region
- * is a contiguous run of rows, the per-row rails stack into one continuous
- * vertical rail that groups the region (Project View = multi-color per region;
- * Workspace View = single accent across the tree).
+ * Region tint: faint accent wash + a 3px left rail. The rail is a square
+ * pseudo-element (not box-shadow/border) so it ignores the row's border-radius
+ * and stays perfectly straight; because a region is a contiguous run of rows,
+ * the per-row rails butt together into one continuous vertical rail that groups
+ * the region (Project View = multi-color per region; Workspace View = single
+ * accent across the tree).
  */
 .row.tinted {
   background-color: color-mix(in srgb, var(--region-accent) 6%, transparent);
-  box-shadow: inset 3px 0 0 var(--region-accent);
+}
+
+.row.tinted::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--region-accent);
 }
 
 .row.tinted:hover {

--- a/frontend/src/components/FileExplorer/TreeNode.module.css
+++ b/frontend/src/components/FileExplorer/TreeNode.module.css
@@ -16,6 +16,15 @@
   background-color: var(--surface-hover);
 }
 
+/* Project-View region tint (accent at low opacity over the panel surface). */
+.row.tinted {
+  background-color: color-mix(in srgb, var(--region-accent) 6%, transparent);
+}
+
+.row.tinted:hover {
+  background-color: color-mix(in srgb, var(--region-accent) 12%, transparent);
+}
+
 .row:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;

--- a/frontend/src/components/FileExplorer/TreeNode.module.css
+++ b/frontend/src/components/FileExplorer/TreeNode.module.css
@@ -16,9 +16,15 @@
   background-color: var(--surface-hover);
 }
 
-/* Project-View region tint (accent at low opacity over the panel surface). */
+/*
+ * Region tint: faint accent wash + a 3px left rail. Because a workspace region
+ * is a contiguous run of rows, the per-row rails stack into one continuous
+ * vertical rail that groups the region (Project View = multi-color per region;
+ * Workspace View = single accent across the tree).
+ */
 .row.tinted {
   background-color: color-mix(in srgb, var(--region-accent) 6%, transparent);
+  box-shadow: inset 3px 0 0 var(--region-accent);
 }
 
 .row.tinted:hover {

--- a/frontend/src/components/FileExplorer/TreeNode.tsx
+++ b/frontend/src/components/FileExplorer/TreeNode.tsx
@@ -2,6 +2,7 @@ import { ChevronRightIcon, ChevronDownIcon } from '../icons';
 import { FileIcon } from './FileIcon';
 import { getFolderType } from './fileIconUtils';
 import type { filesystem } from '../../../wailsjs/go/models';
+import type { WorkspaceAccent } from '../../stores/ideStore';
 import styles from './TreeNode.module.css';
 
 interface TreeNodeProps {
@@ -21,6 +22,8 @@ interface TreeNodeProps {
   onSelect: (entry: filesystem.FileEntry) => void;
   /** Called when a file is double-clicked (open) */
   onOpen: (entry: filesystem.FileEntry) => void;
+  /** Project-View region tint resolver. Absent → no tinting (Workspace View). */
+  getRegionAccent?: (entry: filesystem.FileEntry) => WorkspaceAccent | null;
 }
 
 /**
@@ -36,11 +39,13 @@ export function TreeNode({
   onToggle,
   onSelect,
   onOpen,
+  getRegionAccent,
 }: TreeNodeProps) {
   const isFolder = entry.isDir;
   const indentPx = depth * 16;
   const isSelected = selectedPath === entry.path;
   const isHidden = isFolder && getFolderType(entry.name) === 'hidden';
+  const regionAccent = getRegionAccent?.(entry) ?? null;
 
   const handleToggleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -78,9 +83,16 @@ export function TreeNode({
   return (
     <div data-testid="tree-node" data-depth={depth}>
       <div
-        className={styles.row}
+        className={`${styles.row}${regionAccent ? ` ${styles.tinted}` : ''}`}
         data-hidden={isHidden || undefined}
-        style={{ paddingLeft: `${indentPx}px` }}
+        style={{
+          paddingLeft: `${indentPx}px`,
+          ...(regionAccent
+            ? ({
+                ['--region-accent' as string]: `var(--accent-${regionAccent})`,
+              } as React.CSSProperties)
+            : {}),
+        }}
         onClick={handleRowClick}
         onDoubleClick={handleRowDoubleClick}
         onKeyDown={handleKeyDown}
@@ -134,6 +146,7 @@ export function TreeNode({
               onToggle={onToggle}
               onSelect={onSelect}
               onOpen={onOpen}
+              getRegionAccent={getRegionAccent}
             />
           ))}
         </div>

--- a/frontend/src/components/FileExplorer/TreeViewToggle.module.css
+++ b/frontend/src/components/FileExplorer/TreeViewToggle.module.css
@@ -1,0 +1,38 @@
+.toggle {
+  display: inline-flex;
+  border: 1px solid var(--surface-border-subtle);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.segment {
+  padding: 3px 10px;
+  background: transparent;
+  border: none;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.segment:hover:not(:disabled) {
+  color: var(--text-secondary);
+  background: var(--surface-hover);
+}
+
+.segment[aria-pressed='true'] {
+  background: var(--surface-active);
+  color: var(--text-primary);
+}
+
+.segment:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.segment:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}

--- a/frontend/src/components/FileExplorer/TreeViewToggle.tsx
+++ b/frontend/src/components/FileExplorer/TreeViewToggle.tsx
@@ -1,0 +1,34 @@
+import { useTreeViewMode, useCanFocusWorkspace, useIDEStore } from '../../stores/ideStore';
+import styles from './TreeViewToggle.module.css';
+
+/**
+ * Segmented Project | Workspace control for the file-tree panel header.
+ * Workspace is disabled when no non-project workspace exists.
+ */
+export function TreeViewToggle() {
+  const mode = useTreeViewMode();
+  const canFocus = useCanFocusWorkspace();
+  const setTreeViewMode = useIDEStore((s) => s.setTreeViewMode);
+
+  return (
+    <div className={styles.toggle} role="group" aria-label="File tree view">
+      <button
+        type="button"
+        className={styles.segment}
+        aria-pressed={mode === 'project'}
+        onClick={() => setTreeViewMode('project')}
+      >
+        Project
+      </button>
+      <button
+        type="button"
+        className={styles.segment}
+        aria-pressed={mode === 'workspace'}
+        disabled={!canFocus}
+        onClick={() => setTreeViewMode('workspace')}
+      >
+        Workspace
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/FileExplorer/WorkspaceTabs.module.css
+++ b/frontend/src/components/FileExplorer/WorkspaceTabs.module.css
@@ -32,6 +32,7 @@
 
 .tab[aria-selected='true'] {
   color: var(--text-primary);
+  border-radius: 0;
   box-shadow: inset 0 -2px 0 var(--tab-accent);
 }
 

--- a/frontend/src/components/FileExplorer/WorkspaceTabs.module.css
+++ b/frontend/src/components/FileExplorer/WorkspaceTabs.module.css
@@ -32,7 +32,6 @@
 
 .tab[aria-selected='true'] {
   color: var(--text-primary);
-  background: color-mix(in srgb, var(--tab-accent) 18%, transparent);
   box-shadow: inset 0 -2px 0 var(--tab-accent);
 }
 

--- a/frontend/src/components/FileExplorer/WorkspaceTabs.module.css
+++ b/frontend/src/components/FileExplorer/WorkspaceTabs.module.css
@@ -1,0 +1,49 @@
+.tabs {
+  display: flex;
+  gap: 4px;
+  padding: 4px 6px;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--surface-border-subtle);
+  scrollbar-width: thin;
+}
+
+.tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  padding: 3px 9px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all var(--transition);
+}
+
+.tab:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.tab[aria-selected='true'] {
+  color: var(--text-primary);
+  background: color-mix(in srgb, var(--tab-accent) 18%, transparent);
+  box-shadow: inset 0 -2px 0 var(--tab-accent);
+}
+
+.tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}

--- a/frontend/src/components/FileExplorer/WorkspaceTabs.tsx
+++ b/frontend/src/components/FileExplorer/WorkspaceTabs.tsx
@@ -1,0 +1,91 @@
+import { useRef } from 'react';
+import { useWorkspaces, useActiveWorkspaceId, useIDEStore } from '../../stores/ideStore';
+import styles from './WorkspaceTabs.module.css';
+
+const VALID_ACCENTS = new Set([
+  'project',
+  'blue',
+  'cyan',
+  'green',
+  'purple',
+  'orange',
+  'amber',
+  'general',
+]);
+
+function accentVar(accent: string): string {
+  return `var(--accent-${VALID_ACCENTS.has(accent) ? accent : 'project'})`;
+}
+
+/**
+ * Workspace-View tab strip. Tabs switch the active workspace (which scopes the
+ * tree). Active tab uses its accent. Rendered only in Workspace View.
+ */
+export function WorkspaceTabs() {
+  const workspaces = useWorkspaces();
+  const activeId = useActiveWorkspaceId();
+  const setActiveWorkspace = useIDEStore((s) => s.setActiveWorkspace);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const tabs = workspaces.filter((w) => w.id !== 'project');
+  if (tabs.length === 0) return null;
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const items = listRef.current?.querySelectorAll<HTMLElement>('[role="tab"]');
+    if (!items?.length) return;
+    const idx = Array.from(items).findIndex((el) => el === document.activeElement);
+    let next: number | null = null;
+    switch (e.key) {
+      case 'ArrowRight':
+        e.preventDefault();
+        next = idx < items.length - 1 ? idx + 1 : 0;
+        break;
+      case 'ArrowLeft':
+        e.preventDefault();
+        next = idx > 0 ? idx - 1 : items.length - 1;
+        break;
+      case 'Home':
+        e.preventDefault();
+        next = 0;
+        break;
+      case 'End':
+        e.preventDefault();
+        next = items.length - 1;
+        break;
+    }
+    if (next !== null) items[next].focus();
+  };
+
+  return (
+    <div
+      ref={listRef}
+      className={styles.tabs}
+      role="tablist"
+      aria-label="Workspaces"
+      onKeyDown={handleKeyDown}
+    >
+      {tabs.map((w) => {
+        const isActive = w.id === activeId;
+        return (
+          <button
+            key={w.id}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
+            className={styles.tab}
+            style={{ ['--tab-accent' as string]: accentVar(w.accent) } as React.CSSProperties}
+            onClick={() => setActiveWorkspace(w.id)}
+          >
+            <span
+              className={styles.dot}
+              style={{ background: accentVar(w.accent) }}
+              aria-hidden="true"
+            />
+            {w.name}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/Terminal/Terminal.module.css
+++ b/frontend/src/components/Terminal/Terminal.module.css
@@ -72,9 +72,7 @@
 
 .tab.active {
   color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 10%, transparent);
   box-shadow: inset 0 -2px 0 var(--accent);
-  border-radius: 5px 5px 0 0;
 }
 
 .tab svg {
@@ -171,7 +169,6 @@
 
 .sessionTab.active {
   color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 10%, transparent);
   box-shadow: inset 0 -2px 0 var(--accent);
 }
 

--- a/frontend/src/components/Terminal/Terminal.module.css
+++ b/frontend/src/components/Terminal/Terminal.module.css
@@ -72,6 +72,7 @@
 
 .tab.active {
   color: var(--accent);
+  border-radius: 0;
   box-shadow: inset 0 -2px 0 var(--accent);
 }
 
@@ -169,6 +170,7 @@
 
 .sessionTab.active {
   color: var(--accent);
+  border-radius: 0;
   box-shadow: inset 0 -2px 0 var(--accent);
 }
 

--- a/frontend/src/hooks/useFileTreePresentation.ts
+++ b/frontend/src/hooks/useFileTreePresentation.ts
@@ -1,0 +1,105 @@
+import { useMemo } from 'react';
+import {
+  useWorkspace,
+  useWorkspaces,
+  useActiveWorkspace,
+  useDirectoryTree,
+  useTreeViewMode,
+  useCanFocusWorkspace,
+} from '../stores/ideStore';
+import type { FileEntry, WorkspaceAccent } from '../stores/ideStore';
+import type { workspace } from '../../wailsjs/go/models';
+import { createRegionAccentResolver, relativePathFromRoot } from '../utils/workspaceRegions';
+
+export interface FileTreePresentation {
+  mode: 'project' | 'workspace';
+  canFocusWorkspace: boolean;
+  /** Repo name (project) or workspace name (workspace). */
+  rootLabel: string;
+  /** Repo root (project) or workspace dir absolute path (workspace). */
+  rootPath: string;
+  /** Top-level entries to render as tree roots. */
+  roots: FileEntry[];
+  /** True when a workspace's relDir cannot be located in the loaded tree. */
+  scopedError: boolean;
+  /** Non-project workspaces, for the Workspace-View tab strip. */
+  tabs: workspace.WorkspaceDef[];
+  /** Region tint resolver — present only in Project View. */
+  getRegionAccent?: (entry: FileEntry) => WorkspaceAccent | null;
+}
+
+/**
+ * Finds the directory node whose normalized repo-relative path equals `relDir`.
+ * This uses the same helper as region tinting so Workspace View scoping has the
+ * same segment-safe containment and Windows/backslash behavior.
+ */
+function findScopedNode(tree: FileEntry[], repoRoot: string, relDir: string): FileEntry | null {
+  for (const entry of tree) {
+    if (entry.isDir && relativePathFromRoot(entry.path, repoRoot) === relDir) {
+      return entry;
+    }
+    const childMatch = entry.children ? findScopedNode(entry.children, repoRoot, relDir) : null;
+    if (childMatch) {
+      return childMatch;
+    }
+  }
+  return null;
+}
+
+export function useFileTreePresentation(): FileTreePresentation {
+  const repo = useWorkspace();
+  const workspaces = useWorkspaces();
+  const active = useActiveWorkspace();
+  const tree = useDirectoryTree();
+  const mode = useTreeViewMode();
+  const canFocusWorkspace = useCanFocusWorkspace();
+
+  const repoRoot = repo?.path ?? '';
+  const repoName = repo?.name ?? '';
+
+  const tabs = useMemo(() => workspaces.filter((w) => w.id !== 'project'), [workspaces]);
+
+  const getRegionAccent = useMemo(
+    () => (mode === 'project' ? createRegionAccentResolver(repoRoot, workspaces) : undefined),
+    [mode, repoRoot, workspaces]
+  );
+
+  return useMemo<FileTreePresentation>(() => {
+    const base = { mode, canFocusWorkspace, tabs };
+
+    if (mode === 'project') {
+      return {
+        ...base,
+        rootLabel: repoName,
+        rootPath: repoRoot,
+        roots: tree,
+        scopedError: false,
+        getRegionAccent,
+      };
+    }
+
+    const relDir = active?.relDir ?? '';
+    const workspaceLabel = active?.name ?? repoName;
+
+    if (relDir === '') {
+      return {
+        ...base,
+        rootLabel: workspaceLabel,
+        rootPath: repoRoot,
+        roots: tree,
+        scopedError: false,
+        getRegionAccent: undefined,
+      };
+    }
+
+    const scoped = findScopedNode(tree, repoRoot, relDir);
+    return {
+      ...base,
+      rootLabel: workspaceLabel,
+      rootPath: scoped?.path ?? `${repoRoot}/${relDir}`,
+      roots: scoped?.children ?? [],
+      scopedError: scoped === null,
+      getRegionAccent: undefined,
+    };
+  }, [mode, canFocusWorkspace, tabs, repoName, repoRoot, tree, active, getRegionAccent]);
+}

--- a/frontend/src/hooks/useFileTreePresentation.ts
+++ b/frontend/src/hooks/useFileTreePresentation.ts
@@ -8,7 +8,6 @@ import {
   useCanFocusWorkspace,
 } from '../stores/ideStore';
 import type { FileEntry, WorkspaceAccent } from '../stores/ideStore';
-import type { workspace } from '../../wailsjs/go/models';
 import { createRegionAccentResolver, relativePathFromRoot } from '../utils/workspaceRegions';
 
 export interface FileTreePresentation {
@@ -22,8 +21,6 @@ export interface FileTreePresentation {
   roots: FileEntry[];
   /** True when a workspace's relDir cannot be located in the loaded tree. */
   scopedError: boolean;
-  /** Non-project workspaces, for the Workspace-View tab strip. */
-  tabs: workspace.WorkspaceDef[];
   /** Region tint resolver — present only in Project View. */
   getRegionAccent?: (entry: FileEntry) => WorkspaceAccent | null;
 }
@@ -57,15 +54,13 @@ export function useFileTreePresentation(): FileTreePresentation {
   const repoRoot = repo?.path ?? '';
   const repoName = repo?.name ?? '';
 
-  const tabs = useMemo(() => workspaces.filter((w) => w.id !== 'project'), [workspaces]);
-
   const getRegionAccent = useMemo(
     () => (mode === 'project' ? createRegionAccentResolver(repoRoot, workspaces) : undefined),
     [mode, repoRoot, workspaces]
   );
 
   return useMemo<FileTreePresentation>(() => {
-    const base = { mode, canFocusWorkspace, tabs };
+    const base = { mode, canFocusWorkspace };
 
     if (mode === 'project') {
       return {
@@ -101,5 +96,5 @@ export function useFileTreePresentation(): FileTreePresentation {
       scopedError: scoped === null,
       getRegionAccent: undefined,
     };
-  }, [mode, canFocusWorkspace, tabs, repoName, repoRoot, tree, active, getRegionAccent]);
+  }, [mode, canFocusWorkspace, repoName, repoRoot, tree, active, getRegionAccent]);
 }

--- a/frontend/src/hooks/useFileTreePresentation.ts
+++ b/frontend/src/hooks/useFileTreePresentation.ts
@@ -21,8 +21,16 @@ export interface FileTreePresentation {
   roots: FileEntry[];
   /** True when a workspace's relDir cannot be located in the loaded tree. */
   scopedError: boolean;
-  /** Region tint resolver — present only in Project View. */
+  /**
+   * Per-entry tint resolver. Project View → per-region multi-color resolver.
+   * Workspace View → uniform resolver returning the active workspace accent.
+   */
   getRegionAccent?: (entry: FileEntry) => WorkspaceAccent | null;
+  /**
+   * Active workspace accent, used for the Workspace-View left rail. Undefined in
+   * Project View (regions are multi-color) and when the workspace has no accent.
+   */
+  treeAccent?: WorkspaceAccent;
 }
 
 /**
@@ -75,6 +83,10 @@ export function useFileTreePresentation(): FileTreePresentation {
 
     const relDir = active?.relDir ?? '';
     const workspaceLabel = active?.name ?? repoName;
+    // Workspace View washes the whole scoped tree in the active workspace's
+    // accent (uniform), reinforcing which workspace the files belong to.
+    const treeAccent = (active?.accent as WorkspaceAccent) || undefined;
+    const workspaceResolver = treeAccent ? () => treeAccent : undefined;
 
     if (relDir === '') {
       return {
@@ -83,7 +95,8 @@ export function useFileTreePresentation(): FileTreePresentation {
         rootPath: repoRoot,
         roots: tree,
         scopedError: false,
-        getRegionAccent: undefined,
+        getRegionAccent: workspaceResolver,
+        treeAccent,
       };
     }
 
@@ -94,7 +107,8 @@ export function useFileTreePresentation(): FileTreePresentation {
       rootPath: scoped?.path ?? `${repoRoot}/${relDir}`,
       roots: scoped?.children ?? [],
       scopedError: scoped === null,
-      getRegionAccent: undefined,
+      getRegionAccent: workspaceResolver,
+      treeAccent,
     };
   }, [mode, canFocusWorkspace, repoName, repoRoot, tree, active, getRegionAccent]);
 }

--- a/frontend/src/stores/ideStore.ts
+++ b/frontend/src/stores/ideStore.ts
@@ -107,6 +107,7 @@ interface IDEState {
   // Workspace identity (#53)
   workspaces: workspace.WorkspaceDef[];
   activeWorkspaceId: string;
+  lastFocusedWorkspaceId: string | null;
 
   // File Explorer
   directoryTree: filesystem.FileEntry[];
@@ -371,6 +372,7 @@ export const useIDEStore = create<IDEStore>()(
       isLoading: false,
       workspaces: [],
       activeWorkspaceId: 'project',
+      lastFocusedWorkspaceId: null,
       directoryTree: [],
       isLoadingTree: false,
       treeError: null,
@@ -420,9 +422,14 @@ export const useIDEStore = create<IDEStore>()(
 
       setActiveWorkspace: (id) =>
         set(
-          (state) => ({
-            activeWorkspaceId: state.workspaces.some((d) => d.id === id) ? id : 'project',
-          }),
+          (state) => {
+            const valid = state.workspaces.some((d) => d.id === id);
+            const nextId = valid ? id : 'project';
+            return {
+              activeWorkspaceId: nextId,
+              lastFocusedWorkspaceId: nextId !== 'project' ? nextId : state.lastFocusedWorkspaceId,
+            };
+          },
           false,
           'setActiveWorkspace'
         ),

--- a/frontend/src/stores/ideStore.ts
+++ b/frontend/src/stores/ideStore.ts
@@ -1562,6 +1562,10 @@ export const useWorkspaces = () => useIDEStore((state) => state.workspaces);
 export const useActiveWorkspaceId = () => useIDEStore((state) => state.activeWorkspaceId);
 export const useActiveWorkspace = () =>
   useIDEStore((state) => state.workspaces.find((w) => w.id === state.activeWorkspaceId) ?? null);
+export const useTreeViewMode = (): 'project' | 'workspace' =>
+  useIDEStore((state) => (state.activeWorkspaceId === 'project' ? 'project' : 'workspace'));
+export const useCanFocusWorkspace = (): boolean =>
+  useIDEStore((state) => state.workspaces.some((w) => w.id !== 'project'));
 export const useActiveAccent = (): WorkspaceAccent =>
   useIDEStore(
     (state) =>

--- a/frontend/src/stores/ideStore.ts
+++ b/frontend/src/stores/ideStore.ts
@@ -411,12 +411,26 @@ export const useIDEStore = create<IDEStore>()(
 
       setWorkspaces: (defs) =>
         set(
-          (state) => ({
-            workspaces: defs,
-            activeWorkspaceId: defs.some((d) => d.id === state.activeWorkspaceId)
-              ? state.activeWorkspaceId
-              : 'project',
-          }),
+          (state) => {
+            const activeValid = defs.some((d) => d.id === state.activeWorkspaceId);
+            const nextActive = activeValid ? state.activeWorkspaceId : 'project';
+
+            const lastStillValid =
+              state.lastFocusedWorkspaceId !== null &&
+              defs.some((d) => d.id === state.lastFocusedWorkspaceId);
+            let nextLast = lastStillValid ? state.lastFocusedWorkspaceId : null;
+
+            // If the active workspace is a real (non-project) workspace, lastFocused follows it.
+            if (nextActive !== 'project') {
+              nextLast = nextActive;
+            }
+
+            return {
+              workspaces: defs,
+              activeWorkspaceId: nextActive,
+              lastFocusedWorkspaceId: nextLast,
+            };
+          },
           false,
           'setWorkspaces'
         ),

--- a/frontend/src/stores/ideStore.ts
+++ b/frontend/src/stores/ideStore.ts
@@ -189,6 +189,7 @@ interface IDEActions {
   setWorkspace: (workspace: WorkspaceInfo | null) => void;
   setWorkspaces: (defs: workspace.WorkspaceDef[]) => void;
   setActiveWorkspace: (id: string) => void;
+  setTreeViewMode: (mode: 'project' | 'workspace') => void;
   setLoading: (isLoading: boolean) => void;
 
   // File Explorer actions
@@ -432,6 +433,30 @@ export const useIDEStore = create<IDEStore>()(
           },
           false,
           'setActiveWorkspace'
+        ),
+
+      setTreeViewMode: (mode) =>
+        set(
+          (state) => {
+            if (mode === 'project') {
+              return { activeWorkspaceId: 'project' };
+            }
+            const candidates = state.workspaces.filter((w) => w.id !== 'project');
+            const lastValid =
+              state.lastFocusedWorkspaceId &&
+              candidates.some((w) => w.id === state.lastFocusedWorkspaceId)
+                ? state.lastFocusedWorkspaceId
+                : null;
+            const firstNonRoot = candidates.find((w) => w.relDir !== '');
+            const firstRoot = candidates.find((w) => w.relDir === '');
+            const target = lastValid ?? firstNonRoot?.id ?? firstRoot?.id ?? 'project';
+            return {
+              activeWorkspaceId: target,
+              lastFocusedWorkspaceId: target !== 'project' ? target : state.lastFocusedWorkspaceId,
+            };
+          },
+          false,
+          'setTreeViewMode'
         ),
 
       setLoading: (isLoading) => set({ isLoading }, false, 'setLoading'),

--- a/frontend/src/utils/workspaceRegions.ts
+++ b/frontend/src/utils/workspaceRegions.ts
@@ -1,0 +1,29 @@
+import { normalizePathForComparison } from './lspUri';
+
+/**
+ * Repo-relative, forward-slash path for `absPath` under `repoRoot`.
+ * Returns '' for the repo root itself, and null for paths outside the root.
+ *
+ * Uses normalizePathForComparison (from lspUri) so containment checks share the
+ * same cross-platform semantics as the rest of the app: backslashes are
+ * converted to forward slashes and Windows drive-letter paths compare
+ * case-insensitively. The returned slice preserves the original case.
+ */
+export function relativePathFromRoot(absPath: string, repoRoot: string): string | null {
+  if (!absPath || !repoRoot) return null;
+
+  const toFwd = (p: string): string => p.replace(/\\/g, '/').replace(/\/+$/, '');
+  const path = toFwd(absPath);
+  const root = toFwd(repoRoot);
+
+  const cmpPath = normalizePathForComparison(path);
+  const cmpRoot = normalizePathForComparison(root);
+
+  if (cmpPath === cmpRoot) return '';
+  if (cmpPath.startsWith(cmpRoot + '/')) {
+    // normalizePathForComparison preserves length, so slicing the original
+    // forward-slashed path by the root length yields the correct-case suffix.
+    return path.slice(root.length + 1);
+  }
+  return null;
+}

--- a/frontend/src/utils/workspaceRegions.ts
+++ b/frontend/src/utils/workspaceRegions.ts
@@ -1,4 +1,6 @@
 import { normalizePathForComparison } from './lspUri';
+import type { WorkspaceAccent, FileEntry } from '../stores/ideStore';
+import type { workspace } from '../../wailsjs/go/models';
 
 /**
  * Repo-relative, forward-slash path for `absPath` under `repoRoot`.
@@ -27,9 +29,6 @@ export function relativePathFromRoot(absPath: string, repoRoot: string): string 
   }
   return null;
 }
-
-import type { WorkspaceAccent, FileEntry } from '../stores/ideStore';
-import type { workspace } from '../../wailsjs/go/models';
 
 /**
  * Project-View tinting of LOOSE ROOT FILES only. Workspace *directory*

--- a/frontend/src/utils/workspaceRegions.ts
+++ b/frontend/src/utils/workspaceRegions.ts
@@ -27,3 +27,66 @@ export function relativePathFromRoot(absPath: string, repoRoot: string): string 
   }
   return null;
 }
+
+import type { WorkspaceAccent, FileEntry } from '../stores/ideStore';
+import type { workspace } from '../../wailsjs/go/models';
+
+/**
+ * Project-View tinting of LOOSE ROOT FILES only. Workspace *directory*
+ * classification stays backend-owned (internal/workspace/detect.go markerRules).
+ * Keep this intentionally tiny — it only colors loose/root files, it does not
+ * classify workspaces.
+ */
+const rootFileAccentRules: {
+  exact: Record<string, WorkspaceAccent>;
+  suffix: ReadonlyArray<{ ext: string; accent: WorkspaceAccent }>;
+} = {
+  exact: {
+    'docker-compose.yml': 'purple',
+    'docker-compose.yaml': 'purple',
+    Dockerfile: 'purple',
+  },
+  suffix: [
+    { ext: '.tf', accent: 'purple' },
+    { ext: '.tfvars', accent: 'purple' },
+  ],
+};
+
+/**
+ * Builds a per-entry accent resolver for Project View region tinting. Call once
+ * per (repoRoot, workspaces) identity and reuse across all rows.
+ *
+ * Rules (in order):
+ *  1. Longest segment-safe non-empty relDir prefix wins → that workspace accent.
+ *  2. Root workspaces (relDir === "") contribute no ambient region tint.
+ *  3. Loose root file (not a dir, no path separator) → rootFileAccentRules.
+ *  4. Otherwise null.
+ */
+export function createRegionAccentResolver(
+  repoRoot: string,
+  workspaces: workspace.WorkspaceDef[]
+): (entry: FileEntry) => WorkspaceAccent | null {
+  const regions = workspaces
+    .filter((w) => w.id !== 'project' && w.relDir !== '')
+    .map((w) => ({ relDir: w.relDir, accent: w.accent as WorkspaceAccent }))
+    .sort((a, b) => b.relDir.length - a.relDir.length);
+
+  return (entry: FileEntry): WorkspaceAccent | null => {
+    const rel = relativePathFromRoot(entry.path, repoRoot);
+    if (rel === null) return null;
+
+    for (const region of regions) {
+      if (rel === region.relDir || rel.startsWith(region.relDir + '/')) {
+        return region.accent;
+      }
+    }
+
+    if (!entry.isDir && !rel.includes('/')) {
+      const exact = rootFileAccentRules.exact[entry.name];
+      if (exact) return exact;
+      const suf = rootFileAccentRules.suffix.find((s) => entry.name.endsWith(s.ext));
+      if (suf) return suf.accent;
+    }
+    return null;
+  };
+}


### PR DESCRIPTION
## Summary
Implements #54 — two file-tree views toggled by a segmented control, building on #53's workspace identity/accent system. Frontend-only; no backend or Wails-binding changes.

- **Project View** — full repo tree with color-coded workspace *regions* (accent tint at 6%, accent-aware 12% hover via `color-mix`) and file-type tinting for loose root files (`docker-compose.yml`/`Dockerfile`/`.tf` → infra/purple).
- **Workspace View** — tree scoped to the active workspace's directory, with a workspace tab strip (roving-tabindex `tablist`) for switching; root-typed workspaces (`relDir === ""`) scope to the whole tree.
- **State model** — reuses #53's `activeWorkspaceId` (`'project'` sentinel = Project View) as single source of truth, plus a `lastFocusedWorkspaceId` helper. `setTreeViewMode` restores focus (lastFocused → first non-root → first root → stay project); `setWorkspaces` reconciles `lastFocusedWorkspaceId` including the persistence restore path.
- **Architecture** — all mode-derived render inputs flow through one `useFileTreePresentation` hook; region tinting is presentation-only via `createRegionAccentResolver` (segment-safe longest-prefix match, shared cross-platform path normalization with scoping); `scopedError` state when a workspace folder is missing.

### Out of scope (bridge note)
Run Profiles grouping/filtering by view is intentionally deferred to #71/#18 — the Run Profiles panel behavior is unchanged across tree views. No backend changes; no `FileEntry` annotation.

## Test Plan
- [x] `npx jest` — full frontend suite: **829 passing, 0 failing** (8 new test files for #54: store, region util, hook, components)
- [x] `npx tsc --noEmit` — clean (only the pre-existing `TS5107` esModuleInterop deprecation)
- [x] `npm run lint` — 0 errors (8 pre-existing warnings, none in #54 files)
- [x] Manual: toggle Project/Workspace; verify region tints in Project View; switch workspace tabs; confirm scoped tree + "Workspace folder not found" state

Generated with [Claude Code](https://claude.com/claude-code)