### PR TITLE
Editor theme system: selectable syntax palettes + diagnostic tooltip surface (#113, #114)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,7 +30,7 @@ Firn IDE brings the focused, keyboard-first productivity of JetBrains IDEs to a 
 | Milestone 6: Search | **COMPLETE** | #23-25 |
 | Milestone 7: Git Integration | Not started | #26-27 |
 | Performance | **IN PROGRESS** | #38 complete; #37 virtualization shipped (#111), lazy-load deferred; #39 open |
-| Editor & LSP DX | Not started | #112-114 open |
+| Editor & LSP DX | **IN PROGRESS** | #113 tooltip + #114 theme system shipped; #112 open |
 | Dependency Upgrades | **COMPLETE** | #40 |
 | Code Quality | Not started | #41-42 |
 | Accessibility | Not started | #43 |
@@ -47,7 +47,7 @@ Current status: **Milestone 3 (Workspace Management) complete; file-tree perform
 2. **#107: LANES output view polish** — resizable stdout/stderr columns, STDERR header glyph color, and sticky-header bleed-through on scroll (UI-only follow-up).
 3. **#103: Formalize run execution identity for compound profiles** — follow-up hardening spun out of #63.
 4. **#47: Terminal shell integration** — error markers & command separators (last open item in Milestone 2).
-5. **#112-114: Editor & LSP developer experience** (surfaced while testing the Python workspace during #111): #112 auto-provision language servers + wire the project environment (zero-config, no raw error), #113 diagnostic hover tooltip needs an opaque background, #114 syntax-highlighting color pass.
+5. **#112: Editor & LSP developer experience** (surfaced while testing the Python workspace during #111): auto-provision language servers + wire the project environment (zero-config, no raw error). **#113 (opaque diagnostic tooltip surface) and #114 (selectable syntax theme system — 7 themes, default Abyssal Current, StatusBar picker, localStorage-persisted) shipped together;** #112 remains the larger follow-up.
 6. **#37 (Phase 2): File tree lazy loading** — load directory children on expand; own spec (backend per-dir read, watcher reconcile, #54 scoped-tree/active-file reconciliation).
 
 ---
@@ -344,11 +344,11 @@ Surfaced while testing a Python workspace (`quantum_trader`) during the file-tre
 ### #112: LSP - auto-provision language servers + wire project environment
 Zero-config language support. Two layers: (a) provision the server **binary** itself (managed download of a pinned version into an app cache — e.g. `basedpyright` standalone to avoid a Node dependency — never the user's global env), and (b) auto-detect and forward the project **environment** (interpreter/venv, `extraPaths` for `src` layouts, `pythonVersion`) via `workspace/configuration` / `didChangeConfiguration`. Today `resolvePythonServer` finds only the binary and sends no env, so imports report false errors. Must generalize to gopls/tsserver/rust-analyzer and degrade to actionable UI (select interpreter / create venv / retry), never a raw error string.
 
-### #113: Editor - diagnostic hover tooltip has no background
-The diagnostic/hover tooltip renders without an opaque surface, so the message blends into the code underneath. Give the CodeMirror `.cm-tooltip` / `.cm-diagnostic` an opaque background, border, padding, shadow, and z-index above content.
+### #113: Editor - diagnostic hover tooltip has no background ✅
+Shipped: the lint tooltip content (`.cm-tooltip-lint`, which renders inside the intentionally-transparent `.cm-tooltip-hover` container) now gets an opaque surface — background, border, padding, shadow, z-index — with per-severity (error/warning/info/hint) left-accent borders, all from the shared chrome design tokens.
 
-### #114: Editor - syntax highlighting color enhancements
-Audit the CodeMirror highlight theme for contrast and token-class distinction (keywords/types/strings/comments/functions/constants) across Python/TS/Go; align with the app's design tokens.
+### #114: Editor - syntax highlighting color enhancements ✅
+Shipped as a **selectable syntax theme system**: `theme.ts` refactored into a pure palette registry (`palettes.ts`) + builders (`buildHighlightStyle` / `buildChrome` / `buildTheme`); 7 themes (Firn Glacier refined, Solar Flare, Tropic Coral Reef, Nebula Jewel, Ember Bifrost, Aurora Bloom, and the default Abyssal Current with its own deeper canvas), live-swapped via the editor `themeCompartment`, chosen from a StatusBar picker, and persisted globally in `localStorage`. Follow-up: per-workspace theme override (Go workspace field + regenerated bindings) and an optional darker-canvas toggle for the other themes.
 
 ---
 

--- a/frontend/src/__tests__/components/Editor/CodeMirrorEditor.test.tsx
+++ b/frontend/src/__tests__/components/Editor/CodeMirrorEditor.test.tsx
@@ -106,6 +106,7 @@ jest.mock('../../../components/Editor/codemirror', () => {
 });
 
 import { CodeMirrorEditor } from '../../../components/Editor/CodeMirrorEditor';
+import { applyEditorTheme } from '../../../components/Editor/codemirror';
 import { useIDEStore } from '../../../stores/ideStore';
 import { useLSPStore } from '../../../stores/lspStore';
 
@@ -121,6 +122,18 @@ beforeEach(() => {
 });
 
 describe('CodeMirrorEditor', () => {
+  it('reconfigures the editor theme when the global syntax theme changes', () => {
+    render(<CodeMirrorEditor fileId="file-1" filename="main.ts" content={'x = 1'} />);
+    (applyEditorTheme as jest.Mock).mockClear();
+
+    act(() => {
+      useIDEStore.getState().setEditorSyntaxTheme('reef');
+    });
+
+    expect(applyEditorTheme).toHaveBeenCalled();
+    expect((applyEditorTheme as jest.Mock).mock.calls.at(-1)?.[1]).toBe('reef');
+  });
+
   it('applies restored cursor and scroll when they arrive after mount', async () => {
     const { rerender } = render(
       <CodeMirrorEditor fileId="file-1" filename="main.ts" content={'one\ntwo\nthree'} />

--- a/frontend/src/__tests__/components/Editor/CodeMirrorEditor.test.tsx
+++ b/frontend/src/__tests__/components/Editor/CodeMirrorEditor.test.tsx
@@ -97,6 +97,7 @@ jest.mock('../../../components/Editor/codemirror', () => {
       reconfigure: mockHoverCompartmentReconfigure,
     },
     createEditorExtensions: mockCreateEditorExtensions,
+    applyEditorTheme: jest.fn(),
     reconfigureCompletion: mockReconfigureCompletion,
     reconfigureHover: mockReconfigureHover,
     resetCompletion: mockResetCompletion,

--- a/frontend/src/__tests__/components/Editor/codemirror/extensions.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/extensions.test.ts
@@ -1,0 +1,43 @@
+jest.mock('../../../../../wailsjs/go/main/App', () => ({
+  LSPComplete: jest.fn(),
+  LSPResolveCompletionItem: jest.fn(),
+  LSPDefinition: jest.fn(),
+  LSPHover: jest.fn(),
+}));
+jest.mock('../../../../utils/lspDocumentSync', () => ({
+  flushLSPDocumentChange: jest.fn(() => Promise.resolve(false)),
+}));
+
+import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import {
+  createEditorExtensions,
+  applyEditorTheme,
+} from '../../../../components/Editor/codemirror/extensions';
+
+describe('editor theme wiring', () => {
+  it('createEditorExtensions accepts a syntaxThemeId', () => {
+    const ext = createEditorExtensions({
+      filename: 'a.ts',
+      filePath: '/a.ts',
+      syntaxThemeId: 'abyssal',
+    });
+    expect(Array.isArray(ext)).toBe(true);
+    expect(ext.length).toBeGreaterThan(0);
+  });
+
+  it('applyEditorTheme reconfigures a live view without throwing', () => {
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: 'const x = 1',
+        extensions: createEditorExtensions({
+          filename: 'a.ts',
+          filePath: '/a.ts',
+          syntaxThemeId: 'glacier',
+        }),
+      }),
+    });
+    expect(() => applyEditorTheme(view, 'reef')).not.toThrow();
+    view.destroy();
+  });
+});

--- a/frontend/src/__tests__/components/Editor/codemirror/palettes.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/palettes.test.ts
@@ -2,6 +2,7 @@ import {
   SYNTAX_THEMES,
   SYNTAX_THEME_BY_ID,
   DEFAULT_SYNTAX_THEME_ID,
+  getSyntaxPalette,
   isSyntaxThemeId,
   type SyntaxPalette,
   type SyntaxThemeId,
@@ -93,5 +94,13 @@ describe('syntax palette registry', () => {
     expect(isSyntaxThemeId('nope')).toBe(false);
     expect(isSyntaxThemeId(null)).toBe(false);
     expect(isSyntaxThemeId(42)).toBe(false);
+  });
+
+  it('getSyntaxPalette returns the matching palette and falls back to the default for unknown ids', () => {
+    expect(getSyntaxPalette('reef')).toBe(SYNTAX_THEME_BY_ID.get('reef')!.palette);
+    // Unknown id falls back to the default (abyssal) palette.
+    expect(getSyntaxPalette('does-not-exist' as SyntaxThemeId)).toBe(
+      SYNTAX_THEME_BY_ID.get(DEFAULT_SYNTAX_THEME_ID)!.palette
+    );
   });
 });

--- a/frontend/src/__tests__/components/Editor/codemirror/palettes.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/palettes.test.ts
@@ -1,0 +1,97 @@
+import {
+  SYNTAX_THEMES,
+  SYNTAX_THEME_BY_ID,
+  DEFAULT_SYNTAX_THEME_ID,
+  isSyntaxThemeId,
+  type SyntaxPalette,
+  type SyntaxThemeId,
+} from '../../../../components/Editor/codemirror/palettes';
+
+const ROLES: (keyof SyntaxPalette)[] = [
+  'background',
+  'comment',
+  'keyword',
+  'string',
+  'number',
+  'function',
+  'type',
+  'constant',
+  'operator',
+  'punctuation',
+  'variable',
+  'property',
+  'regexp',
+  'tag',
+  'attribute',
+  'escape',
+];
+
+// Relative luminance + contrast ratio (WCAG) for the comment-contrast guard.
+function luminance(hex: string): number {
+  const m = hex.replace('#', '');
+  const rgb = [0, 2, 4].map((i) => parseInt(m.slice(i, i + 2), 16) / 255);
+  const lin = rgb.map((c) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4));
+  return 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2];
+}
+function contrast(a: string, b: string): number {
+  const l1 = luminance(a);
+  const l2 = luminance(b);
+  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+}
+
+describe('syntax palette registry', () => {
+  it('exposes 7 themes in a stable order', () => {
+    expect(SYNTAX_THEMES.map((t) => t.id)).toEqual([
+      'glacier',
+      'solar',
+      'reef',
+      'nebula',
+      'bifrost',
+      'aurora',
+      'abyssal',
+    ]);
+  });
+
+  it('default theme id exists in the registry', () => {
+    expect(SYNTAX_THEME_BY_ID.has(DEFAULT_SYNTAX_THEME_ID)).toBe(true);
+    expect(DEFAULT_SYNTAX_THEME_ID).toBe('abyssal');
+  });
+
+  it('every theme defines every palette role as a non-empty string', () => {
+    for (const theme of SYNTAX_THEMES) {
+      expect(theme.label.length).toBeGreaterThan(0);
+      for (const role of ROLES) {
+        expect(typeof theme.palette[role]).toBe('string');
+        expect(theme.palette[role].length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('has unique ids and a lookup map covering all themes', () => {
+    const ids = SYNTAX_THEMES.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) {
+      expect(SYNTAX_THEME_BY_ID.get(id as SyntaxThemeId)?.id).toBe(id);
+    }
+  });
+
+  it('never makes number and constant byte-identical within a theme', () => {
+    for (const theme of SYNTAX_THEMES) {
+      expect(theme.palette.number.toLowerCase()).not.toBe(theme.palette.constant.toLowerCase());
+    }
+  });
+
+  it('keeps comment contrast at or above 4:1 on each theme canvas', () => {
+    for (const theme of SYNTAX_THEMES) {
+      const ratio = contrast(theme.palette.comment, theme.palette.background);
+      expect(ratio).toBeGreaterThanOrEqual(4);
+    }
+  });
+
+  it('isSyntaxThemeId guards unknown values', () => {
+    expect(isSyntaxThemeId('abyssal')).toBe(true);
+    expect(isSyntaxThemeId('nope')).toBe(false);
+    expect(isSyntaxThemeId(null)).toBe(false);
+    expect(isSyntaxThemeId(42)).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/components/Editor/codemirror/palettes.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/palettes.test.ts
@@ -8,24 +8,8 @@ import {
   type SyntaxThemeId,
 } from '../../../../components/Editor/codemirror/palettes';
 
-const ROLES: (keyof SyntaxPalette)[] = [
-  'background',
-  'comment',
-  'keyword',
-  'string',
-  'number',
-  'function',
-  'type',
-  'constant',
-  'operator',
-  'punctuation',
-  'variable',
-  'property',
-  'regexp',
-  'tag',
-  'attribute',
-  'escape',
-];
+// Derive role keys from a live palette so a new SyntaxPalette field is auto-covered.
+const ROLES = Object.keys(SYNTAX_THEMES[0].palette) as (keyof SyntaxPalette)[];
 
 // Relative luminance + contrast ratio (WCAG) for the comment-contrast guard.
 function luminance(hex: string): number {
@@ -63,7 +47,7 @@ describe('syntax palette registry', () => {
       expect(theme.label.length).toBeGreaterThan(0);
       for (const role of ROLES) {
         expect(typeof theme.palette[role]).toBe('string');
-        expect(theme.palette[role].length).toBeGreaterThan(0);
+        expect(theme.palette[role]).toMatch(/^#[0-9A-Fa-f]{6}$/);
       }
     }
   });
@@ -90,7 +74,9 @@ describe('syntax palette registry', () => {
   });
 
   it('isSyntaxThemeId guards unknown values', () => {
-    expect(isSyntaxThemeId('abyssal')).toBe(true);
+    for (const theme of SYNTAX_THEMES) {
+      expect(isSyntaxThemeId(theme.id)).toBe(true);
+    }
     expect(isSyntaxThemeId('nope')).toBe(false);
     expect(isSyntaxThemeId(null)).toBe(false);
     expect(isSyntaxThemeId(42)).toBe(false);

--- a/frontend/src/__tests__/components/Editor/codemirror/pythonHighlight.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/pythonHighlight.test.ts
@@ -1,0 +1,52 @@
+import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { python } from '@codemirror/lang-python';
+import {
+  PY_BUILTINS,
+  PY_SELF_NAMES,
+  pythonTokenClass,
+  pythonHighlightExtensions,
+} from '../../../../components/Editor/codemirror/pythonHighlight';
+
+describe('pythonTokenClass', () => {
+  it('classifies self and cls as self', () => {
+    expect(pythonTokenClass('VariableName', 'self', false)).toBe('firn-tok-self');
+    expect(pythonTokenClass('VariableName', 'cls', false)).toBe('firn-tok-self');
+  });
+
+  it('classifies builtin types/functions as builtin', () => {
+    for (const name of ['dict', 'str', 'float', 'int', 'list', 'len', 'print']) {
+      expect(pythonTokenClass('VariableName', name, false)).toBe('firn-tok-builtin');
+    }
+  });
+
+  it('treats a decorator name as decorator even when it is also a builtin', () => {
+    expect(pythonTokenClass('VariableName', 'property', true)).toBe('firn-tok-decorator');
+    expect(pythonTokenClass('PropertyName', 'route', true)).toBe('firn-tok-decorator');
+  });
+
+  it('leaves ordinary identifiers and non-decorator property names alone', () => {
+    expect(pythonTokenClass('VariableName', 'my_var', false)).toBeNull();
+    expect(pythonTokenClass('PropertyName', 'value', false)).toBeNull();
+  });
+
+  it('exposes the builtin and self name sets', () => {
+    expect(PY_BUILTINS.has('dict')).toBe(true);
+    expect(PY_BUILTINS.has('float')).toBe(true);
+    expect(PY_SELF_NAMES.has('self')).toBe(true);
+    expect(PY_SELF_NAMES.has('cls')).toBe(true);
+  });
+});
+
+describe('pythonHighlightExtensions', () => {
+  it('mounts on a python document without throwing', () => {
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: '@property\ndef f(self):\n    return dict()\n',
+        extensions: [python(), pythonHighlightExtensions()],
+      }),
+    });
+    expect(view).toBeDefined();
+    view.destroy();
+  });
+});

--- a/frontend/src/__tests__/components/Editor/codemirror/pythonHighlight.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/pythonHighlight.test.ts
@@ -1,33 +1,46 @@
 import { EditorState } from '@codemirror/state';
-import { EditorView } from '@codemirror/view';
+import { ensureSyntaxTree } from '@codemirror/language';
 import { python } from '@codemirror/lang-python';
 import {
   PY_BUILTINS,
   PY_SELF_NAMES,
   pythonTokenClass,
+  collectPythonMarks,
   pythonHighlightExtensions,
+  type PythonTokenContext,
 } from '../../../../components/Editor/codemirror/pythonHighlight';
+
+const ctx = (over: Partial<PythonTokenContext> = {}): PythonTokenContext => ({
+  decoratorName: false,
+  kwargName: false,
+  ...over,
+});
 
 describe('pythonTokenClass', () => {
   it('classifies self and cls as self', () => {
-    expect(pythonTokenClass('VariableName', 'self', false)).toBe('firn-tok-self');
-    expect(pythonTokenClass('VariableName', 'cls', false)).toBe('firn-tok-self');
+    expect(pythonTokenClass('VariableName', 'self', ctx())).toBe('firn-tok-self');
+    expect(pythonTokenClass('VariableName', 'cls', ctx())).toBe('firn-tok-self');
   });
 
   it('classifies builtin types/functions as builtin', () => {
     for (const name of ['dict', 'str', 'float', 'int', 'list', 'len', 'print']) {
-      expect(pythonTokenClass('VariableName', name, false)).toBe('firn-tok-builtin');
+      expect(pythonTokenClass('VariableName', name, ctx())).toBe('firn-tok-builtin');
     }
   });
 
-  it('treats a decorator name as decorator even when it is also a builtin', () => {
-    expect(pythonTokenClass('VariableName', 'property', true)).toBe('firn-tok-decorator');
-    expect(pythonTokenClass('PropertyName', 'route', true)).toBe('firn-tok-decorator');
+  it('lets decorator and kwarg context win, even for builtin names', () => {
+    expect(pythonTokenClass('VariableName', 'property', ctx({ decoratorName: true }))).toBe(
+      'firn-tok-decorator'
+    );
+    expect(pythonTokenClass('PropertyName', 'route', ctx({ decoratorName: true }))).toBe(
+      'firn-tok-decorator'
+    );
+    expect(pythonTokenClass('VariableName', 'id', ctx({ kwargName: true }))).toBe('firn-tok-param');
   });
 
   it('leaves ordinary identifiers and non-decorator property names alone', () => {
-    expect(pythonTokenClass('VariableName', 'my_var', false)).toBeNull();
-    expect(pythonTokenClass('PropertyName', 'value', false)).toBeNull();
+    expect(pythonTokenClass('VariableName', 'my_var', ctx())).toBeNull();
+    expect(pythonTokenClass('PropertyName', 'value', ctx())).toBeNull();
   });
 
   it('exposes the builtin and self name sets', () => {
@@ -38,15 +51,34 @@ describe('pythonTokenClass', () => {
   });
 });
 
+describe('collectPythonMarks (syntax-tree walk)', () => {
+  const doc = '@staticmethod\ndef f(self, x: dict):\n    return Foo(id=x)\n';
+  const state = EditorState.create({ doc, extensions: [python()] });
+  // Force a full parse — without a view, lezer parses lazily.
+  const tree = ensureSyntaxTree(state, doc.length, 5000)!;
+  const marks = collectPythonMarks(state, tree);
+  const textFor = (cls: string) =>
+    marks.filter((mark) => mark.cls === cls).map((mark) => doc.slice(mark.from, mark.to));
+
+  it('marks the decorator name (not just the @)', () => {
+    expect(textFor('firn-tok-decorator')).toContain('staticmethod');
+  });
+
+  it('marks self', () => {
+    expect(textFor('firn-tok-self')).toContain('self');
+  });
+
+  it('marks builtin types', () => {
+    expect(textFor('firn-tok-builtin')).toContain('dict');
+  });
+
+  it('marks keyword-argument names', () => {
+    expect(textFor('firn-tok-param')).toContain('id');
+  });
+});
+
 describe('pythonHighlightExtensions', () => {
-  it('mounts on a python document without throwing', () => {
-    const view = new EditorView({
-      state: EditorState.create({
-        doc: '@property\ndef f(self):\n    return dict()\n',
-        extensions: [python(), pythonHighlightExtensions()],
-      }),
-    });
-    expect(view).toBeDefined();
-    view.destroy();
+  it('returns a defined extension', () => {
+    expect(pythonHighlightExtensions()).toBeDefined();
   });
 });

--- a/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
@@ -4,6 +4,11 @@ import {
   buildHighlightSpec,
   buildHighlightStyle,
   firnGlacierHighlightStyle,
+  buildChromeRules,
+  buildTheme,
+  defaultEditorTheme,
+  firnGlacier,
+  firnGlacierTheme,
 } from '../../../../components/Editor/codemirror/theme';
 import { getSyntaxPalette } from '../../../../components/Editor/codemirror/palettes';
 
@@ -39,5 +44,35 @@ describe('highlight-style builders', () => {
 
   it('keeps the legacy firnGlacierHighlightStyle export', () => {
     expect(firnGlacierHighlightStyle).toBeInstanceOf(HighlightStyle);
+  });
+});
+
+describe('buildChromeRules', () => {
+  it('uses the supplied background for canvas and gutters', () => {
+    const rules = buildChromeRules('#08111C');
+    expect((rules['&'] as Record<string, string>).backgroundColor).toBe('#08111C');
+    expect((rules['.cm-gutters'] as Record<string, string>).backgroundColor).toBe('#08111C');
+  });
+});
+
+describe('buildTheme', () => {
+  it('returns a defined extension for every theme id', () => {
+    for (const id of [
+      'glacier',
+      'solar',
+      'reef',
+      'nebula',
+      'bifrost',
+      'aurora',
+      'abyssal',
+    ] as const) {
+      expect(buildTheme(id)).toBeDefined();
+    }
+  });
+
+  it('keeps legacy theme exports defined', () => {
+    expect(defaultEditorTheme).toBeDefined();
+    expect(firnGlacier).toBeDefined();
+    expect(firnGlacierTheme).toBeDefined();
   });
 });

--- a/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
@@ -79,50 +79,6 @@ describe('buildTheme', () => {
   });
 });
 
-jest.mock('../../../../../wailsjs/go/main/App', () => ({
-  LSPComplete: jest.fn(),
-  LSPResolveCompletionItem: jest.fn(),
-  LSPDefinition: jest.fn(),
-  LSPHover: jest.fn(),
-}));
-jest.mock('../../../../utils/lspDocumentSync', () => ({
-  flushLSPDocumentChange: jest.fn(() => Promise.resolve(false)),
-}));
-
-import { EditorState } from '@codemirror/state';
-import { EditorView } from '@codemirror/view';
-import {
-  createEditorExtensions,
-  applyEditorTheme,
-} from '../../../../components/Editor/codemirror/extensions';
-
-describe('editor theme wiring', () => {
-  it('createEditorExtensions accepts a syntaxThemeId', () => {
-    const ext = createEditorExtensions({
-      filename: 'a.ts',
-      filePath: '/a.ts',
-      syntaxThemeId: 'abyssal',
-    });
-    expect(Array.isArray(ext)).toBe(true);
-    expect(ext.length).toBeGreaterThan(0);
-  });
-
-  it('applyEditorTheme reconfigures a live view without throwing', () => {
-    const view = new EditorView({
-      state: EditorState.create({
-        doc: 'const x = 1',
-        extensions: createEditorExtensions({
-          filename: 'a.ts',
-          filePath: '/a.ts',
-          syntaxThemeId: 'glacier',
-        }),
-      }),
-    });
-    expect(() => applyEditorTheme(view, 'reef')).not.toThrow();
-    view.destroy();
-  });
-});
-
 describe('#113 diagnostic tooltip surface', () => {
   const rules = buildChromeRules('#0F172A');
 

--- a/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
@@ -52,6 +52,8 @@ describe('buildChromeRules', () => {
     const rules = buildChromeRules('#08111C');
     expect((rules['&'] as Record<string, string>).backgroundColor).toBe('#08111C');
     expect((rules['.cm-gutters'] as Record<string, string>).backgroundColor).toBe('#08111C');
+    // Guard against accidental truncation of the chrome rule set.
+    expect(Object.keys(rules).length).toBeGreaterThan(20);
   });
 });
 

--- a/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
@@ -61,9 +61,14 @@ describe('buildChromeRules', () => {
   it('colours the python overlay token classes from the palette', () => {
     const palette = getSyntaxPalette('abyssal');
     const rules = buildChromeRules(palette);
-    expect((rules['.firn-tok-self'] as Record<string, string>).color).toBe(palette.keyword);
-    expect((rules['.firn-tok-builtin'] as Record<string, string>).color).toBe(palette.type);
-    expect((rules['.firn-tok-decorator'] as Record<string, string>).color).toBe(palette.function);
+    expect((rules['.firn-tok-self'] as Record<string, string>).color).toContain(palette.keyword);
+    expect((rules['.firn-tok-builtin'] as Record<string, string>).color).toContain(palette.type);
+    expect((rules['.firn-tok-decorator'] as Record<string, string>).color).toContain(
+      palette.function
+    );
+    expect((rules['.firn-tok-param'] as Record<string, string>).color).toContain(palette.property);
+    // Overlay must win the cascade against syntax highlighting.
+    expect((rules['.firn-tok-self'] as Record<string, string>).color).toContain('!important');
   });
 });
 

--- a/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
@@ -26,8 +26,8 @@ describe('highlight-style builders', () => {
     expect(colorFor(t.regexp)).toBe(palette.regexp);
     // Compound tag (most likely to be mis-nested) — function(variableName).
     expect(colorFor(t.function(t.variableName))).toBe(palette.function);
-    // Decorator marker (@) — t.meta — must map to the function color.
-    expect(colorFor(t.meta)).toBe(palette.function);
+    // Decorator marker (@) — t.meta — must map to the decorator color.
+    expect(colorFor(t.meta)).toBe(palette.decorator);
   });
 
   it('builds a defined HighlightStyle for every palette', () => {
@@ -64,9 +64,9 @@ describe('buildChromeRules', () => {
     expect((rules['.firn-tok-self'] as Record<string, string>).color).toContain(palette.keyword);
     expect((rules['.firn-tok-builtin'] as Record<string, string>).color).toContain(palette.type);
     expect((rules['.firn-tok-decorator'] as Record<string, string>).color).toContain(
-      palette.function
+      palette.decorator
     );
-    expect((rules['.firn-tok-param'] as Record<string, string>).color).toContain(palette.property);
+    expect((rules['.firn-tok-param'] as Record<string, string>).color).toContain(palette.param);
     // Overlay must win the cascade against syntax highlighting.
     expect((rules['.firn-tok-self'] as Record<string, string>).color).toContain('!important');
   });

--- a/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
@@ -78,3 +78,27 @@ describe('buildTheme', () => {
     expect(firnGlacierTheme).toBeDefined();
   });
 });
+
+describe('#113 diagnostic tooltip surface', () => {
+  const rules = buildChromeRules('#0F172A');
+
+  it('gives the lint tooltip an opaque surface', () => {
+    const lint = rules['.cm-tooltip-lint'] as Record<string, string>;
+    expect(lint).toBeDefined();
+    expect(lint.backgroundColor).toBeDefined();
+    expect(lint.backgroundColor).not.toBe('transparent');
+    expect(lint.border).toBeDefined();
+    expect(lint.boxShadow).toBeDefined();
+    expect(lint.padding).toBeDefined();
+  });
+
+  it('styles diagnostics and per-severity accents', () => {
+    expect(rules['.cm-diagnostic']).toBeDefined();
+    const error = rules['.cm-diagnostic-error'] as Record<string, string>;
+    const warning = rules['.cm-diagnostic-warning'] as Record<string, string>;
+    const info = rules['.cm-diagnostic-info'] as Record<string, string>;
+    expect(error.borderLeft).toContain('#EF4444');
+    expect(warning.borderLeft).toContain('#F59E0B');
+    expect(info.borderLeft).toContain('#3B82F6');
+  });
+});

--- a/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
@@ -1,4 +1,5 @@
 import { tags as t } from '@lezer/highlight';
+import { HighlightStyle } from '@codemirror/language';
 import {
   buildHighlightSpec,
   buildHighlightStyle,
@@ -6,7 +7,7 @@ import {
 } from '../../../../components/Editor/codemirror/theme';
 import { getSyntaxPalette } from '../../../../components/Editor/codemirror/palettes';
 
-describe('buildHighlightSpec', () => {
+describe('highlight-style builders', () => {
   it('maps token roles to the supplied palette colors', () => {
     const palette = getSyntaxPalette('abyssal');
     const spec = buildHighlightSpec(palette);
@@ -18,6 +19,8 @@ describe('buildHighlightSpec', () => {
     expect(colorFor(t.number)).toBe(palette.number);
     expect(colorFor(t.typeName)).toBe(palette.type);
     expect(colorFor(t.regexp)).toBe(palette.regexp);
+    // Compound tag (most likely to be mis-nested) — function(variableName).
+    expect(colorFor(t.function(t.variableName))).toBe(palette.function);
   });
 
   it('builds a defined HighlightStyle for every palette', () => {
@@ -30,11 +33,11 @@ describe('buildHighlightSpec', () => {
       'aurora',
       'abyssal',
     ] as const) {
-      expect(buildHighlightStyle(getSyntaxPalette(id))).toBeDefined();
+      expect(buildHighlightStyle(getSyntaxPalette(id))).toBeInstanceOf(HighlightStyle);
     }
   });
 
   it('keeps the legacy firnGlacierHighlightStyle export', () => {
-    expect(firnGlacierHighlightStyle).toBeDefined();
+    expect(firnGlacierHighlightStyle).toBeInstanceOf(HighlightStyle);
   });
 });

--- a/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
@@ -87,6 +87,7 @@ describe('#113 diagnostic tooltip surface', () => {
     expect(lint).toBeDefined();
     expect(lint.backgroundColor).toBeDefined();
     expect(lint.backgroundColor).not.toBe('transparent');
+    expect(lint.backgroundColor).toBe('#1E293B'); // colors.surface
     expect(lint.border).toBeDefined();
     expect(lint.boxShadow).toBeDefined();
     expect(lint.padding).toBeDefined();
@@ -100,5 +101,7 @@ describe('#113 diagnostic tooltip surface', () => {
     expect(error.borderLeft).toContain('#EF4444');
     expect(warning.borderLeft).toContain('#F59E0B');
     expect(info.borderLeft).toContain('#3B82F6');
+    const hint = rules['.cm-diagnostic-hint'] as Record<string, string>;
+    expect(hint.borderLeft).toContain('#64748B');
   });
 });

--- a/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
@@ -79,6 +79,50 @@ describe('buildTheme', () => {
   });
 });
 
+jest.mock('../../../../../wailsjs/go/main/App', () => ({
+  LSPComplete: jest.fn(),
+  LSPResolveCompletionItem: jest.fn(),
+  LSPDefinition: jest.fn(),
+  LSPHover: jest.fn(),
+}));
+jest.mock('../../../../utils/lspDocumentSync', () => ({
+  flushLSPDocumentChange: jest.fn(() => Promise.resolve(false)),
+}));
+
+import { EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import {
+  createEditorExtensions,
+  applyEditorTheme,
+} from '../../../../components/Editor/codemirror/extensions';
+
+describe('editor theme wiring', () => {
+  it('createEditorExtensions accepts a syntaxThemeId', () => {
+    const ext = createEditorExtensions({
+      filename: 'a.ts',
+      filePath: '/a.ts',
+      syntaxThemeId: 'abyssal',
+    });
+    expect(Array.isArray(ext)).toBe(true);
+    expect(ext.length).toBeGreaterThan(0);
+  });
+
+  it('applyEditorTheme reconfigures a live view without throwing', () => {
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: 'const x = 1',
+        extensions: createEditorExtensions({
+          filename: 'a.ts',
+          filePath: '/a.ts',
+          syntaxThemeId: 'glacier',
+        }),
+      }),
+    });
+    expect(() => applyEditorTheme(view, 'reef')).not.toThrow();
+    view.destroy();
+  });
+});
+
 describe('#113 diagnostic tooltip surface', () => {
   const rules = buildChromeRules('#0F172A');
 

--- a/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
@@ -26,6 +26,8 @@ describe('highlight-style builders', () => {
     expect(colorFor(t.regexp)).toBe(palette.regexp);
     // Compound tag (most likely to be mis-nested) — function(variableName).
     expect(colorFor(t.function(t.variableName))).toBe(palette.function);
+    // Decorator marker (@) — t.meta — must map to the function color.
+    expect(colorFor(t.meta)).toBe(palette.function);
   });
 
   it('builds a defined HighlightStyle for every palette', () => {
@@ -48,12 +50,20 @@ describe('highlight-style builders', () => {
 });
 
 describe('buildChromeRules', () => {
-  it('uses the supplied background for canvas and gutters', () => {
-    const rules = buildChromeRules('#08111C');
+  it('uses the palette background for canvas and gutters', () => {
+    const rules = buildChromeRules(getSyntaxPalette('abyssal'));
     expect((rules['&'] as Record<string, string>).backgroundColor).toBe('#08111C');
     expect((rules['.cm-gutters'] as Record<string, string>).backgroundColor).toBe('#08111C');
     // Guard against accidental truncation of the chrome rule set.
     expect(Object.keys(rules).length).toBeGreaterThan(20);
+  });
+
+  it('colours the python overlay token classes from the palette', () => {
+    const palette = getSyntaxPalette('abyssal');
+    const rules = buildChromeRules(palette);
+    expect((rules['.firn-tok-self'] as Record<string, string>).color).toBe(palette.keyword);
+    expect((rules['.firn-tok-builtin'] as Record<string, string>).color).toBe(palette.type);
+    expect((rules['.firn-tok-decorator'] as Record<string, string>).color).toBe(palette.function);
   });
 });
 
@@ -80,7 +90,7 @@ describe('buildTheme', () => {
 });
 
 describe('#113 diagnostic tooltip surface', () => {
-  const rules = buildChromeRules('#0F172A');
+  const rules = buildChromeRules(getSyntaxPalette('glacier'));
 
   it('gives the lint tooltip an opaque surface', () => {
     const lint = rules['.cm-tooltip-lint'] as Record<string, string>;

--- a/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
+++ b/frontend/src/__tests__/components/Editor/codemirror/theme.test.ts
@@ -1,0 +1,40 @@
+import { tags as t } from '@lezer/highlight';
+import {
+  buildHighlightSpec,
+  buildHighlightStyle,
+  firnGlacierHighlightStyle,
+} from '../../../../components/Editor/codemirror/theme';
+import { getSyntaxPalette } from '../../../../components/Editor/codemirror/palettes';
+
+describe('buildHighlightSpec', () => {
+  it('maps token roles to the supplied palette colors', () => {
+    const palette = getSyntaxPalette('abyssal');
+    const spec = buildHighlightSpec(palette);
+    const colorFor = (tag: unknown) => spec.find((s) => s.tag === tag)?.color;
+
+    expect(colorFor(t.keyword)).toBe(palette.keyword);
+    expect(colorFor(t.comment)).toBe(palette.comment);
+    expect(colorFor(t.string)).toBe(palette.string);
+    expect(colorFor(t.number)).toBe(palette.number);
+    expect(colorFor(t.typeName)).toBe(palette.type);
+    expect(colorFor(t.regexp)).toBe(palette.regexp);
+  });
+
+  it('builds a defined HighlightStyle for every palette', () => {
+    for (const id of [
+      'glacier',
+      'solar',
+      'reef',
+      'nebula',
+      'bifrost',
+      'aurora',
+      'abyssal',
+    ] as const) {
+      expect(buildHighlightStyle(getSyntaxPalette(id))).toBeDefined();
+    }
+  });
+
+  it('keeps the legacy firnGlacierHighlightStyle export', () => {
+    expect(firnGlacierHighlightStyle).toBeDefined();
+  });
+});

--- a/frontend/src/__tests__/components/EditorThemePicker.test.tsx
+++ b/frontend/src/__tests__/components/EditorThemePicker.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EditorThemePicker } from '../../components/StatusBar/EditorThemePicker';
+import { useIDEStore } from '../../stores/ideStore';
+import { SYNTAX_THEMES } from '../../components/Editor/codemirror/palettes';
+
+describe('EditorThemePicker', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useIDEStore.getState().setEditorSyntaxTheme('abyssal');
+  });
+
+  it('renders all themes and reflects the active one', () => {
+    render(<EditorThemePicker />);
+    const select = screen.getByLabelText('Editor theme') as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+    expect(select.options).toHaveLength(SYNTAX_THEMES.length);
+    expect(select.value).toBe('abyssal');
+  });
+
+  it('changing the select updates the store', () => {
+    render(<EditorThemePicker />);
+    const select = screen.getByLabelText('Editor theme');
+    fireEvent.change(select, { target: { value: 'reef' } });
+    expect(useIDEStore.getState().editorSyntaxTheme).toBe('reef');
+  });
+});

--- a/frontend/src/__tests__/components/EditorThemePicker.test.tsx
+++ b/frontend/src/__tests__/components/EditorThemePicker.test.tsx
@@ -9,26 +9,28 @@ describe('EditorThemePicker', () => {
     useIDEStore.getState().setEditorSyntaxTheme('abyssal');
   });
 
-  it('renders all themes and reflects the active one', () => {
+  it('shows the active theme label and is collapsed by default', () => {
     render(<EditorThemePicker />);
-    const select = screen.getByLabelText('Editor theme') as HTMLSelectElement;
-    expect(select).toBeInTheDocument();
-    expect(select.options).toHaveLength(SYNTAX_THEMES.length);
-    expect(select.value).toBe('abyssal');
+    const trigger = screen.getByLabelText('Editor theme');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).toHaveTextContent('Abyssal Current');
+    expect(screen.queryByRole('listbox')).toBeNull();
   });
 
-  it('changing the select updates the store', () => {
+  it('opens a listbox of all themes on click, marking the active one', () => {
     render(<EditorThemePicker />);
-    const select = screen.getByLabelText('Editor theme');
-    fireEvent.change(select, { target: { value: 'reef' } });
+    fireEvent.click(screen.getByLabelText('Editor theme'));
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(SYNTAX_THEMES.length);
+    const selected = options.find((option) => option.getAttribute('aria-selected') === 'true');
+    expect(selected).toHaveTextContent('Abyssal Current');
+  });
+
+  it('selecting an option updates the store and closes the menu', () => {
+    render(<EditorThemePicker />);
+    fireEvent.click(screen.getByLabelText('Editor theme'));
+    fireEvent.click(screen.getByText('Tropic Coral Reef'));
     expect(useIDEStore.getState().editorSyntaxTheme).toBe('reef');
-  });
-
-  it('ignores a non-theme value without changing the store', () => {
-    render(<EditorThemePicker />);
-    const select = screen.getByLabelText('Editor theme');
-    const before = useIDEStore.getState().editorSyntaxTheme;
-    fireEvent.change(select, { target: { value: 'not-a-theme' } });
-    expect(useIDEStore.getState().editorSyntaxTheme).toBe(before);
+    expect(screen.queryByRole('listbox')).toBeNull();
   });
 });

--- a/frontend/src/__tests__/components/EditorThemePicker.test.tsx
+++ b/frontend/src/__tests__/components/EditorThemePicker.test.tsx
@@ -23,4 +23,12 @@ describe('EditorThemePicker', () => {
     fireEvent.change(select, { target: { value: 'reef' } });
     expect(useIDEStore.getState().editorSyntaxTheme).toBe('reef');
   });
+
+  it('ignores a non-theme value without changing the store', () => {
+    render(<EditorThemePicker />);
+    const select = screen.getByLabelText('Editor theme');
+    const before = useIDEStore.getState().editorSyntaxTheme;
+    fireEvent.change(select, { target: { value: 'not-a-theme' } });
+    expect(useIDEStore.getState().editorSyntaxTheme).toBe(before);
+  });
 });

--- a/frontend/src/__tests__/stores/ideStore.editorTheme.test.ts
+++ b/frontend/src/__tests__/stores/ideStore.editorTheme.test.ts
@@ -1,4 +1,4 @@
-import { useIDEStore, useEditorSyntaxTheme } from '../../stores/ideStore';
+import { useIDEStore, useEditorSyntaxTheme, loadInitialSyntaxTheme } from '../../stores/ideStore';
 import { renderHook } from '@testing-library/react';
 
 const KEY = 'firn.editorSyntaxTheme';
@@ -9,7 +9,7 @@ describe('editorSyntaxTheme store slice', () => {
     useIDEStore.getState().setEditorSyntaxTheme('abyssal');
   });
 
-  it('defaults to abyssal', () => {
+  it('state is abyssal after reset', () => {
     expect(useIDEStore.getState().editorSyntaxTheme).toBe('abyssal');
   });
 
@@ -30,5 +30,26 @@ describe('editorSyntaxTheme store slice', () => {
     useIDEStore.getState().setEditorSyntaxTheme('solar');
     const { result } = renderHook(() => useEditorSyntaxTheme());
     expect(result.current).toBe('solar');
+  });
+});
+
+describe('loadInitialSyntaxTheme', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('hydrates a valid persisted value', () => {
+    localStorage.setItem('firn.editorSyntaxTheme', 'nebula');
+    expect(loadInitialSyntaxTheme()).toBe('nebula');
+  });
+
+  it('falls back to the default for a corrupt persisted value', () => {
+    localStorage.setItem('firn.editorSyntaxTheme', 'not-a-real-theme');
+    expect(loadInitialSyntaxTheme()).toBe('abyssal');
+  });
+
+  it('falls back to the default when nothing is persisted', () => {
+    localStorage.removeItem('firn.editorSyntaxTheme');
+    expect(loadInitialSyntaxTheme()).toBe('abyssal');
   });
 });

--- a/frontend/src/__tests__/stores/ideStore.editorTheme.test.ts
+++ b/frontend/src/__tests__/stores/ideStore.editorTheme.test.ts
@@ -1,0 +1,34 @@
+import { useIDEStore, useEditorSyntaxTheme } from '../../stores/ideStore';
+import { renderHook } from '@testing-library/react';
+
+const KEY = 'firn.editorSyntaxTheme';
+
+describe('editorSyntaxTheme store slice', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useIDEStore.getState().setEditorSyntaxTheme('abyssal');
+  });
+
+  it('defaults to abyssal', () => {
+    expect(useIDEStore.getState().editorSyntaxTheme).toBe('abyssal');
+  });
+
+  it('setEditorSyntaxTheme updates state and persists to localStorage', () => {
+    useIDEStore.getState().setEditorSyntaxTheme('reef');
+    expect(useIDEStore.getState().editorSyntaxTheme).toBe('reef');
+    expect(localStorage.getItem(KEY)).toBe('reef');
+  });
+
+  it('ignores invalid ids by leaving state unchanged', () => {
+    useIDEStore.getState().setEditorSyntaxTheme('nebula');
+    // @ts-expect-error testing runtime guard with a bad value
+    useIDEStore.getState().setEditorSyntaxTheme('bogus');
+    expect(useIDEStore.getState().editorSyntaxTheme).toBe('nebula');
+  });
+
+  it('exposes a selector hook', () => {
+    useIDEStore.getState().setEditorSyntaxTheme('solar');
+    const { result } = renderHook(() => useEditorSyntaxTheme());
+    expect(result.current).toBe('solar');
+  });
+});

--- a/frontend/src/components/Editor/CodeMirrorEditor.tsx
+++ b/frontend/src/components/Editor/CodeMirrorEditor.tsx
@@ -242,12 +242,10 @@ export const CodeMirrorEditor = memo(function CodeMirrorEditor({
     return cancel;
   }, [fileId]);
 
-  // Live-swap the editor theme when the global syntax theme changes.
+  // Live-swap the editor theme when the global syntax theme changes. The initial
+  // theme is baked in by createEditorExtensions, so we only handle later changes.
   useEffect(() => {
     let prev = useIDEStore.getState().editorSyntaxTheme;
-    const view = editorRef.current;
-    if (view) applyEditorTheme(view, prev);
-
     return useIDEStore.subscribe((state) => {
       const next = state.editorSyntaxTheme;
       if (next === prev) return;

--- a/frontend/src/components/Editor/CodeMirrorEditor.tsx
+++ b/frontend/src/components/Editor/CodeMirrorEditor.tsx
@@ -16,6 +16,7 @@ import {
   EditorView,
   EditorState,
   createEditorExtensions,
+  applyEditorTheme,
   completionCompartment,
   hoverCompartment,
   reconfigureCompletion,
@@ -140,6 +141,7 @@ export const CodeMirrorEditor = memo(function CodeMirrorEditor({
       filePath: fileId,
       readOnly,
       tabSize,
+      syntaxThemeId: useIDEStore.getState().editorSyntaxTheme,
       onChange: handleContentChange,
       onCursorChange,
     });
@@ -239,6 +241,21 @@ export const CodeMirrorEditor = memo(function CodeMirrorEditor({
 
     return cancel;
   }, [fileId]);
+
+  // Live-swap the editor theme when the global syntax theme changes.
+  useEffect(() => {
+    let prev = useIDEStore.getState().editorSyntaxTheme;
+    const view = editorRef.current;
+    if (view) applyEditorTheme(view, prev);
+
+    return useIDEStore.subscribe((state) => {
+      const next = state.editorSyntaxTheme;
+      if (next === prev) return;
+      prev = next;
+      const currentView = editorRef.current;
+      if (currentView) applyEditorTheme(currentView, next);
+    });
+  }, []);
 
   // Enable LSP completion/hover when the matching server becomes ready.
   useEffect(() => {

--- a/frontend/src/components/Editor/codemirror/extensions.ts
+++ b/frontend/src/components/Editor/codemirror/extensions.ts
@@ -54,7 +54,8 @@ import { xml } from '@codemirror/lang-xml';
 import { yaml } from '@codemirror/lang-yaml';
 import { rust } from '@codemirror/lang-rust';
 
-import { firnGlacier } from './theme';
+import { buildTheme } from './theme';
+import { type SyntaxThemeId, DEFAULT_SYNTAX_THEME_ID } from './palettes';
 import { diagnosticsExtensions } from './diagnostics';
 import { completionExtensions } from './completion';
 import { hoverExtensions } from './hover';
@@ -295,6 +296,7 @@ export function createEditorExtensions(options: {
   readOnly?: boolean;
   tabSize?: number;
   placeholder?: string;
+  syntaxThemeId?: SyntaxThemeId;
   onChange?: (content: string) => void;
   onCursorChange?: (line: number, column: number) => void;
 }): Extension[] {
@@ -304,6 +306,7 @@ export function createEditorExtensions(options: {
     readOnly: isReadOnly = false,
     tabSize: tabs = 2,
     placeholder,
+    syntaxThemeId = DEFAULT_SYNTAX_THEME_ID,
     onChange,
     onCursorChange,
   } = options;
@@ -312,7 +315,7 @@ export function createEditorExtensions(options: {
 
   const extensions: Extension[] = [
     // Theme
-    themeCompartment.of(firnGlacier),
+    themeCompartment.of(buildTheme(syntaxThemeId)),
 
     // Core functionality
     ...coreExtensions(),
@@ -381,4 +384,9 @@ export function createEditorExtensions(options: {
   }
 
   return extensions;
+}
+
+/** Reconfigures a live editor's theme compartment to the given syntax theme. */
+export function applyEditorTheme(view: EditorView, id: SyntaxThemeId): void {
+  view.dispatch({ effects: themeCompartment.reconfigure(buildTheme(id)) });
 }

--- a/frontend/src/components/Editor/codemirror/extensions.ts
+++ b/frontend/src/components/Editor/codemirror/extensions.ts
@@ -60,6 +60,7 @@ import { diagnosticsExtensions } from './diagnostics';
 import { completionExtensions } from './completion';
 import { hoverExtensions } from './hover';
 import { definitionExtensions } from './definition';
+import { pythonHighlightExtensions } from './pythonHighlight';
 export { getLanguageName } from '../../../utils/editorLanguage';
 
 /**
@@ -312,6 +313,8 @@ export function createEditorExtensions(options: {
   } = options;
 
   const language = getLanguageExtension(filename);
+  const fileExt = filename.split('.').pop()?.toLowerCase();
+  const isPython = fileExt === 'py' || fileExt === 'pyw' || fileExt === 'pyi';
 
   const extensions: Extension[] = [
     // Theme
@@ -340,6 +343,9 @@ export function createEditorExtensions(options: {
 
     // Language (in compartment for dynamic switching)
     languageCompartment.of(language || []),
+
+    // Python-only semantic overlay (self/cls, builtins, decorator names)
+    ...(isPython ? [pythonHighlightExtensions()] : []),
 
     // Diagnostics (lint gutter + underlines, populated dynamically)
     ...diagnosticsExtensions(),

--- a/frontend/src/components/Editor/codemirror/index.ts
+++ b/frontend/src/components/Editor/codemirror/index.ts
@@ -29,6 +29,7 @@ export {
 // Extensions and utilities
 export {
   createEditorExtensions,
+  applyEditorTheme,
   getLanguageExtension,
   getLanguageName,
   languageCompartment,

--- a/frontend/src/components/Editor/codemirror/index.ts
+++ b/frontend/src/components/Editor/codemirror/index.ts
@@ -5,7 +5,26 @@
  */
 
 // Theme
-export { firnGlacier, firnGlacierTheme, firnGlacierHighlightStyle } from './theme';
+export {
+  firnGlacier,
+  firnGlacierTheme,
+  firnGlacierHighlightStyle,
+  buildTheme,
+  buildSyntaxTheme,
+  buildChrome,
+  buildHighlightStyle,
+  defaultEditorTheme,
+} from './theme';
+export {
+  SYNTAX_THEMES,
+  SYNTAX_THEME_BY_ID,
+  DEFAULT_SYNTAX_THEME_ID,
+  isSyntaxThemeId,
+  getSyntaxPalette,
+  type SyntaxThemeId,
+  type SyntaxPalette,
+  type SyntaxThemeDefinition,
+} from './palettes';
 
 // Extensions and utilities
 export {

--- a/frontend/src/components/Editor/codemirror/palettes.ts
+++ b/frontend/src/components/Editor/codemirror/palettes.ts
@@ -1,0 +1,220 @@
+/**
+ * Syntax palettes for the Firn editor theme system.
+ *
+ * Pure data + id helpers — no React, no CodeMirror imports — so both the editor
+ * theme builders and the Zustand store can import from here without cycles.
+ *
+ * A palette defines ONLY syntax token colors plus the editor canvas `background`.
+ * All other editor chrome (borders, tooltip surface, selection, gutters, text)
+ * is shared and lives in theme.ts (`colors`).
+ */
+
+export interface SyntaxPalette {
+  /** Editor canvas + gutter background. */
+  background: string;
+  comment: string;
+  keyword: string;
+  string: string;
+  number: string;
+  function: string;
+  type: string;
+  constant: string;
+  operator: string;
+  punctuation: string;
+  /** Plain identifier color. */
+  variable: string;
+  property: string;
+  regexp: string;
+  tag: string;
+  attribute: string;
+  /** String-escape sequences. */
+  escape: string;
+}
+
+export type SyntaxThemeId =
+  | 'glacier'
+  | 'solar'
+  | 'reef'
+  | 'nebula'
+  | 'bifrost'
+  | 'aurora'
+  | 'abyssal';
+
+export interface SyntaxThemeDefinition {
+  id: SyntaxThemeId;
+  /** Human label shown in the picker. */
+  label: string;
+  palette: SyntaxPalette;
+}
+
+/** Ordered for picker display. Order is product behavior — keep it stable. */
+export const SYNTAX_THEMES: readonly SyntaxThemeDefinition[] = [
+  {
+    id: 'glacier',
+    label: 'Firn Glacier',
+    palette: {
+      background: '#0F172A',
+      comment: '#6B829E',
+      keyword: '#C4B5FD',
+      string: '#86EFAC',
+      number: '#FCD34D',
+      function: '#7DD3FC',
+      type: '#FDA4AF',
+      constant: '#F0ABFC',
+      operator: '#22D3EE',
+      punctuation: '#CBD5E1',
+      variable: '#F1F5F9',
+      property: '#FDE68A',
+      regexp: '#86EFAC',
+      tag: '#FDA4AF',
+      attribute: '#FCD34D',
+      escape: '#22D3EE',
+    },
+  },
+  {
+    id: 'solar',
+    label: 'Solar Flare',
+    palette: {
+      background: '#0F172A',
+      comment: '#8A8374',
+      keyword: '#FB7185',
+      string: '#A3E635',
+      number: '#FBBF24',
+      function: '#FACC15',
+      type: '#2DD4BF',
+      constant: '#FB923C',
+      operator: '#F472B6',
+      punctuation: '#D6D3D1',
+      variable: '#FDE68A',
+      property: '#FDBA74',
+      regexp: '#FCA5A5',
+      tag: '#FB7185',
+      attribute: '#FBBF24',
+      escape: '#F472B6',
+    },
+  },
+  {
+    id: 'reef',
+    label: 'Tropic Coral Reef',
+    palette: {
+      background: '#0F172A',
+      comment: '#5F7E86',
+      keyword: '#FF6B9D',
+      string: '#5EE6A8',
+      number: '#FF9E64',
+      function: '#FFC857',
+      type: '#22D3EE',
+      constant: '#C77DFF',
+      operator: '#7DD3FC',
+      punctuation: '#8DA9BC',
+      variable: '#EAF2F8',
+      property: '#FCA5A5',
+      regexp: '#5EE6A8',
+      tag: '#FF6B9D',
+      attribute: '#FFC857',
+      escape: '#7DD3FC',
+    },
+  },
+  {
+    id: 'nebula',
+    label: 'Nebula Jewel',
+    palette: {
+      background: '#0F172A',
+      comment: '#768293',
+      keyword: '#C084FC',
+      string: '#FBBF24',
+      number: '#FB7185',
+      function: '#38BDF8',
+      type: '#34D399',
+      constant: '#E879F9',
+      operator: '#2DD4BF',
+      punctuation: '#94A3B8',
+      variable: '#E5E7EB',
+      property: '#A3E635',
+      regexp: '#FBBF24',
+      tag: '#C084FC',
+      attribute: '#A3E635',
+      escape: '#2DD4BF',
+    },
+  },
+  {
+    id: 'bifrost',
+    label: 'Ember Bifrost',
+    palette: {
+      background: '#0F172A',
+      comment: '#71849D',
+      keyword: '#F97316',
+      string: '#7DD3FC',
+      number: '#A5B4FC',
+      function: '#FBBF24',
+      type: '#5EEAD4',
+      constant: '#C4B5FD',
+      operator: '#FB7185',
+      punctuation: '#94A3B8',
+      variable: '#E2E8F0',
+      property: '#93C5FD',
+      regexp: '#67E8F9',
+      tag: '#F97316',
+      attribute: '#FBBF24',
+      escape: '#FB7185',
+    },
+  },
+  {
+    id: 'aurora',
+    label: 'Aurora Bloom',
+    palette: {
+      background: '#0F172A',
+      comment: '#5F7E86',
+      keyword: '#FF6B9D',
+      string: '#5EE6A8',
+      number: '#A5B4FC',
+      function: '#FFC857',
+      type: '#22D3EE',
+      constant: '#C77DFF',
+      operator: '#FB7185',
+      punctuation: '#8DA9BC',
+      variable: '#EAF2F8',
+      property: '#7DD3FC',
+      regexp: '#67E8F9',
+      tag: '#FF6B9D',
+      attribute: '#FFC857',
+      escape: '#FB7185',
+    },
+  },
+  {
+    id: 'abyssal',
+    label: 'Abyssal Current',
+    palette: {
+      background: '#08111C',
+      comment: '#5C7A8F',
+      keyword: '#F472B6',
+      string: '#4ADE80',
+      number: '#FBBF24',
+      function: '#38BDF8',
+      type: '#2DD4BF',
+      constant: '#A78BFA',
+      operator: '#67E8F9',
+      punctuation: '#7A93AB',
+      variable: '#CBD7E6',
+      property: '#7DD3FC',
+      regexp: '#5EEAD4',
+      tag: '#F472B6',
+      attribute: '#FBBF24',
+      escape: '#67E8F9',
+    },
+  },
+];
+
+export const SYNTAX_THEME_BY_ID: ReadonlyMap<SyntaxThemeId, SyntaxThemeDefinition> = new Map(
+  SYNTAX_THEMES.map((theme) => [theme.id, theme])
+);
+
+export const DEFAULT_SYNTAX_THEME_ID: SyntaxThemeId = 'abyssal';
+
+export function isSyntaxThemeId(value: unknown): value is SyntaxThemeId {
+  return typeof value === 'string' && SYNTAX_THEME_BY_ID.has(value as SyntaxThemeId);
+}
+
+export function getSyntaxPalette(id: SyntaxThemeId): SyntaxPalette {
+  return (SYNTAX_THEME_BY_ID.get(id) ?? SYNTAX_THEME_BY_ID.get(DEFAULT_SYNTAX_THEME_ID)!).palette;
+}

--- a/frontend/src/components/Editor/codemirror/palettes.ts
+++ b/frontend/src/components/Editor/codemirror/palettes.ts
@@ -159,6 +159,8 @@ export const SYNTAX_THEMES: readonly SyntaxThemeDefinition[] = [
       escape: '#FB7185',
     },
   },
+  // Aurora Bloom = Ember Bifrost's warm/cool structure rendered in Tropic Reef hues,
+  // so it intentionally shares several role colors with `reef`.
   {
     id: 'aurora',
     label: 'Aurora Bloom',
@@ -216,5 +218,9 @@ export function isSyntaxThemeId(value: unknown): value is SyntaxThemeId {
 }
 
 export function getSyntaxPalette(id: SyntaxThemeId): SyntaxPalette {
-  return (SYNTAX_THEME_BY_ID.get(id) ?? SYNTAX_THEME_BY_ID.get(DEFAULT_SYNTAX_THEME_ID)!).palette;
+  return (
+    SYNTAX_THEME_BY_ID.get(id) ??
+    SYNTAX_THEME_BY_ID.get(DEFAULT_SYNTAX_THEME_ID) ??
+    SYNTAX_THEMES[0]
+  ).palette;
 }

--- a/frontend/src/components/Editor/codemirror/palettes.ts
+++ b/frontend/src/components/Editor/codemirror/palettes.ts
@@ -29,6 +29,10 @@ export interface SyntaxPalette {
   attribute: string;
   /** String-escape sequences. */
   escape: string;
+  /** Decorator marker + name (`@property`). */
+  decorator: string;
+  /** Keyword-argument / call parameter names (`Foo(id=…)`). */
+  param: string;
 }
 
 export type SyntaxThemeId =
@@ -69,6 +73,8 @@ export const SYNTAX_THEMES: readonly SyntaxThemeDefinition[] = [
       tag: '#FDA4AF',
       attribute: '#FCD34D',
       escape: '#22D3EE',
+      decorator: '#FBBF24',
+      param: '#C084FC',
     },
   },
   {
@@ -91,6 +97,8 @@ export const SYNTAX_THEMES: readonly SyntaxThemeDefinition[] = [
       tag: '#FB7185',
       attribute: '#FBBF24',
       escape: '#F472B6',
+      decorator: '#C084FC',
+      param: '#67E8F9',
     },
   },
   {
@@ -113,6 +121,8 @@ export const SYNTAX_THEMES: readonly SyntaxThemeDefinition[] = [
       tag: '#FF6B9D',
       attribute: '#FFC857',
       escape: '#7DD3FC',
+      decorator: '#A78BFA',
+      param: '#38BDF8',
     },
   },
   {
@@ -135,6 +145,8 @@ export const SYNTAX_THEMES: readonly SyntaxThemeDefinition[] = [
       tag: '#C084FC',
       attribute: '#A3E635',
       escape: '#2DD4BF',
+      decorator: '#FBBF24',
+      param: '#F0ABFC',
     },
   },
   {
@@ -157,6 +169,8 @@ export const SYNTAX_THEMES: readonly SyntaxThemeDefinition[] = [
       tag: '#F97316',
       attribute: '#FBBF24',
       escape: '#FB7185',
+      decorator: '#F472B6',
+      param: '#A78BFA',
     },
   },
   // Aurora Bloom = Ember Bifrost's warm/cool structure rendered in Tropic Reef hues,
@@ -181,6 +195,8 @@ export const SYNTAX_THEMES: readonly SyntaxThemeDefinition[] = [
       tag: '#FF6B9D',
       attribute: '#FFC857',
       escape: '#FB7185',
+      decorator: '#A78BFA',
+      param: '#FBBF24',
     },
   },
   {
@@ -203,6 +219,8 @@ export const SYNTAX_THEMES: readonly SyntaxThemeDefinition[] = [
       tag: '#F472B6',
       attribute: '#FBBF24',
       escape: '#67E8F9',
+      decorator: '#FBBF24',
+      param: '#A78BFA',
     },
   },
 ];

--- a/frontend/src/components/Editor/codemirror/pythonHighlight.ts
+++ b/frontend/src/components/Editor/codemirror/pythonHighlight.ts
@@ -2,16 +2,19 @@
  * Python-specific highlight overlay.
  *
  * lezer-python tags `self`/`cls`, builtin types/functions (`dict`, `str`, `float`,
- * …), and decorator names all as plain `VariableName`/`PropertyName` — the same tag
- * as any user identifier — so the syntax theme's HighlightStyle cannot distinguish
- * them. This ViewPlugin walks the syntax tree and marks those tokens with CSS classes
- * that the active theme colours (see `buildChromeRules` in theme.ts):
+ * …), decorator names, and keyword-argument names all as plain `VariableName`/
+ * `PropertyName` — the same tag as any user identifier — so the syntax theme's
+ * HighlightStyle cannot distinguish them. This ViewPlugin walks the syntax tree
+ * and marks those tokens with CSS classes the active theme colours (see
+ * `buildChromeRules` in theme.ts):
  *   - `.firn-tok-self`      → palette.keyword  (self / cls)
  *   - `.firn-tok-builtin`   → palette.type     (dict / str / float / len / …)
- *   - `.firn-tok-decorator` → palette.function (the name in `@property`, `@app.route`)
+ *   - `.firn-tok-decorator` → palette.function (name in `@property`, `@app.route`)
+ *   - `.firn-tok-param`     → palette.property (keyword-arg names: `Foo(id=…)`)
  *
- * Scope this to Python documents only — other languages share the `VariableName` tag
- * and would mis-colour identifiers like a JS variable named `self`.
+ * Runs at `Prec.highest` so its mark spans nest *inside* the syntax-highlight spans
+ * and win the colour cascade. Scope to Python documents only — other languages share
+ * the `VariableName` tag and would be mis-coloured.
  */
 
 import {
@@ -22,8 +25,8 @@ import {
   type ViewUpdate,
 } from '@codemirror/view';
 import { syntaxTree } from '@codemirror/language';
-import { RangeSetBuilder, type Extension } from '@codemirror/state';
-import type { SyntaxNode } from '@lezer/common';
+import { Prec, RangeSetBuilder, type EditorState, type Extension } from '@codemirror/state';
+import type { SyntaxNode, SyntaxNodeRef, Tree } from '@lezer/common';
 
 /** Python identifiers conventionally highlighted like keywords. */
 export const PY_SELF_NAMES = new Set(['self', 'cls']);
@@ -101,19 +104,34 @@ export const PY_BUILTINS = new Set([
   'zip',
 ]);
 
-export type PythonTokenClass = 'firn-tok-self' | 'firn-tok-builtin' | 'firn-tok-decorator';
+export type PythonTokenClass =
+  | 'firn-tok-self'
+  | 'firn-tok-builtin'
+  | 'firn-tok-decorator'
+  | 'firn-tok-param';
+
+export interface PythonTokenContext {
+  /** Node is the callee/name of a decorator. */
+  decoratorName: boolean;
+  /** Node is a keyword-argument name (`name=` inside a call's ArgList). */
+  kwargName: boolean;
+}
 
 /**
- * Pure classifier (exported for tests). Decorator-name detection takes precedence so
- * `@property` colours `property` as a decorator rather than as the `property` builtin.
+ * Pure classifier (exported for tests). Decorator-name and kwarg-name context take
+ * precedence so e.g. `@property` colours `property` as a decorator rather than as the
+ * `property` builtin.
  */
 export function pythonTokenClass(
   nodeName: string,
   text: string,
-  isDecoratorName: boolean
+  ctx: PythonTokenContext
 ): PythonTokenClass | null {
-  if (isDecoratorName && (nodeName === 'VariableName' || nodeName === 'PropertyName')) {
+  if (ctx.decoratorName && (nodeName === 'VariableName' || nodeName === 'PropertyName')) {
     return 'firn-tok-decorator';
+  }
+  if (ctx.kwargName && nodeName === 'VariableName') {
+    return 'firn-tok-param';
   }
   if (nodeName !== 'VariableName') return null;
   if (PY_SELF_NAMES.has(text)) return 'firn-tok-self';
@@ -122,9 +140,9 @@ export function pythonTokenClass(
 }
 
 /**
- * True when `node` is the callee/name of a decorator (lives inside a `Decorator`
- * node and is NOT one of its call arguments). `@wraps(func)` → `wraps` is a name,
- * `func` is an argument (inside `ArgList`) and is left alone.
+ * True when `node` is the callee/name of a decorator (inside a `Decorator` node and
+ * NOT one of its call arguments). `@wraps(func)` → `wraps` is a name, `func` is an
+ * argument (inside `ArgList`) and is left alone.
  */
 function isDecoratorName(node: SyntaxNode): boolean {
   for (let cur: SyntaxNode | null = node.parent; cur; cur = cur.parent) {
@@ -134,24 +152,54 @@ function isDecoratorName(node: SyntaxNode): boolean {
   return false;
 }
 
+/** True when `node` is the `name` in a `name=value` keyword argument. */
+function isKwargName(node: SyntaxNode): boolean {
+  return node.parent?.name === 'ArgList' && node.nextSibling?.name === 'AssignOp';
+}
+
+function classifyNode(state: EditorState, ref: SyntaxNodeRef): PythonTokenClass | null {
+  if (ref.name !== 'VariableName' && ref.name !== 'PropertyName') return null;
+  const node = ref.node;
+  return pythonTokenClass(ref.name, state.sliceDoc(ref.from, ref.to), {
+    decoratorName: isDecoratorName(node),
+    kwargName: isKwargName(node),
+  });
+}
+
+/**
+ * Collects every overlay mark in the document. Exported for tests so the tree-walk +
+ * classification can be verified without rendering.
+ */
+export function collectPythonMarks(
+  state: EditorState,
+  tree: Tree = syntaxTree(state)
+): { from: number; to: number; cls: PythonTokenClass }[] {
+  const out: { from: number; to: number; cls: PythonTokenClass }[] = [];
+  tree.iterate({
+    enter: (ref) => {
+      const cls = classifyNode(state, ref);
+      if (cls) out.push({ from: ref.from, to: ref.to, cls });
+    },
+  });
+  return out;
+}
+
 const MARKS: Record<PythonTokenClass, Decoration> = {
   'firn-tok-self': Decoration.mark({ class: 'firn-tok-self' }),
   'firn-tok-builtin': Decoration.mark({ class: 'firn-tok-builtin' }),
   'firn-tok-decorator': Decoration.mark({ class: 'firn-tok-decorator' }),
+  'firn-tok-param': Decoration.mark({ class: 'firn-tok-param' }),
 };
 
 function buildDecorations(view: EditorView): DecorationSet {
   const builder = new RangeSetBuilder<Decoration>();
-  const tree = syntaxTree(view.state);
   for (const { from, to } of view.visibleRanges) {
-    tree.iterate({
+    syntaxTree(view.state).iterate({
       from,
       to,
-      enter: (node) => {
-        if (node.name !== 'VariableName' && node.name !== 'PropertyName') return;
-        const text = view.state.sliceDoc(node.from, node.to);
-        const cls = pythonTokenClass(node.name, text, isDecoratorName(node.node));
-        if (cls) builder.add(node.from, node.to, MARKS[cls]);
+      enter: (ref) => {
+        const cls = classifyNode(view.state, ref);
+        if (cls) builder.add(ref.from, ref.to, MARKS[cls]);
       },
     });
   }
@@ -162,24 +210,26 @@ function buildDecorations(view: EditorView): DecorationSet {
  * Python highlight overlay extension. Add only for Python documents.
  */
 export function pythonHighlightExtensions(): Extension {
-  return ViewPlugin.fromClass(
-    class {
-      decorations: DecorationSet;
+  return Prec.highest(
+    ViewPlugin.fromClass(
+      class {
+        decorations: DecorationSet;
 
-      constructor(view: EditorView) {
-        this.decorations = buildDecorations(view);
-      }
-
-      update(update: ViewUpdate) {
-        if (
-          update.docChanged ||
-          update.viewportChanged ||
-          syntaxTree(update.startState) !== syntaxTree(update.state)
-        ) {
-          this.decorations = buildDecorations(update.view);
+        constructor(view: EditorView) {
+          this.decorations = buildDecorations(view);
         }
-      }
-    },
-    { decorations: (plugin) => plugin.decorations }
+
+        update(update: ViewUpdate) {
+          if (
+            update.docChanged ||
+            update.viewportChanged ||
+            syntaxTree(update.startState) !== syntaxTree(update.state)
+          ) {
+            this.decorations = buildDecorations(update.view);
+          }
+        }
+      },
+      { decorations: (plugin) => plugin.decorations }
+    )
   );
 }

--- a/frontend/src/components/Editor/codemirror/pythonHighlight.ts
+++ b/frontend/src/components/Editor/codemirror/pythonHighlight.ts
@@ -1,0 +1,185 @@
+/**
+ * Python-specific highlight overlay.
+ *
+ * lezer-python tags `self`/`cls`, builtin types/functions (`dict`, `str`, `float`,
+ * …), and decorator names all as plain `VariableName`/`PropertyName` — the same tag
+ * as any user identifier — so the syntax theme's HighlightStyle cannot distinguish
+ * them. This ViewPlugin walks the syntax tree and marks those tokens with CSS classes
+ * that the active theme colours (see `buildChromeRules` in theme.ts):
+ *   - `.firn-tok-self`      → palette.keyword  (self / cls)
+ *   - `.firn-tok-builtin`   → palette.type     (dict / str / float / len / …)
+ *   - `.firn-tok-decorator` → palette.function (the name in `@property`, `@app.route`)
+ *
+ * Scope this to Python documents only — other languages share the `VariableName` tag
+ * and would mis-colour identifiers like a JS variable named `self`.
+ */
+
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+} from '@codemirror/view';
+import { syntaxTree } from '@codemirror/language';
+import { RangeSetBuilder, type Extension } from '@codemirror/state';
+import type { SyntaxNode } from '@lezer/common';
+
+/** Python identifiers conventionally highlighted like keywords. */
+export const PY_SELF_NAMES = new Set(['self', 'cls']);
+
+/** Python builtin types/functions highlighted distinctly from user variables. */
+export const PY_BUILTINS = new Set([
+  // Types
+  'bool',
+  'bytearray',
+  'bytes',
+  'complex',
+  'dict',
+  'float',
+  'frozenset',
+  'int',
+  'list',
+  'memoryview',
+  'object',
+  'range',
+  'set',
+  'slice',
+  'str',
+  'tuple',
+  'type',
+  // Common builtin functions
+  'abs',
+  'all',
+  'any',
+  'ascii',
+  'bin',
+  'callable',
+  'chr',
+  'classmethod',
+  'compile',
+  'delattr',
+  'dir',
+  'divmod',
+  'enumerate',
+  'eval',
+  'exec',
+  'filter',
+  'format',
+  'getattr',
+  'globals',
+  'hasattr',
+  'hash',
+  'help',
+  'hex',
+  'id',
+  'input',
+  'isinstance',
+  'issubclass',
+  'iter',
+  'len',
+  'locals',
+  'map',
+  'max',
+  'min',
+  'next',
+  'oct',
+  'open',
+  'ord',
+  'pow',
+  'print',
+  'property',
+  'repr',
+  'reversed',
+  'round',
+  'setattr',
+  'sorted',
+  'staticmethod',
+  'sum',
+  'super',
+  'vars',
+  'zip',
+]);
+
+export type PythonTokenClass = 'firn-tok-self' | 'firn-tok-builtin' | 'firn-tok-decorator';
+
+/**
+ * Pure classifier (exported for tests). Decorator-name detection takes precedence so
+ * `@property` colours `property` as a decorator rather than as the `property` builtin.
+ */
+export function pythonTokenClass(
+  nodeName: string,
+  text: string,
+  isDecoratorName: boolean
+): PythonTokenClass | null {
+  if (isDecoratorName && (nodeName === 'VariableName' || nodeName === 'PropertyName')) {
+    return 'firn-tok-decorator';
+  }
+  if (nodeName !== 'VariableName') return null;
+  if (PY_SELF_NAMES.has(text)) return 'firn-tok-self';
+  if (PY_BUILTINS.has(text)) return 'firn-tok-builtin';
+  return null;
+}
+
+/**
+ * True when `node` is the callee/name of a decorator (lives inside a `Decorator`
+ * node and is NOT one of its call arguments). `@wraps(func)` → `wraps` is a name,
+ * `func` is an argument (inside `ArgList`) and is left alone.
+ */
+function isDecoratorName(node: SyntaxNode): boolean {
+  for (let cur: SyntaxNode | null = node.parent; cur; cur = cur.parent) {
+    if (cur.name === 'ArgList') return false;
+    if (cur.name === 'Decorator') return true;
+  }
+  return false;
+}
+
+const MARKS: Record<PythonTokenClass, Decoration> = {
+  'firn-tok-self': Decoration.mark({ class: 'firn-tok-self' }),
+  'firn-tok-builtin': Decoration.mark({ class: 'firn-tok-builtin' }),
+  'firn-tok-decorator': Decoration.mark({ class: 'firn-tok-decorator' }),
+};
+
+function buildDecorations(view: EditorView): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  const tree = syntaxTree(view.state);
+  for (const { from, to } of view.visibleRanges) {
+    tree.iterate({
+      from,
+      to,
+      enter: (node) => {
+        if (node.name !== 'VariableName' && node.name !== 'PropertyName') return;
+        const text = view.state.sliceDoc(node.from, node.to);
+        const cls = pythonTokenClass(node.name, text, isDecoratorName(node.node));
+        if (cls) builder.add(node.from, node.to, MARKS[cls]);
+      },
+    });
+  }
+  return builder.finish();
+}
+
+/**
+ * Python highlight overlay extension. Add only for Python documents.
+ */
+export function pythonHighlightExtensions(): Extension {
+  return ViewPlugin.fromClass(
+    class {
+      decorations: DecorationSet;
+
+      constructor(view: EditorView) {
+        this.decorations = buildDecorations(view);
+      }
+
+      update(update: ViewUpdate) {
+        if (
+          update.docChanged ||
+          update.viewportChanged ||
+          syntaxTree(update.startState) !== syntaxTree(update.state)
+        ) {
+          this.decorations = buildDecorations(update.view);
+        }
+      }
+    },
+    { decorations: (plugin) => plugin.decorations }
+  );
+}

--- a/frontend/src/components/Editor/codemirror/theme.ts
+++ b/frontend/src/components/Editor/codemirror/theme.ts
@@ -91,11 +91,13 @@ export function buildChromeRules(palette: SyntaxPalette) {
       lineHeight: '1.6',
     },
 
-    // Python overlay token colours (see pythonHighlight.ts) — palette-driven so
-    // they swap with the active theme.
-    '.firn-tok-self': { color: palette.keyword },
-    '.firn-tok-builtin': { color: palette.type },
-    '.firn-tok-decorator': { color: palette.function },
+    // Python overlay token colours (see pythonHighlight.ts) — palette-driven so they
+    // swap with the active theme. `!important` wins the merged-span case where the
+    // overlay mark coincides exactly with a syntax-highlight span.
+    '.firn-tok-self': { color: `${palette.keyword} !important` },
+    '.firn-tok-builtin': { color: `${palette.type} !important` },
+    '.firn-tok-decorator': { color: `${palette.function} !important` },
+    '.firn-tok-param': { color: `${palette.property} !important` },
 
     // Content area
     '.cm-content': {

--- a/frontend/src/components/Editor/codemirror/theme.ts
+++ b/frontend/src/components/Editor/codemirror/theme.ts
@@ -72,7 +72,6 @@ const colors = {
   searchMatchSelectedBorder: '#F59E0B',
 
   // Gutter
-  gutterBackground: '#0F172A',
   gutterForeground: '#475569',
   gutterActiveForeground: '#64748B',
 
@@ -938,7 +937,7 @@ export function buildChrome(palette: SyntaxPalette): Extension {
   return EditorView.theme(buildChromeRules(palette.background), { dark: true });
 }
 
-/** Legacy alias — chrome at the refined Glacier canvas. */
+/** Legacy alias — chrome-only theme at the Glacier canvas. @see firnGlacier for chrome + syntax. */
 export const firnGlacierTheme = buildChrome(getSyntaxPalette('glacier'));
 
 /**
@@ -1053,20 +1052,17 @@ export function buildHighlightStyle(palette: SyntaxPalette): HighlightStyle {
  */
 export const firnGlacierHighlightStyle = buildHighlightStyle(getSyntaxPalette('glacier'));
 
-/**
- * Complete Firn Glacier theme extension combining editor theme and syntax highlighting.
- */
 /** Assembles chrome + syntax highlighting for a theme id. */
 export function buildTheme(id: SyntaxThemeId): Extension {
   const palette = getSyntaxPalette(id);
   return [buildChrome(palette), syntaxHighlighting(buildHighlightStyle(palette))];
 }
 
-/** Preferred name for new call sites. */
+/** Alias of `buildTheme` with a more descriptive name; both are equivalent. */
 export const buildSyntaxTheme = buildTheme;
 
-/** The active default editor theme (Abyssal Current). */
+/** The active default editor theme (the palette named by DEFAULT_SYNTAX_THEME_ID). */
 export const defaultEditorTheme: Extension = buildTheme(DEFAULT_SYNTAX_THEME_ID);
 
-/** Legacy alias — the Firn Glacier look (kept for back-compat / existing imports). */
+/** Legacy alias — the Firn Glacier look (chrome + syntax). @see firnGlacierTheme for chrome only. */
 export const firnGlacier: Extension = buildTheme('glacier');

--- a/frontend/src/components/Editor/codemirror/theme.ts
+++ b/frontend/src/components/Editor/codemirror/theme.ts
@@ -440,6 +440,54 @@ export function buildChromeRules(background: string) {
       outlineOffset: '1px',
     },
 
+    // Diagnostic (lint) hover tooltip surface (#113). The lint content renders
+    // as `.cm-tooltip-lint` inside the transparent `.cm-tooltip-hover` container;
+    // background is not inherited, so an opaque surface here fixes the blend.
+    '.cm-tooltip-lint': {
+      backgroundColor: colors.surface,
+      border: `1px solid ${colors.border}`,
+      borderRadius: '7px',
+      padding: '8px 10px',
+      boxShadow: '0 12px 30px rgba(0, 0, 0, 0.34)',
+      color: colors.foreground,
+      fontSize: '12px',
+      lineHeight: '1.5',
+      maxWidth: '460px',
+      zIndex: '1300',
+    },
+    '.cm-diagnostic': {
+      padding: '2px 0',
+      marginLeft: '0',
+      borderLeft: 'none',
+      whiteSpace: 'pre-wrap',
+    },
+    '.cm-diagnostic-error': {
+      borderLeft: `3px solid ${colors.error}`,
+      paddingLeft: '8px',
+    },
+    '.cm-diagnostic-warning': {
+      borderLeft: `3px solid ${colors.warning}`,
+      paddingLeft: '8px',
+    },
+    '.cm-diagnostic-info': {
+      borderLeft: `3px solid ${colors.info}`,
+      paddingLeft: '8px',
+    },
+    '.cm-diagnosticSource': {
+      color: colors.foregroundMuted,
+      fontSize: '11px',
+    },
+    '.cm-diagnosticAction': {
+      backgroundColor: colors.surfaceActive,
+      border: `1px solid ${colors.border}`,
+      borderRadius: '4px',
+      color: colors.foreground,
+      margin: '0 0 0 8px',
+      padding: '1px 6px',
+      fontSize: '11px',
+      cursor: 'pointer',
+    },
+
     // Linting
     '.cm-lintRange-error': {
       backgroundImage: `url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='6' height='3'><path d='m0 3 l2 -2 l1 0 l2 2 l1 0' stroke='%23EF4444' fill='none' stroke-width='1.2'/></svg>")`,

--- a/frontend/src/components/Editor/codemirror/theme.ts
+++ b/frontend/src/components/Editor/codemirror/theme.ts
@@ -84,16 +84,22 @@ const colors = {
 /**
  * Editor theme - controls the visual appearance of the editor chrome.
  */
-export function buildChromeRules(background: string) {
+export function buildChromeRules(palette: SyntaxPalette) {
   return {
     // Root editor styling
     '&': {
       color: colors.foreground,
-      backgroundColor: background,
+      backgroundColor: palette.background,
       fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
       fontSize: '13px',
       lineHeight: '1.6',
     },
+
+    // Python overlay token colours (see pythonHighlight.ts) — palette-driven so
+    // they swap with the active theme.
+    '.firn-tok-self': { color: palette.keyword },
+    '.firn-tok-builtin': { color: palette.type },
+    '.firn-tok-decorator': { color: palette.function },
 
     // Content area
     '.cm-content': {
@@ -160,7 +166,7 @@ export function buildChromeRules(background: string) {
 
     // Gutters (line numbers, fold markers)
     '.cm-gutters': {
-      backgroundColor: background,
+      backgroundColor: palette.background,
       color: colors.gutterForeground,
       border: 'none',
       borderRight: `1px solid ${colors.borderSubtle}`,
@@ -986,7 +992,7 @@ export function buildChromeRules(background: string) {
 
 /** Builds the editor chrome theme for a palette (canvas background from the palette). */
 export function buildChrome(palette: SyntaxPalette): Extension {
-  return EditorView.theme(buildChromeRules(palette.background), { dark: true });
+  return EditorView.theme(buildChromeRules(palette), { dark: true });
 }
 
 /** Legacy alias — chrome-only theme at the Glacier canvas. @see firnGlacier for chrome + syntax. */
@@ -1033,7 +1039,14 @@ export function buildHighlightSpec(palette: SyntaxPalette) {
     { tag: t.paren, color: palette.punctuation },
     { tag: t.brace, color: palette.punctuation },
     { tag: t.bracket, color: palette.punctuation },
+    { tag: t.squareBracket, color: palette.punctuation },
     { tag: t.separator, color: palette.punctuation },
+
+    // Decorators (@ = t.meta) + operators lezer-python emits that were uncolored.
+    { tag: t.meta, color: palette.function },
+    { tag: t.updateOperator, color: palette.operator },
+    { tag: t.definitionOperator, color: palette.operator },
+    { tag: t.derefOperator, color: palette.punctuation },
 
     // Variables and properties
     { tag: t.variableName, color: palette.variable },

--- a/frontend/src/components/Editor/codemirror/theme.ts
+++ b/frontend/src/components/Editor/codemirror/theme.ts
@@ -1012,6 +1012,8 @@ export function buildHighlightSpec(palette: SyntaxPalette) {
     { tag: t.heading2, color: palette.function, fontWeight: 'bold', fontSize: '1.2em' },
     { tag: t.heading3, color: palette.function, fontWeight: 'bold' },
 
+    // The following markdown/link/label/invalid tokens use the shared chrome
+    // `colors` (not the palette), so they stay constant across syntax themes.
     // Markdown specific (shared chrome accent)
     { tag: t.link, color: colors.accent, textDecoration: 'underline' },
     { tag: t.url, color: colors.accent },
@@ -1033,7 +1035,10 @@ export function buildHighlightStyle(palette: SyntaxPalette): HighlightStyle {
   return HighlightStyle.define(buildHighlightSpec(palette));
 }
 
-/** Legacy alias — the refined Firn Glacier highlight style. */
+/**
+ * Highlight style for the Glacier palette. Named export kept for back-compat
+ * (re-exported from index.ts and consumed by the `firnGlacier` extension below).
+ */
 export const firnGlacierHighlightStyle = buildHighlightStyle(getSyntaxPalette('glacier'));
 
 /**

--- a/frontend/src/components/Editor/codemirror/theme.ts
+++ b/frontend/src/components/Editor/codemirror/theme.ts
@@ -96,8 +96,8 @@ export function buildChromeRules(palette: SyntaxPalette) {
     // overlay mark coincides exactly with a syntax-highlight span.
     '.firn-tok-self': { color: `${palette.keyword} !important` },
     '.firn-tok-builtin': { color: `${palette.type} !important` },
-    '.firn-tok-decorator': { color: `${palette.function} !important` },
-    '.firn-tok-param': { color: `${palette.property} !important` },
+    '.firn-tok-decorator': { color: `${palette.decorator} !important` },
+    '.firn-tok-param': { color: `${palette.param} !important` },
 
     // Content area
     '.cm-content': {
@@ -1038,7 +1038,7 @@ export function buildHighlightSpec(palette: SyntaxPalette) {
     { tag: t.separator, color: palette.punctuation },
 
     // Decorators (@ = t.meta) + operators lezer-python emits that were uncolored.
-    { tag: t.meta, color: palette.function },
+    { tag: t.meta, color: palette.decorator },
     { tag: t.updateOperator, color: palette.operator },
     { tag: t.definitionOperator, color: palette.operator },
     { tag: t.derefOperator, color: palette.punctuation },

--- a/frontend/src/components/Editor/codemirror/theme.ts
+++ b/frontend/src/components/Editor/codemirror/theme.ts
@@ -71,10 +71,6 @@ const colors = {
   searchMatchSelected: 'rgba(245, 158, 11, 0.55)',
   searchMatchSelectedBorder: '#F59E0B',
 
-  // Gutter
-  gutterForeground: '#475569',
-  gutterActiveForeground: '#64748B',
-
   // Status
   error: '#EF4444',
   warning: '#F59E0B',
@@ -167,26 +163,23 @@ export function buildChromeRules(palette: SyntaxPalette) {
     // Gutters (line numbers, fold markers)
     '.cm-gutters': {
       backgroundColor: palette.background,
-      color: colors.gutterForeground,
+      color: palette.comment,
       border: 'none',
       borderRight: `1px solid ${colors.borderSubtle}`,
     },
 
-    '.cm-gutter': {
-      minWidth: '48px',
-    },
-
-    // Line numbers
+    // Line numbers — size to content (no fixed-width empty gutter) and tint with
+    // the palette comment color so the gutter fits each theme instead of a fixed gray.
     '.cm-lineNumbers .cm-gutterElement': {
-      padding: '0 12px 0 8px',
-      minWidth: '40px',
+      padding: '0 6px 0 10px',
+      minWidth: '20px',
       textAlign: 'right',
     },
 
-    // Active line number
+    // Active line number — brighter palette tone than the muted comment color.
     '.cm-activeLineGutter': {
       backgroundColor: colors.activeLine,
-      color: colors.gutterActiveForeground,
+      color: palette.punctuation,
     },
 
     // Fold markers

--- a/frontend/src/components/Editor/codemirror/theme.ts
+++ b/frontend/src/components/Editor/codemirror/theme.ts
@@ -9,6 +9,7 @@ import { EditorView } from '@codemirror/view';
 import { Extension } from '@codemirror/state';
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
 import { tags as t } from '@lezer/highlight';
+import { type SyntaxPalette, getSyntaxPalette } from './palettes';
 
 /**
  * Firn Glacier color palette extracted from design tokens.
@@ -929,101 +930,111 @@ export const firnGlacierTheme = EditorView.theme(
 );
 
 /**
- * Syntax highlighting styles for the Firn Glacier theme.
- * Uses semantic token types from @lezer/highlight.
+ * Builds the ordered tag→style spec for a palette. Exported for unit tests so
+ * palette wiring can be asserted without instantiating a HighlightStyle.
  */
-export const firnGlacierHighlightStyle = HighlightStyle.define([
-  // Comments
-  { tag: t.comment, color: colors.comment, fontStyle: 'italic' },
-  { tag: t.lineComment, color: colors.comment, fontStyle: 'italic' },
-  { tag: t.blockComment, color: colors.comment, fontStyle: 'italic' },
-  { tag: t.docComment, color: colors.comment, fontStyle: 'italic' },
+export function buildHighlightSpec(palette: SyntaxPalette) {
+  return [
+    // Comments
+    { tag: t.comment, color: palette.comment, fontStyle: 'italic' },
+    { tag: t.lineComment, color: palette.comment, fontStyle: 'italic' },
+    { tag: t.blockComment, color: palette.comment, fontStyle: 'italic' },
+    { tag: t.docComment, color: palette.comment, fontStyle: 'italic' },
 
-  // Strings
-  { tag: t.string, color: colors.string },
-  { tag: t.special(t.string), color: colors.string },
-  { tag: t.character, color: colors.string },
-  { tag: t.escape, color: colors.operator },
+    // Strings
+    { tag: t.string, color: palette.string },
+    { tag: t.special(t.string), color: palette.string },
+    { tag: t.character, color: palette.string },
+    { tag: t.escape, color: palette.escape },
 
-  // Numbers
-  { tag: t.number, color: colors.number },
-  { tag: t.integer, color: colors.number },
-  { tag: t.float, color: colors.number },
+    // Numbers
+    { tag: t.number, color: palette.number },
+    { tag: t.integer, color: palette.number },
+    { tag: t.float, color: palette.number },
 
-  // Keywords
-  { tag: t.keyword, color: colors.keyword },
-  { tag: t.modifier, color: colors.keyword },
-  { tag: t.controlKeyword, color: colors.keyword },
-  { tag: t.operatorKeyword, color: colors.keyword },
-  { tag: t.definitionKeyword, color: colors.keyword },
-  { tag: t.moduleKeyword, color: colors.keyword },
+    // Keywords
+    { tag: t.keyword, color: palette.keyword },
+    { tag: t.modifier, color: palette.keyword },
+    { tag: t.controlKeyword, color: palette.keyword },
+    { tag: t.operatorKeyword, color: palette.keyword },
+    { tag: t.definitionKeyword, color: palette.keyword },
+    { tag: t.moduleKeyword, color: palette.keyword },
 
-  // Operators and punctuation
-  { tag: t.operator, color: colors.operator },
-  { tag: t.compareOperator, color: colors.operator },
-  { tag: t.arithmeticOperator, color: colors.operator },
-  { tag: t.logicOperator, color: colors.operator },
-  { tag: t.bitwiseOperator, color: colors.operator },
-  { tag: t.punctuation, color: colors.punctuation },
-  { tag: t.paren, color: colors.punctuation },
-  { tag: t.brace, color: colors.punctuation },
-  { tag: t.bracket, color: colors.punctuation },
-  { tag: t.separator, color: colors.punctuation },
+    // Operators and punctuation
+    { tag: t.operator, color: palette.operator },
+    { tag: t.compareOperator, color: palette.operator },
+    { tag: t.arithmeticOperator, color: palette.operator },
+    { tag: t.logicOperator, color: palette.operator },
+    { tag: t.bitwiseOperator, color: palette.operator },
+    { tag: t.punctuation, color: palette.punctuation },
+    { tag: t.paren, color: palette.punctuation },
+    { tag: t.brace, color: palette.punctuation },
+    { tag: t.bracket, color: palette.punctuation },
+    { tag: t.separator, color: palette.punctuation },
 
-  // Variables and properties
-  { tag: t.variableName, color: colors.foreground },
-  { tag: t.definition(t.variableName), color: colors.variable },
-  { tag: t.propertyName, color: colors.variable },
-  { tag: t.definition(t.propertyName), color: colors.variable },
+    // Variables and properties
+    { tag: t.variableName, color: palette.variable },
+    { tag: t.definition(t.variableName), color: palette.variable },
+    { tag: t.propertyName, color: palette.property },
+    { tag: t.definition(t.propertyName), color: palette.property },
 
-  // Functions
-  { tag: t.function(t.variableName), color: colors.function },
-  { tag: t.definition(t.function(t.variableName)), color: colors.function },
-  { tag: t.function(t.propertyName), color: colors.function },
+    // Functions
+    { tag: t.function(t.variableName), color: palette.function },
+    { tag: t.definition(t.function(t.variableName)), color: palette.function },
+    { tag: t.function(t.propertyName), color: palette.function },
 
-  // Types
-  { tag: t.typeName, color: colors.type },
-  { tag: t.className, color: colors.type },
-  { tag: t.namespace, color: colors.type },
-  { tag: t.annotation, color: colors.type },
-  { tag: t.self, color: colors.keyword },
+    // Types
+    { tag: t.typeName, color: palette.type },
+    { tag: t.className, color: palette.type },
+    { tag: t.namespace, color: palette.type },
+    { tag: t.annotation, color: palette.type },
+    { tag: t.self, color: palette.keyword },
 
-  // Constants and special values
-  { tag: t.constant(t.variableName), color: colors.constant },
-  { tag: t.bool, color: colors.constant },
-  { tag: t.null, color: colors.constant },
-  { tag: t.atom, color: colors.constant },
-  { tag: t.unit, color: colors.constant },
+    // Constants and special values
+    { tag: t.constant(t.variableName), color: palette.constant },
+    { tag: t.bool, color: palette.constant },
+    { tag: t.null, color: palette.constant },
+    { tag: t.atom, color: palette.constant },
+    { tag: t.unit, color: palette.constant },
 
-  // HTML/JSX tags
-  { tag: t.tagName, color: colors.tag },
-  { tag: t.angleBracket, color: colors.punctuation },
-  { tag: t.attributeName, color: colors.attribute },
-  { tag: t.attributeValue, color: colors.string },
+    // HTML/JSX tags
+    { tag: t.tagName, color: palette.tag },
+    { tag: t.angleBracket, color: palette.punctuation },
+    { tag: t.attributeName, color: palette.attribute },
+    { tag: t.attributeValue, color: palette.string },
 
-  // Regular expressions
-  { tag: t.regexp, color: colors.regexp },
+    // Regular expressions
+    { tag: t.regexp, color: palette.regexp },
 
-  // Headings (Markdown)
-  { tag: t.heading, color: colors.function, fontWeight: 'bold' },
-  { tag: t.heading1, color: colors.function, fontWeight: 'bold', fontSize: '1.4em' },
-  { tag: t.heading2, color: colors.function, fontWeight: 'bold', fontSize: '1.2em' },
-  { tag: t.heading3, color: colors.function, fontWeight: 'bold' },
+    // Headings (Markdown)
+    { tag: t.heading, color: palette.function, fontWeight: 'bold' },
+    { tag: t.heading1, color: palette.function, fontWeight: 'bold', fontSize: '1.4em' },
+    { tag: t.heading2, color: palette.function, fontWeight: 'bold', fontSize: '1.2em' },
+    { tag: t.heading3, color: palette.function, fontWeight: 'bold' },
 
-  // Markdown specific
-  { tag: t.link, color: colors.accent, textDecoration: 'underline' },
-  { tag: t.url, color: colors.accent },
-  { tag: t.emphasis, fontStyle: 'italic' },
-  { tag: t.strong, fontWeight: 'bold' },
-  { tag: t.strikethrough, textDecoration: 'line-through' },
-  { tag: t.quote, color: colors.foregroundSecondary, fontStyle: 'italic' },
+    // Markdown specific (shared chrome accent)
+    { tag: t.link, color: colors.accent, textDecoration: 'underline' },
+    { tag: t.url, color: colors.accent },
+    { tag: t.emphasis, fontStyle: 'italic' },
+    { tag: t.strong, fontWeight: 'bold' },
+    { tag: t.strikethrough, textDecoration: 'line-through' },
+    { tag: t.quote, color: colors.foregroundSecondary, fontStyle: 'italic' },
 
-  // Labels (goto, break targets)
-  { tag: t.labelName, color: colors.accent },
+    // Labels (goto, break targets)
+    { tag: t.labelName, color: colors.accent },
 
-  // Invalid/error
-  { tag: t.invalid, color: colors.error },
-]);
+    // Invalid/error
+    { tag: t.invalid, color: colors.error },
+  ];
+}
+
+/** Builds a CodeMirror HighlightStyle for a palette. */
+export function buildHighlightStyle(palette: SyntaxPalette): HighlightStyle {
+  return HighlightStyle.define(buildHighlightSpec(palette));
+}
+
+/** Legacy alias — the refined Firn Glacier highlight style. */
+export const firnGlacierHighlightStyle = buildHighlightStyle(getSyntaxPalette('glacier'));
 
 /**
  * Complete Firn Glacier theme extension combining editor theme and syntax highlighting.

--- a/frontend/src/components/Editor/codemirror/theme.ts
+++ b/frontend/src/components/Editor/codemirror/theme.ts
@@ -9,7 +9,12 @@ import { EditorView } from '@codemirror/view';
 import { Extension } from '@codemirror/state';
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
 import { tags as t } from '@lezer/highlight';
-import { type SyntaxPalette, getSyntaxPalette } from './palettes';
+import {
+  type SyntaxPalette,
+  type SyntaxThemeId,
+  DEFAULT_SYNTAX_THEME_ID,
+  getSyntaxPalette,
+} from './palettes';
 
 /**
  * Firn Glacier color palette extracted from design tokens.
@@ -80,12 +85,12 @@ const colors = {
 /**
  * Editor theme - controls the visual appearance of the editor chrome.
  */
-export const firnGlacierTheme = EditorView.theme(
-  {
+export function buildChromeRules(background: string) {
+  return {
     // Root editor styling
     '&': {
       color: colors.foreground,
-      backgroundColor: colors.background,
+      backgroundColor: background,
       fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
       fontSize: '13px',
       lineHeight: '1.6',
@@ -156,7 +161,7 @@ export const firnGlacierTheme = EditorView.theme(
 
     // Gutters (line numbers, fold markers)
     '.cm-gutters': {
-      backgroundColor: colors.gutterBackground,
+      backgroundColor: background,
       color: colors.gutterForeground,
       border: 'none',
       borderRight: `1px solid ${colors.borderSubtle}`,
@@ -925,9 +930,16 @@ export const firnGlacierTheme = EditorView.theme(
       textUnderlineOffset: '2px',
       cursor: 'pointer',
     },
-  },
-  { dark: true }
-);
+  };
+}
+
+/** Builds the editor chrome theme for a palette (canvas background from the palette). */
+export function buildChrome(palette: SyntaxPalette): Extension {
+  return EditorView.theme(buildChromeRules(palette.background), { dark: true });
+}
+
+/** Legacy alias — chrome at the refined Glacier canvas. */
+export const firnGlacierTheme = buildChrome(getSyntaxPalette('glacier'));
 
 /**
  * Builds the ordered tag→style spec for a palette. Exported for unit tests so
@@ -1044,7 +1056,17 @@ export const firnGlacierHighlightStyle = buildHighlightStyle(getSyntaxPalette('g
 /**
  * Complete Firn Glacier theme extension combining editor theme and syntax highlighting.
  */
-export const firnGlacier: Extension = [
-  firnGlacierTheme,
-  syntaxHighlighting(firnGlacierHighlightStyle),
-];
+/** Assembles chrome + syntax highlighting for a theme id. */
+export function buildTheme(id: SyntaxThemeId): Extension {
+  const palette = getSyntaxPalette(id);
+  return [buildChrome(palette), syntaxHighlighting(buildHighlightStyle(palette))];
+}
+
+/** Preferred name for new call sites. */
+export const buildSyntaxTheme = buildTheme;
+
+/** The active default editor theme (Abyssal Current). */
+export const defaultEditorTheme: Extension = buildTheme(DEFAULT_SYNTAX_THEME_ID);
+
+/** Legacy alias — the Firn Glacier look (kept for back-compat / existing imports). */
+export const firnGlacier: Extension = buildTheme('glacier');

--- a/frontend/src/components/Editor/codemirror/theme.ts
+++ b/frontend/src/components/Editor/codemirror/theme.ts
@@ -1104,10 +1104,20 @@ export function buildHighlightStyle(palette: SyntaxPalette): HighlightStyle {
  */
 export const firnGlacierHighlightStyle = buildHighlightStyle(getSyntaxPalette('glacier'));
 
-/** Assembles chrome + syntax highlighting for a theme id. */
+const themeCache = new Map<SyntaxThemeId, Extension>();
+
+/**
+ * Assembles chrome + syntax highlighting for a theme id. Memoized: palettes are
+ * static, so a theme's assembled extension is immutable and safely shared across
+ * editor views and reused across swaps.
+ */
 export function buildTheme(id: SyntaxThemeId): Extension {
+  const cached = themeCache.get(id);
+  if (cached) return cached;
   const palette = getSyntaxPalette(id);
-  return [buildChrome(palette), syntaxHighlighting(buildHighlightStyle(palette))];
+  const theme: Extension = [buildChrome(palette), syntaxHighlighting(buildHighlightStyle(palette))];
+  themeCache.set(id, theme);
+  return theme;
 }
 
 /** Alias of `buildTheme` with a more descriptive name; both are equivalent. */

--- a/frontend/src/components/Editor/codemirror/theme.ts
+++ b/frontend/src/components/Editor/codemirror/theme.ts
@@ -473,8 +473,12 @@ export function buildChromeRules(background: string) {
       borderLeft: `3px solid ${colors.info}`,
       paddingLeft: '8px',
     },
+    '.cm-diagnostic-hint': {
+      borderLeft: `3px solid ${colors.foregroundMuted}`,
+      paddingLeft: '8px',
+    },
     '.cm-diagnosticSource': {
-      color: colors.foregroundMuted,
+      color: colors.foregroundSecondary,
       fontSize: '11px',
     },
     '.cm-diagnosticAction': {

--- a/frontend/src/components/StatusBar/EditorThemePicker.module.css
+++ b/frontend/src/components/StatusBar/EditorThemePicker.module.css
@@ -4,6 +4,7 @@
 }
 
 .select {
+  /* max-width hard-clips long labels; native <select> ignores text-overflow on WebKit. */
   max-width: 140px;
   background: transparent;
   border: none;
@@ -12,7 +13,6 @@
   font-size: 11px;
   padding: 0 4px;
   cursor: pointer;
-  text-overflow: ellipsis;
 }
 
 .select:hover {
@@ -28,16 +28,4 @@
 .select option {
   background: var(--surface-panel);
   color: var(--text-primary);
-}
-
-.srOnly {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
 }

--- a/frontend/src/components/StatusBar/EditorThemePicker.module.css
+++ b/frontend/src/components/StatusBar/EditorThemePicker.module.css
@@ -1,0 +1,43 @@
+.picker {
+  display: inline-flex;
+  align-items: center;
+}
+
+.select {
+  max-width: 140px;
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 11px;
+  padding: 0 4px;
+  cursor: pointer;
+  text-overflow: ellipsis;
+}
+
+.select:hover {
+  color: var(--text-primary);
+}
+
+.select:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
+  border-radius: 3px;
+}
+
+.select option {
+  background: var(--surface-panel);
+  color: var(--text-primary);
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/frontend/src/components/StatusBar/EditorThemePicker.module.css
+++ b/frontend/src/components/StatusBar/EditorThemePicker.module.css
@@ -1,11 +1,14 @@
 .picker {
+  position: relative;
   display: inline-flex;
   align-items: center;
 }
 
-.select {
-  /* max-width hard-clips long labels; native <select> ignores text-overflow on WebKit. */
-  max-width: 140px;
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 160px;
   background: transparent;
   border: none;
   color: var(--text-secondary);
@@ -15,17 +18,74 @@
   cursor: pointer;
 }
 
-.select:hover {
+.trigger:hover {
   color: var(--text-primary);
 }
 
-.select:focus-visible {
+.trigger:focus-visible {
   outline: 1px solid var(--accent);
   outline-offset: 1px;
   border-radius: 3px;
 }
 
-.select option {
+.triggerLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chevron {
+  font-size: 9px;
+  opacity: 0.8;
+}
+
+/* Opens upward — the status bar sits at the bottom of the window. No max-height,
+   so all themes are always visible (no OS-clipped scrollbar). */
+.menu {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  right: 0;
+  margin: 0;
+  padding: 4px;
+  min-width: 168px;
+  list-style: none;
   background: var(--surface-panel);
+  border: 1px solid var(--surface-border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+  z-index: 1000;
+}
+
+.option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px 5px 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  border-radius: 5px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.option:hover {
+  background: var(--surface-hover);
   color: var(--text-primary);
+}
+
+.option:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: -1px;
+}
+
+.optionSelected {
+  color: var(--text-primary);
+}
+
+.check {
+  display: inline-block;
+  width: 12px;
+  text-align: center;
+  color: var(--accent);
+  font-size: 11px;
 }

--- a/frontend/src/components/StatusBar/EditorThemePicker.tsx
+++ b/frontend/src/components/StatusBar/EditorThemePicker.tsx
@@ -1,0 +1,33 @@
+import styles from './EditorThemePicker.module.css';
+import { useEditorSyntaxTheme, useIDEStore } from '../../stores/ideStore';
+import { SYNTAX_THEMES, isSyntaxThemeId } from '../../components/Editor/codemirror/palettes';
+
+/**
+ * Compact editor-theme selector for the status bar. Global app state, so it is
+ * always rendered (independent of whether a file is open).
+ */
+export function EditorThemePicker() {
+  const active = useEditorSyntaxTheme();
+  const setTheme = useIDEStore((state) => state.setEditorSyntaxTheme);
+
+  return (
+    <label className={styles.picker}>
+      <span className={styles.srOnly}>Editor theme</span>
+      <select
+        aria-label="Editor theme"
+        className={styles.select}
+        value={active}
+        onChange={(event) => {
+          const value = event.target.value;
+          if (isSyntaxThemeId(value)) setTheme(value);
+        }}
+      >
+        {SYNTAX_THEMES.map((theme) => (
+          <option key={theme.id} value={theme.id}>
+            {theme.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/frontend/src/components/StatusBar/EditorThemePicker.tsx
+++ b/frontend/src/components/StatusBar/EditorThemePicker.tsx
@@ -11,8 +11,7 @@ export function EditorThemePicker() {
   const setTheme = useIDEStore((state) => state.setEditorSyntaxTheme);
 
   return (
-    <label className={styles.picker}>
-      <span className={styles.srOnly}>Editor theme</span>
+    <div className={styles.picker}>
       <select
         aria-label="Editor theme"
         className={styles.select}
@@ -28,6 +27,6 @@ export function EditorThemePicker() {
           </option>
         ))}
       </select>
-    </label>
+    </div>
   );
 }

--- a/frontend/src/components/StatusBar/EditorThemePicker.tsx
+++ b/frontend/src/components/StatusBar/EditorThemePicker.tsx
@@ -1,6 +1,10 @@
 import styles from './EditorThemePicker.module.css';
 import { useEditorSyntaxTheme, useIDEStore } from '../../stores/ideStore';
-import { SYNTAX_THEMES, isSyntaxThemeId } from '../../components/Editor/codemirror/palettes';
+import {
+  SYNTAX_THEMES,
+  SYNTAX_THEME_BY_ID,
+  isSyntaxThemeId,
+} from '../../components/Editor/codemirror/palettes';
 
 /**
  * Compact editor-theme selector for the status bar. Global app state, so it is
@@ -9,11 +13,13 @@ import { SYNTAX_THEMES, isSyntaxThemeId } from '../../components/Editor/codemirr
 export function EditorThemePicker() {
   const active = useEditorSyntaxTheme();
   const setTheme = useIDEStore((state) => state.setEditorSyntaxTheme);
+  const activeLabel = SYNTAX_THEME_BY_ID.get(active)?.label;
 
   return (
     <div className={styles.picker}>
       <select
         aria-label="Editor theme"
+        title={activeLabel}
         className={styles.select}
         value={active}
         onChange={(event) => {

--- a/frontend/src/components/StatusBar/EditorThemePicker.tsx
+++ b/frontend/src/components/StatusBar/EditorThemePicker.tsx
@@ -1,38 +1,124 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
 import styles from './EditorThemePicker.module.css';
 import { useEditorSyntaxTheme, useIDEStore } from '../../stores/ideStore';
 import {
   SYNTAX_THEMES,
   SYNTAX_THEME_BY_ID,
-  isSyntaxThemeId,
+  type SyntaxThemeId,
 } from '../../components/Editor/codemirror/palettes';
 
 /**
- * Compact editor-theme selector for the status bar. Global app state, so it is
- * always rendered (independent of whether a file is open).
+ * Editor-theme selector for the status bar. A custom popover (not a native
+ * `<select>`, which the OS height-clips into a scrollbar when anchored at the
+ * bottom of the window) so the full theme list always expands upward. Global app
+ * state, so it is always rendered regardless of whether a file is open.
  */
 export function EditorThemePicker() {
   const active = useEditorSyntaxTheme();
   const setTheme = useIDEStore((state) => state.setEditorSyntaxTheme);
-  const activeLabel = SYNTAX_THEME_BY_ID.get(active)?.label;
+  const activeLabel = SYNTAX_THEME_BY_ID.get(active)?.label ?? active;
+
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const optionRefs = useRef<Array<HTMLLIElement | null>>([]);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  // Close on click outside the picker.
+  useEffect(() => {
+    if (!open) return;
+    const onPointer = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        close();
+      }
+    };
+    document.addEventListener('mousedown', onPointer);
+    return () => document.removeEventListener('mousedown', onPointer);
+  }, [open, close]);
+
+  // Move focus to the active option when the menu opens.
+  useEffect(() => {
+    if (!open) return;
+    const index = SYNTAX_THEMES.findIndex((theme) => theme.id === active);
+    optionRefs.current[Math.max(0, index)]?.focus();
+  }, [open, active]);
+
+  const choose = useCallback(
+    (id: SyntaxThemeId) => {
+      setTheme(id);
+      setOpen(false);
+    },
+    [setTheme]
+  );
+
+  const moveFocus = (from: number, delta: number) => {
+    const count = SYNTAX_THEMES.length;
+    optionRefs.current[(from + delta + count) % count]?.focus();
+  };
 
   return (
-    <div className={styles.picker}>
-      <select
+    <div className={styles.picker} ref={containerRef}>
+      <button
+        type="button"
+        className={styles.trigger}
         aria-label="Editor theme"
+        aria-haspopup="listbox"
+        aria-expanded={open}
         title={activeLabel}
-        className={styles.select}
-        value={active}
-        onChange={(event) => {
-          const value = event.target.value;
-          if (isSyntaxThemeId(value)) setTheme(value);
+        onClick={() => setOpen((value) => !value)}
+        onKeyDown={(event) => {
+          if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+            event.preventDefault();
+            setOpen(true);
+          }
         }}
       >
-        {SYNTAX_THEMES.map((theme) => (
-          <option key={theme.id} value={theme.id}>
-            {theme.label}
-          </option>
-        ))}
-      </select>
+        <span className={styles.triggerLabel}>{activeLabel}</span>
+        <span className={styles.chevron} aria-hidden="true">
+          ▾
+        </span>
+      </button>
+
+      {open && (
+        <ul className={styles.menu} role="listbox" aria-label="Editor theme" tabIndex={-1}>
+          {SYNTAX_THEMES.map((theme, index) => {
+            const selected = theme.id === active;
+            return (
+              <li
+                key={theme.id}
+                ref={(element) => {
+                  optionRefs.current[index] = element;
+                }}
+                role="option"
+                aria-selected={selected}
+                tabIndex={selected ? 0 : -1}
+                className={`${styles.option} ${selected ? styles.optionSelected : ''}`}
+                onClick={() => choose(theme.id)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    choose(theme.id);
+                  } else if (event.key === 'ArrowDown') {
+                    event.preventDefault();
+                    moveFocus(index, 1);
+                  } else if (event.key === 'ArrowUp') {
+                    event.preventDefault();
+                    moveFocus(index, -1);
+                  } else if (event.key === 'Escape') {
+                    event.preventDefault();
+                    close();
+                  }
+                }}
+              >
+                <span className={styles.check} aria-hidden="true">
+                  {selected ? '✓' : ''}
+                </span>
+                {theme.label}
+              </li>
+            );
+          })}
+        </ul>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/StatusBar/StatusBar.tsx
+++ b/frontend/src/components/StatusBar/StatusBar.tsx
@@ -2,6 +2,7 @@ import styles from './StatusBar.module.css';
 import { StatusBranchIcon, CheckIcon, AlertCircleIcon } from '../icons';
 import { useGitBranch, useActiveFile, useCursorPosition } from '../../stores/ideStore';
 import { useLSPErrorCount, useLSPInfoCount, useLSPWarningCount } from '../../stores/lspStore';
+import { EditorThemePicker } from './EditorThemePicker';
 
 export function StatusBar() {
   const gitBranch = useGitBranch();
@@ -24,6 +25,7 @@ export function StatusBar() {
       </div>
       <div className={styles.spacer} />
       <div className={styles.right}>
+        <EditorThemePicker />
         {activeFile && (
           <>
             <span className={styles.item}>{activeFile.language || 'Plain Text'}</span>

--- a/frontend/src/stores/ideStore.ts
+++ b/frontend/src/stores/ideStore.ts
@@ -18,6 +18,23 @@ import { MAX_OUTPUT_ENTRIES, ALL_PROFILES_ID } from '../types/runOutput';
 import { parseCompoundStepKey } from '../utils/compoundRunKeys';
 import { estimateDuration, estimateRemaining } from '../utils/estimateCompletion';
 import { parseFileReferences } from '../utils/parseFileReferences';
+import {
+  type SyntaxThemeId,
+  DEFAULT_SYNTAX_THEME_ID,
+  isSyntaxThemeId,
+} from '../components/Editor/codemirror/palettes';
+
+const SYNTAX_THEME_STORAGE_KEY = 'firn.editorSyntaxTheme';
+
+function loadInitialSyntaxTheme(): SyntaxThemeId {
+  try {
+    const raw =
+      typeof localStorage !== 'undefined' ? localStorage.getItem(SYNTAX_THEME_STORAGE_KEY) : null;
+    return isSyntaxThemeId(raw) ? raw : DEFAULT_SYNTAX_THEME_ID;
+  } catch {
+    return DEFAULT_SYNTAX_THEME_ID;
+  }
+}
 
 // Types
 export type SidebarView = 'explorer' | 'search' | 'git' | 'run';
@@ -175,6 +192,7 @@ interface IDEState {
 
   // Status
   gitBranch: string;
+  editorSyntaxTheme: SyntaxThemeId;
 
   // Editor navigation
   pendingEditorNavigation: EditorNavigationRequest | null;
@@ -281,6 +299,7 @@ interface IDEActions {
 
   // Status actions
   setGitBranch: (branch: string) => void;
+  setEditorSyntaxTheme: (id: SyntaxThemeId) => void;
 
   // Editor navigation actions
   requestEditorNavigation: (fileId: string, line: number, column: number) => void;
@@ -403,6 +422,7 @@ export const useIDEStore = create<IDEStore>()(
       recentWorkspaces: [],
       recentWorkspacesVersion: 0,
       gitBranch: '',
+      editorSyntaxTheme: loadInitialSyntaxTheme(),
       pendingEditorNavigation: null,
 
       // Workspace actions
@@ -1479,6 +1499,18 @@ export const useIDEStore = create<IDEStore>()(
       // Status actions
       setGitBranch: (gitBranch) => set({ gitBranch }, false, 'setGitBranch'),
 
+      setEditorSyntaxTheme: (id) => {
+        if (!isSyntaxThemeId(id)) return;
+        try {
+          if (typeof localStorage !== 'undefined') {
+            localStorage.setItem(SYNTAX_THEME_STORAGE_KEY, id);
+          }
+        } catch {
+          // localStorage may be unavailable (private mode / WebView quirks); state still updates.
+        }
+        set({ editorSyntaxTheme: id }, false, 'setEditorSyntaxTheme');
+      },
+
       // Editor navigation actions
       requestEditorNavigation: (fileId, line, column) =>
         set(
@@ -1595,6 +1627,8 @@ export const useActiveTerminalSession = () =>
     return id ? (state.terminalSessions.find((s) => s.id === id) ?? null) : null;
   });
 export const useGitBranch = () => useIDEStore((state) => state.gitBranch);
+export const useEditorSyntaxTheme = (): SyntaxThemeId =>
+  useIDEStore((state) => state.editorSyntaxTheme);
 export const useDirectoryTree = () => useIDEStore((state) => state.directoryTree);
 export const useExpandedPaths = () => useIDEStore((state) => state.expandedPaths);
 export const useSelectedPath = () => useIDEStore((state) => state.selectedPath);

--- a/frontend/src/stores/ideStore.ts
+++ b/frontend/src/stores/ideStore.ts
@@ -26,7 +26,7 @@ import {
 
 const SYNTAX_THEME_STORAGE_KEY = 'firn.editorSyntaxTheme';
 
-function loadInitialSyntaxTheme(): SyntaxThemeId {
+export function loadInitialSyntaxTheme(): SyntaxThemeId {
   try {
     const raw =
       typeof localStorage !== 'undefined' ? localStorage.getItem(SYNTAX_THEME_STORAGE_KEY) : null;
@@ -1501,6 +1501,7 @@ export const useIDEStore = create<IDEStore>()(
 
       setEditorSyntaxTheme: (id) => {
         if (!isSyntaxThemeId(id)) return;
+        set({ editorSyntaxTheme: id }, false, 'setEditorSyntaxTheme');
         try {
           if (typeof localStorage !== 'undefined') {
             localStorage.setItem(SYNTAX_THEME_STORAGE_KEY, id);
@@ -1508,7 +1509,6 @@ export const useIDEStore = create<IDEStore>()(
         } catch {
           // localStorage may be unavailable (private mode / WebView quirks); state still updates.
         }
-        set({ editorSyntaxTheme: id }, false, 'setEditorSyntaxTheme');
       },
 
       // Editor navigation actions


### PR DESCRIPTION
## Summary
Closes #113, Closes #114.

Replaces the single Firn Glacier editor theme with a **selectable syntax-theme system** and gives the diagnostic lint tooltip an opaque surface.

### #114 — Selectable syntax theme system
- **`palettes.ts`** (new): pure registry of **7 themes** — Firn Glacier (refined), Solar Flare, Tropic Coral Reef, Nebula Jewel, Ember Bifrost, Aurora Bloom, and the default **Abyssal Current** (deeper `#08111C` canvas). `SyntaxPalette` + `isSyntaxThemeId` + helpers; no React/CM imports (cycle-safe).
- **`theme.ts`**: refactored into builders — `buildHighlightSpec`/`buildHighlightStyle` (token colors), `buildChromeRules`/`buildChrome` (chrome; canvas bg from the palette), `buildTheme(id)` (memoized). Legacy aliases kept.
- **Live switching** via the existing `themeCompartment` — no editor remount; cursor/scroll/undo preserved.
- **StatusBar picker**: a custom popover (native `<select>` gets OS-clipped at the window bottom) that opens upward, shows all 7, keyboard + `aria-listbox` accessible.
- **Persistence**: global preference in `localStorage` (`firn.editorSyntaxTheme`), validated on hydrate.
- **Gutter**: palette-tinted line numbers (was a fixed gray) + sized to content (no wide empty gutter).
- **Python highlight overlay** (`pythonHighlight.ts`, scoped to `.py`): lezer tags `self`/`cls`, builtins (`dict`/`str`/`float`/…), decorator names, and kwarg names all as plain `VariableName` — a syntax-tree decoration overlay (at `Prec.highest`) marks them with palette-driven classes so they're distinguishable. Dedicated `decorator`/`param` palette roles tuned per theme for contrast.

### #113 — Diagnostic tooltip surface
The lint tooltip (`.cm-tooltip-lint`, rendered inside the intentionally-transparent `.cm-tooltip-hover`) now gets an opaque surface — background, border, padding, shadow, z-index — with per-severity (error/warning/info/hint) left-accent borders from the shared chrome tokens.

## Test plan
- Jest **882 passing**; `tsc --noEmit` clean (pre-existing TS5107 deprecation aside); `eslint` 0 errors.
- In-app (Wails) confirmed: live theme switching, Python overlay coloring (self/builtins/decorators/kwargs), picker popover, gutter, persistence across reload, opaque diagnostic tooltip.

## Deferred (follow-ups, non-blocking)
- Per-workspace theme override (Go workspace field + bindings) — global ships here.
- Prune now-test-only legacy theme aliases; dedup the stale syntax subset in `theme.ts` `colors`.
- Hover/completion code-sample colors stay Glacier-fixed (documented).
- Per-theme darker-canvas toggle for non-Abyssal themes.

Generated with [Claude Code](https://claude.com/claude-code)
