### PR TITLE
fix(terminal): actionable error when the system PTY pool is exhausted

### DIFF
--- a/app.go
+++ b/app.go
@@ -263,6 +263,7 @@ func (a *App) ToggleMaximize() {
 func (a *App) CreateTerminal() (string, error) {
 	id, err := a.termManager.Create()
 	if err != nil {
+		runtime.LogErrorf(a.ctx, "CreateTerminal failed: %v", err)
 		return "", err
 	}
 

--- a/frontend/src/components/Terminal/Terminal.tsx
+++ b/frontend/src/components/Terminal/Terminal.tsx
@@ -186,7 +186,7 @@ export function Terminal() {
           markInitialSessionCreated();
         }
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'Unknown error';
+        const message = err instanceof Error ? err.message : String(err) || 'Unknown error';
         showToast(`Failed to create terminal: ${message}`, 'error');
       } finally {
         isCreatingRef.current = false;

--- a/internal/terminal/session.go
+++ b/internal/terminal/session.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"syscall"
 	"time"
 
 	"github.com/creack/pty"
@@ -35,7 +36,16 @@ func NewSession() (*Session, error) {
 	cmd := exec.Command(shell)
 	ptmx, err := pty.Start(cmd)
 	if err != nil {
-		return nil, err
+		// ENXIO ("device not configured") from /dev/ptmx means the system PTY
+		// pool is exhausted (macOS caps it at kern.tty.ptmx_max). Surface an
+		// actionable message instead of the raw errno.
+		if errors.Is(err, syscall.ENXIO) {
+			return nil, fmt.Errorf(
+				"no pseudo-terminals available: the system PTY limit (kern.tty.ptmx_max) is exhausted — close terminal-heavy apps or raise the limit: %w",
+				err,
+			)
+		}
+		return nil, fmt.Errorf("starting shell %q: %w", shell, err)
 	}
 	return &Session{cmd: cmd, running: true, pty: ptmx}, nil
 }


### PR DESCRIPTION
## Summary
When `pty.Start` returns ENXIO (`/dev/ptmx` "device not configured"), the macOS system-wide PTY pool (`kern.tty.ptmx_max`, default 511) is exhausted — **not a Firn failure**. Previously this surfaced as an opaque `Failed to create terminal: Unknown error` toast.

- Map ENXIO → an actionable message: *"no pseudo-terminals available: the system PTY limit (kern.tty.ptmx_max) is exhausted — close terminal-heavy apps or raise the limit."*
- Log the real error server-side via `runtime.LogErrorf` (nothing was logged before).
- Stop the frontend swallowing non-`Error` rejections to `'Unknown error'` (`String(err)`), so Wails string errors are shown.

## Context
Diagnosed live: the pool was at **511/511**, with a leaking `Claude` process holding **505** handles (known upstream pty-fd leak: anthropics/claude-code#65995, google-gemini/gemini-cli#26327). `pty.Open()` correctly returns ENXIO when zero ptys are free. `go test ./internal/terminal` passes — the PTY mechanism is fine; this PR only improves error UX.

## Test plan
- `go build ./...`, `go vet ./internal/terminal/...`, `go test ./internal/terminal/...` (11 pass)
- frontend `tsc --noEmit` + `eslint` clean

Generated with [Claude Code](https://claude.com/claude-code)
