### PR TITLE
[codex] Restore theme picker keyboard focus

### DIFF
--- a/frontend/src/__tests__/components/EditorThemePicker.test.tsx
+++ b/frontend/src/__tests__/components/EditorThemePicker.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { EditorThemePicker } from '../../components/StatusBar/EditorThemePicker';
 import { useIDEStore } from '../../stores/ideStore';
 import { SYNTAX_THEMES } from '../../components/Editor/codemirror/palettes';
@@ -11,7 +12,7 @@ describe('EditorThemePicker', () => {
 
   it('shows the active theme label and is collapsed by default', () => {
     render(<EditorThemePicker />);
-    const trigger = screen.getByLabelText('Editor theme');
+    const trigger = screen.getByRole('button', { name: 'Editor theme' });
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
     expect(trigger).toHaveTextContent('Abyssal Current');
     expect(screen.queryByRole('listbox')).toBeNull();
@@ -19,7 +20,7 @@ describe('EditorThemePicker', () => {
 
   it('opens a listbox of all themes on click, marking the active one', () => {
     render(<EditorThemePicker />);
-    fireEvent.click(screen.getByLabelText('Editor theme'));
+    fireEvent.click(screen.getByRole('button', { name: 'Editor theme' }));
     const options = screen.getAllByRole('option');
     expect(options).toHaveLength(SYNTAX_THEMES.length);
     const selected = options.find((option) => option.getAttribute('aria-selected') === 'true');
@@ -28,9 +29,54 @@ describe('EditorThemePicker', () => {
 
   it('selecting an option updates the store and closes the menu', () => {
     render(<EditorThemePicker />);
-    fireEvent.click(screen.getByLabelText('Editor theme'));
+    fireEvent.click(screen.getByRole('button', { name: 'Editor theme' }));
     fireEvent.click(screen.getByText('Tropic Coral Reef'));
     expect(useIDEStore.getState().editorSyntaxTheme).toBe('reef');
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('restores focus to the trigger when closed with Escape', () => {
+    render(<EditorThemePicker />);
+    const trigger = screen.getByRole('button', { name: 'Editor theme' });
+    fireEvent.click(trigger);
+
+    const selected = screen.getByRole('option', { selected: true });
+    expect(selected).toHaveFocus();
+
+    fireEvent.keyDown(selected, { key: 'Escape' });
+
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(trigger).toHaveFocus();
+  });
+
+  it('restores focus to the trigger after keyboard selection', () => {
+    render(<EditorThemePicker />);
+    const trigger = screen.getByRole('button', { name: 'Editor theme' });
+    fireEvent.click(trigger);
+
+    const reef = screen.getByText('Tropic Coral Reef');
+    reef.focus();
+    fireEvent.keyDown(reef, { key: 'Enter' });
+
+    expect(useIDEStore.getState().editorSyntaxTheme).toBe('reef');
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(trigger).toHaveFocus();
+  });
+
+  it('closes the menu when keyboard focus leaves the picker', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <EditorThemePicker />
+        <button type="button">After picker</button>
+      </>
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Editor theme' }));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    await user.tab();
+
+    expect(screen.getByRole('button', { name: 'After picker' })).toHaveFocus();
     expect(screen.queryByRole('listbox')).toBeNull();
   });
 });

--- a/frontend/src/components/StatusBar/EditorThemePicker.tsx
+++ b/frontend/src/components/StatusBar/EditorThemePicker.tsx
@@ -20,9 +20,13 @@ export function EditorThemePicker() {
 
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const optionRefs = useRef<Array<HTMLLIElement | null>>([]);
 
-  const close = useCallback(() => setOpen(false), []);
+  const close = useCallback((restoreFocus = false) => {
+    setOpen(false);
+    if (restoreFocus) triggerRef.current?.focus();
+  }, []);
 
   // Close on click outside the picker.
   useEffect(() => {
@@ -46,9 +50,9 @@ export function EditorThemePicker() {
   const choose = useCallback(
     (id: SyntaxThemeId) => {
       setTheme(id);
-      setOpen(false);
+      close(true);
     },
-    [setTheme]
+    [close, setTheme]
   );
 
   const moveFocus = (from: number, delta: number) => {
@@ -57,9 +61,19 @@ export function EditorThemePicker() {
   };
 
   return (
-    <div className={styles.picker} ref={containerRef}>
+    <div
+      className={styles.picker}
+      ref={containerRef}
+      onBlur={(event) => {
+        if (!open) return;
+        const nextTarget = event.relatedTarget;
+        if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
+        close();
+      }}
+    >
       <button
         type="button"
+        ref={triggerRef}
         className={styles.trigger}
         aria-label="Editor theme"
         aria-haspopup="listbox"
@@ -106,7 +120,7 @@ export function EditorThemePicker() {
                     moveFocus(index, -1);
                   } else if (event.key === 'Escape') {
                     event.preventDefault();
-                    close();
+                    close(true);
                   }
                 }}
               >


### PR DESCRIPTION
## Summary

Fixes the StatusBar editor theme picker keyboard focus lifecycle after the theme-system PR landed.

- restores focus to the picker trigger when closing with Escape
- restores focus to the trigger after keyboard selection
- closes the popover when keyboard focus leaves the picker
- adds regression coverage for Escape, Enter selection, and Tab/focus-leave behavior

## Root cause

The custom listbox moved focus into an option when opened, but closing the menu unmounted that focused option without returning focus to the trigger. It also only closed on outside mouse interaction, so keyboard focus could leave the picker while the popover stayed open.

## Validation

- `npm test -- EditorThemePicker.test.tsx --runInBand` — 6 passed
- `npm exec tsc -- --noEmit --pretty false` — passed
- `npm test -- --runInBand` — 83 suites / 885 tests passed
- `npm run lint` — exit 0, 10 existing unrelated warnings
- `git diff --check` — clean
