### PR TITLE
fix(ui): duplicate file-tree scrollbar + stray tab-bar scrollbar

### DIFF
--- a/frontend/src/components/Editor/Editor.module.css
+++ b/frontend/src/components/Editor/Editor.module.css
@@ -25,12 +25,17 @@
   background: var(--surface-tab-bar);
   flex-shrink: 0;
   min-height: 38px;
+  /* overflow-x: auto forces overflow-y to compute to auto too (CSS spec), which
+     showed a stray vertical scrollbar when tabs slightly exceed the bar height.
+     Pin the cross axis hidden and fully suppress the (still-scrollable) x-bar. */
   overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
   border-bottom: none;
 }
 
 .tabBar::-webkit-scrollbar {
-  height: 0;
+  display: none;
 }
 
 /* ═══════════════════════════════════════════════════════════════

--- a/frontend/src/components/FileExplorer/FileExplorer.module.css
+++ b/frontend/src/components/FileExplorer/FileExplorer.module.css
@@ -36,9 +36,20 @@
   color: var(--text-muted);
 }
 
+/* Flex column filling the Panel content so only the inner .scrollArea scrolls.
+   Without this, the workspace tabs + a height:100% tree overflow the Panel's
+   own overflow:auto content, producing a second (outer) scrollbar. */
+.explorerBody {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .tree {
   padding: 4px;
-  height: 100%;
+  flex: 1;
   min-height: 0;
   overflow: hidden;
   box-sizing: border-box;

--- a/frontend/src/components/FileExplorer/FileExplorer.tsx
+++ b/frontend/src/components/FileExplorer/FileExplorer.tsx
@@ -237,8 +237,10 @@ export function FileExplorer() {
         />
       }
     >
-      {mode === 'workspace' && <WorkspaceTabs />}
-      <div className={styles.tree}>{renderContent()}</div>
+      <div className={styles.explorerBody}>
+        {mode === 'workspace' && <WorkspaceTabs />}
+        <div className={styles.tree}>{renderContent()}</div>
+      </div>
     </Panel>
   );
 }


### PR DESCRIPTION
## Summary
Two pre-existing layout fixes (CSS + one wrapper element).

**File tree — duplicate scrollbar.** The Panel's shared `.content { overflow: auto }` was scrolling in addition to the virtualizer's own `.scrollArea`, because FileExplorer stacked `<WorkspaceTabs>` and a `height: 100%` `.tree` as siblings inside `.content`, overflowing it. Wrap the body in a flex column (`.explorerBody`) and make `.tree` `flex: 1`, so only the inner `.scrollArea` scrolls.

**Editor tab bar — stray scrollbar.** `.tabBar { overflow-x: auto }` makes `overflow-y` compute to `auto` (CSS spec), so tabs slightly taller than the 38px bar produced a vertical scrollbar that the existing `::-webkit-scrollbar { height: 0 }` didn't hide. Pin `overflow-y: hidden` and fully suppress the (still-scrollable) horizontal scrollbar.

## Test plan
- Jest: FileExplorer + Editor suites 138 passing; `tsc --noEmit` clean; `eslint` 0 errors.
- In-app (Wails): single scrollbar in the file tree; no scrollbar on the tab bar (horizontal scroll still works).

Generated with [Claude Code](https://claude.com/claude-code)
