### PR TITLE
feat(lsp): Python environment auto-wiring (#112 Phase 1)

### DIFF
--- a/frontend/src/__tests__/components/Editor/CodeMirrorEditor.test.tsx
+++ b/frontend/src/__tests__/components/Editor/CodeMirrorEditor.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 
 type DispatchSpec = {
   selection?: { anchor: number };
@@ -254,5 +254,22 @@ describe('CodeMirrorEditor', () => {
         },
       ],
     });
+  });
+
+  it('renders the LSP setup card when a python file reports a missing interpreter', async () => {
+    render(<CodeMirrorEditor fileId="/project/app.py" filename="app.py" content="x = 1" />);
+
+    act(() => {
+      useIDEStore.getState().setWorkspace({ name: 'project', path: '/project' });
+      useLSPStore.getState().setServerStatus({
+        family: 'python',
+        workspace: '/project',
+        state: 'ready',
+        setupState: 'missing_interpreter',
+        action: 'create_venv',
+      });
+    });
+
+    await waitFor(() => expect(screen.getByText(/no python interpreter/i)).toBeInTheDocument());
   });
 });

--- a/frontend/src/__tests__/components/Editor/CodeMirrorEditor.test.tsx
+++ b/frontend/src/__tests__/components/Editor/CodeMirrorEditor.test.tsx
@@ -272,4 +272,31 @@ describe('CodeMirrorEditor', () => {
 
     await waitFor(() => expect(screen.getByText(/no python interpreter/i)).toBeInTheDocument());
   });
+
+  it('clears the LSP setup card when reused for a file without an LSP family', async () => {
+    const { rerender } = render(
+      <CodeMirrorEditor fileId="/project/app.py" filename="app.py" content="x = 1" />
+    );
+
+    act(() => {
+      useIDEStore.getState().setWorkspace({ name: 'project', path: '/project' });
+      useLSPStore.getState().setServerStatus({
+        family: 'python',
+        workspace: '/project',
+        state: 'ready',
+        setupState: 'missing_interpreter',
+        action: 'create_venv',
+      });
+    });
+
+    await waitFor(() => expect(screen.getByText(/no python interpreter/i)).toBeInTheDocument());
+
+    rerender(
+      <CodeMirrorEditor fileId="/project/README.md" filename="README.md" content="# Docs" />
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText(/no python interpreter/i)).not.toBeInTheDocument()
+    );
+  });
 });

--- a/frontend/src/__tests__/components/Editor/LSPSetupCard.test.tsx
+++ b/frontend/src/__tests__/components/Editor/LSPSetupCard.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { describeSetup, LSPSetupCard } from '../../../components/Editor/LSPSetupCard';
+import type { LSPServerStatus } from '../../../stores/lspStore';
+
+function status(overrides: Partial<LSPServerStatus>): LSPServerStatus {
+  return { family: 'python', workspace: '/proj', state: 'ready', ...overrides };
+}
+
+describe('describeSetup', () => {
+  it('returns null when ready', () => {
+    expect(describeSetup(status({ setupState: 'ready' }))).toBeNull();
+  });
+
+  it('returns null when setupState is absent', () => {
+    expect(describeSetup(status({}))).toBeNull();
+  });
+
+  it('describes a missing interpreter with a venv hint', () => {
+    const notice = describeSetup(status({ setupState: 'missing_interpreter' }));
+    expect(notice).not.toBeNull();
+    expect(notice!.tone).toBe('warning');
+    expect(notice!.hint.toLowerCase()).toContain('venv');
+  });
+
+  it('describes a missing server as an error', () => {
+    const notice = describeSetup(status({ setupState: 'missing_server' }));
+    expect(notice!.tone).toBe('error');
+  });
+});
+
+describe('LSPSetupCard', () => {
+  it('renders nothing when ready', () => {
+    const { container } = render(<LSPSetupCard status={status({ setupState: 'ready' })} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the message and hint for missing_interpreter', () => {
+    render(<LSPSetupCard status={status({ setupState: 'missing_interpreter' })} />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByText(/no python interpreter/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/Editor/LSPSetupCard.test.tsx
+++ b/frontend/src/__tests__/components/Editor/LSPSetupCard.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import { describeSetup, LSPSetupCard } from '../../../components/Editor/LSPSetupCard';
+import { LSPSetupCard } from '../../../components/Editor/LSPSetupCard';
+import { describeSetup } from '../../../components/Editor/lspSetupNotice';
 import type { LSPServerStatus } from '../../../stores/lspStore';
 
 function status(overrides: Partial<LSPServerStatus>): LSPServerStatus {

--- a/frontend/src/__tests__/hooks/useLSPEvents.test.ts
+++ b/frontend/src/__tests__/hooks/useLSPEvents.test.ts
@@ -173,6 +173,26 @@ describe('useLSPEvents', () => {
     expect(toast!.message).toContain('typescript-language-server not found');
   });
 
+  it('does not show a raw Toast when lsp:status carries typed setup status', () => {
+    const handlers = captureEventHandlers();
+    renderHook(() => useLSPEvents());
+
+    act(() => {
+      handlers['lsp:status']({
+        family: 'python',
+        workspace: '/project',
+        state: 'error',
+        error: 'pyright-langserver not found: install it with "npm install -g pyright"',
+        setupState: 'missing_server',
+        detailCode: 'server_not_found',
+      });
+    });
+
+    const status = useLSPStore.getState().serverStatuses.get('/project::python');
+    expect(status?.setupState).toBe('missing_server');
+    expect(useIDEStore.getState().toast).toBeNull();
+  });
+
   it('does not show Toast on non-error lsp:status events', () => {
     const handlers = captureEventHandlers();
     renderHook(() => useLSPEvents());

--- a/frontend/src/components/Editor/CodeMirrorEditor.module.css
+++ b/frontend/src/components/Editor/CodeMirrorEditor.module.css
@@ -5,7 +5,16 @@
  * seamlessly with the Firn Glacier theme.
  */
 
+.editorRoot {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
 .container {
+  flex: 1;
+  min-height: 0;
   width: 100%;
   height: 100%;
   overflow: hidden;

--- a/frontend/src/components/Editor/CodeMirrorEditor.tsx
+++ b/frontend/src/components/Editor/CodeMirrorEditor.tsx
@@ -262,7 +262,10 @@ export const CodeMirrorEditor = memo(function CodeMirrorEditor({
   // Enable LSP completion/hover when the matching server becomes ready.
   useEffect(() => {
     const family = lspFamilyForFile(filename);
-    if (!family) return;
+    if (!family) {
+      setSetupStatus(undefined);
+      return;
+    }
 
     let lastConfigKey: string | null = null;
 

--- a/frontend/src/components/Editor/CodeMirrorEditor.tsx
+++ b/frontend/src/components/Editor/CodeMirrorEditor.tsx
@@ -11,7 +11,7 @@
  * - Proper cleanup on unmount
  */
 
-import { useEffect, useRef, useCallback, memo } from 'react';
+import { useEffect, useRef, useCallback, memo, useState } from 'react';
 import {
   EditorView,
   EditorState,
@@ -26,6 +26,8 @@ import {
 } from './codemirror';
 import { useIDEStore, type EditorNavigationRequest } from '../../stores/ideStore';
 import { useLSPStore, findServerStatusForFile } from '../../stores/lspStore';
+import type { LSPServerStatus } from '../../stores/lspStore';
+import { LSPSetupCard } from './LSPSetupCard';
 import { filePathToURI } from '../../utils/lspUri';
 import { lspFamilyForFile } from '../../utils/lspLanguageId';
 import styles from './CodeMirrorEditor.module.css';
@@ -85,6 +87,8 @@ export const CodeMirrorEditor = memo(function CodeMirrorEditor({
   const hasAppliedInitialScrollRef = useRef(false);
   // Flag to skip onChange during external content sync
   const isSyncingRef = useRef(false);
+
+  const [setupStatus, setSetupStatus] = useState<LSPServerStatus | undefined>(undefined);
 
   // Keep refs in sync
   fileIdRef.current = fileId;
@@ -270,6 +274,7 @@ export const CodeMirrorEditor = memo(function CodeMirrorEditor({
       // Status lookup is by file path so nested project-root servers (#20)
       // drive completion/hover correctly inside monorepo packages.
       const status = findServerStatusForFile(useLSPStore.getState().serverStatuses, fileId, family);
+      setSetupStatus(status);
       const isReady = status?.state === 'ready';
       const triggerCharacters = status?.completionTriggerCharacters ?? [];
       const nextConfigKey = isReady
@@ -340,7 +345,12 @@ export const CodeMirrorEditor = memo(function CodeMirrorEditor({
     return cancel;
   }, [fileId]);
 
-  return <div ref={containerRef} className={styles.container} data-testid="codemirror-editor" />;
+  return (
+    <div className={styles.editorRoot}>
+      <LSPSetupCard status={setupStatus} />
+      <div ref={containerRef} className={styles.container} data-testid="codemirror-editor" />
+    </div>
+  );
 });
 
 CodeMirrorEditor.displayName = 'CodeMirrorEditor';

--- a/frontend/src/components/Editor/LSPSetupCard.module.css
+++ b/frontend/src/components/Editor/LSPSetupCard.module.css
@@ -1,0 +1,27 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px 12px;
+  font-size: 12px;
+  line-height: 1.4;
+  border-bottom: 1px solid var(--surface-border);
+  background: var(--surface-elevated);
+}
+
+.error {
+  border-left: 3px solid var(--status-error);
+}
+
+.warning {
+  border-left: 3px solid var(--status-warning);
+}
+
+.message {
+  color: var(--text-primary, #e6e6e6);
+  font-weight: 500;
+}
+
+.hint {
+  color: var(--text-secondary, #9a9a9a);
+}

--- a/frontend/src/components/Editor/LSPSetupCard.tsx
+++ b/frontend/src/components/Editor/LSPSetupCard.tsx
@@ -1,56 +1,6 @@
 import type { LSPServerStatus } from '../../stores/lspStore';
+import { describeSetup } from './lspSetupNotice';
 import styles from './LSPSetupCard.module.css';
-
-export interface LSPSetupNotice {
-  message: string;
-  hint: string;
-  tone: 'error' | 'warning';
-}
-
-/**
- * Maps a server's typed setup status onto a user-facing message + next-step
- * hint. Returns null when there is nothing actionable to show (server ready,
- * or no setup state reported). Phase 1 surfaces guidance text only; the
- * interactive interpreter picker is a follow-up.
- */
-export function describeSetup(status: LSPServerStatus | undefined): LSPSetupNotice | null {
-  if (!status?.setupState || status.setupState === 'ready') return null;
-
-  switch (status.setupState) {
-    case 'missing_server':
-      return {
-        message: `Language server not found for ${status.family}.`,
-        hint: 'Install it (e.g. pyright) or add it as a project dependency, then reopen the file.',
-        tone: 'error',
-      };
-    case 'missing_interpreter':
-      return {
-        message: 'No Python interpreter found - imports and types cannot be checked.',
-        hint: 'Create a virtual environment (uv sync, or python -m venv .venv) and reopen the file.',
-        tone: 'warning',
-      };
-    case 'misconfigured_env':
-      return {
-        message: 'Python environment looks incomplete - diagnostics may be unreliable.',
-        hint: 'Check that your .venv contains a Python interpreter.',
-        tone: 'warning',
-      };
-    case 'config_degraded':
-      return {
-        message: `Using a fallback interpreter${status.interpreterPath ? ` (${status.interpreterPath})` : ''}.`,
-        hint: 'Create or activate a project virtual environment for accurate import/version checks.',
-        tone: 'warning',
-      };
-    case 'retryable':
-      return {
-        message: 'The language server failed to start.',
-        hint: 'Reopen the file to retry.',
-        tone: 'error',
-      };
-    default:
-      return null;
-  }
-}
 
 export function LSPSetupCard({ status }: { status: LSPServerStatus | undefined }) {
   const notice = describeSetup(status);

--- a/frontend/src/components/Editor/LSPSetupCard.tsx
+++ b/frontend/src/components/Editor/LSPSetupCard.tsx
@@ -1,0 +1,64 @@
+import type { LSPServerStatus } from '../../stores/lspStore';
+import styles from './LSPSetupCard.module.css';
+
+export interface LSPSetupNotice {
+  message: string;
+  hint: string;
+  tone: 'error' | 'warning';
+}
+
+/**
+ * Maps a server's typed setup status onto a user-facing message + next-step
+ * hint. Returns null when there is nothing actionable to show (server ready,
+ * or no setup state reported). Phase 1 surfaces guidance text only; the
+ * interactive interpreter picker is a follow-up.
+ */
+export function describeSetup(status: LSPServerStatus | undefined): LSPSetupNotice | null {
+  if (!status?.setupState || status.setupState === 'ready') return null;
+
+  switch (status.setupState) {
+    case 'missing_server':
+      return {
+        message: `Language server not found for ${status.family}.`,
+        hint: 'Install it (e.g. pyright) or add it as a project dependency, then reopen the file.',
+        tone: 'error',
+      };
+    case 'missing_interpreter':
+      return {
+        message: 'No Python interpreter found - imports and types cannot be checked.',
+        hint: 'Create a virtual environment (uv sync, or python -m venv .venv) and reopen the file.',
+        tone: 'warning',
+      };
+    case 'misconfigured_env':
+      return {
+        message: 'Python environment looks incomplete - diagnostics may be unreliable.',
+        hint: 'Check that your .venv contains a Python interpreter.',
+        tone: 'warning',
+      };
+    case 'config_degraded':
+      return {
+        message: `Using a fallback interpreter${status.interpreterPath ? ` (${status.interpreterPath})` : ''}.`,
+        hint: 'Create or activate a project virtual environment for accurate import/version checks.',
+        tone: 'warning',
+      };
+    case 'retryable':
+      return {
+        message: 'The language server failed to start.',
+        hint: 'Reopen the file to retry.',
+        tone: 'error',
+      };
+    default:
+      return null;
+  }
+}
+
+export function LSPSetupCard({ status }: { status: LSPServerStatus | undefined }) {
+  const notice = describeSetup(status);
+  if (!notice) return null;
+  return (
+    <div role="status" aria-live="polite" className={`${styles.card} ${styles[notice.tone]}`}>
+      <span className={styles.message}>{notice.message}</span>
+      <span className={styles.hint}>{notice.hint}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/Editor/lspSetupNotice.ts
+++ b/frontend/src/components/Editor/lspSetupNotice.ts
@@ -1,0 +1,52 @@
+import type { LSPServerStatus } from '../../stores/lspStore';
+
+export interface LSPSetupNotice {
+  message: string;
+  hint: string;
+  tone: 'error' | 'warning';
+}
+
+/**
+ * Maps a server's typed setup status onto a user-facing message + next-step
+ * hint. Returns null when there is nothing actionable to show (server ready,
+ * or no setup state reported). Phase 1 surfaces guidance text only; the
+ * interactive interpreter picker is a follow-up.
+ */
+export function describeSetup(status: LSPServerStatus | undefined): LSPSetupNotice | null {
+  if (!status?.setupState || status.setupState === 'ready') return null;
+
+  switch (status.setupState) {
+    case 'missing_server':
+      return {
+        message: `Language server not found for ${status.family}.`,
+        hint: 'Install it (e.g. pyright) or add it as a project dependency, then reopen the file.',
+        tone: 'error',
+      };
+    case 'missing_interpreter':
+      return {
+        message: 'No Python interpreter found - imports and types cannot be checked.',
+        hint: 'Create a virtual environment (uv sync, or python -m venv .venv) and reopen the file.',
+        tone: 'warning',
+      };
+    case 'misconfigured_env':
+      return {
+        message: 'Python environment looks incomplete - diagnostics may be unreliable.',
+        hint: 'Check that your .venv contains a Python interpreter.',
+        tone: 'warning',
+      };
+    case 'config_degraded':
+      return {
+        message: `Using a fallback interpreter${status.interpreterPath ? ` (${status.interpreterPath})` : ''}.`,
+        hint: 'Create or activate a project virtual environment for accurate import/version checks.',
+        tone: 'warning',
+      };
+    case 'retryable':
+      return {
+        message: 'The language server failed to start.',
+        hint: 'Reopen the file to retry.',
+        tone: 'error',
+      };
+    default:
+      return null;
+  }
+}

--- a/frontend/src/hooks/useLSPEvents.ts
+++ b/frontend/src/hooks/useLSPEvents.ts
@@ -74,7 +74,9 @@ export function useLSPEvents() {
 
       useLSPStore.getState().setServerStatus(payload);
 
-      if (payload.state === 'error' && payload.error) {
+      const hasTypedSetupStatus = Boolean(payload.setupState);
+
+      if (payload.state === 'error' && payload.error && !hasTypedSetupStatus) {
         // Deduplicate: only toast once per workspace::family error state
         const dedupeKey = `${payload.workspace}::${payload.family}`;
         if (!toastedErrors.current.has(dedupeKey)) {

--- a/frontend/src/stores/lspStore.ts
+++ b/frontend/src/stores/lspStore.ts
@@ -52,7 +52,7 @@ export type LSPSetupState =
   | 'config_degraded'
   | 'retryable';
 
-export type LSPSetupAction = 'create_venv' | 'select_interpreter' | 'retry' | '';
+export type LSPSetupAction = 'create_venv' | 'select_interpreter' | 'retry';
 
 export interface LSPServerStatus {
   family: string;

--- a/frontend/src/stores/lspStore.ts
+++ b/frontend/src/stores/lspStore.ts
@@ -44,6 +44,16 @@ export interface LSPDiagnostic {
   message: string;
 }
 
+export type LSPSetupState =
+  | 'ready'
+  | 'missing_server'
+  | 'missing_interpreter'
+  | 'misconfigured_env'
+  | 'config_degraded'
+  | 'retryable';
+
+export type LSPSetupAction = 'create_venv' | 'select_interpreter' | 'retry' | '';
+
 export interface LSPServerStatus {
   family: string;
   workspace: string;
@@ -51,6 +61,14 @@ export interface LSPServerStatus {
   state: 'starting' | 'ready' | 'stopping' | 'stopped' | 'error';
   error?: string;
   completionTriggerCharacters?: string[];
+  setupState?: LSPSetupState;
+  interpreterPath?: string;
+  projectRoot?: string;
+  configSource?: string;
+  extraPaths?: string[];
+  pythonVersion?: string;
+  action?: LSPSetupAction;
+  detailCode?: string;
 }
 
 // --- Store ---

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -17,6 +17,10 @@ const DefaultRequestTimeout = 10 * time.Second
 // clientCapabilities is the static capabilities blob sent during initialization.
 // These don't change at runtime. Go code never reads them back — they're write-once for the server.
 var clientCapabilities = json.RawMessage(`{
+	"workspace": {
+		"configuration": true,
+		"didChangeConfiguration": {"dynamicRegistration": false}
+	},
 	"textDocument": {
 		"synchronization": {"didSave": true},
 		"completion": {
@@ -37,6 +41,13 @@ var clientCapabilities = json.RawMessage(`{
 // NotificationHandler is called when the server sends a notification.
 type NotificationHandler func(method string, params json.RawMessage)
 
+// ServerRequestHandler handles a server-to-client request. handled must be true
+// for the handler's result/rpcErr to be sent; when false the client replies
+// with the default -32601. The explicit flag is required because a nil result
+// is a valid successful JSON-RPC response and cannot be distinguished from
+// "not handled" by nil alone.
+type ServerRequestHandler func(method string, params json.RawMessage) (result any, handled bool, rpcErr *JSONRPCError)
+
 // ClientState represents the lifecycle state of the LSP client.
 type ClientState int
 
@@ -52,6 +63,9 @@ const (
 type Client struct {
 	transport Transport
 	handler   NotificationHandler
+
+	serverRequestHandler ServerRequestHandler
+	srhMu                sync.RWMutex
 
 	nextID    atomic.Int64
 	pending   map[int64]chan *JSONRPCMessage
@@ -77,6 +91,15 @@ func NewClient(transport Transport, handler NotificationHandler) *Client {
 	}
 	go c.readLoop()
 	return c
+}
+
+// SetServerRequestHandler registers a handler for server-to-client requests
+// (e.g. workspace/configuration). Set it before Initialize so the handler is
+// in place before the server begins pulling configuration.
+func (c *Client) SetServerRequestHandler(h ServerRequestHandler) {
+	c.srhMu.Lock()
+	c.serverRequestHandler = h
+	c.srhMu.Unlock()
 }
 
 // Initialize sends the initialize request and the initialized notification.
@@ -204,6 +227,13 @@ func (c *Client) DidClose(uri string) error {
 	return c.notify("textDocument/didClose", DidCloseTextDocumentParams{
 		TextDocument: TextDocumentIdentifier{URI: uri},
 	})
+}
+
+// DidChangeConfiguration notifies the server that configuration changed,
+// prompting servers that pull settings (e.g. pyright) to re-request them via
+// workspace/configuration.
+func (c *Client) DidChangeConfiguration(settings any) error {
+	return c.notify("workspace/didChangeConfiguration", map[string]any{"settings": settings})
 }
 
 // Hover sends a textDocument/hover request.
@@ -464,16 +494,34 @@ func (c *Client) dispatchResponse(msg *JSONRPCMessage) {
 	}
 }
 
-// respondToServerRequest handles server-to-client requests with a generic response.
+// respondToServerRequest dispatches a server-to-client request to the registered
+// handler if any; otherwise (or when the handler declines) it replies -32601.
 func (c *Client) respondToServerRequest(msg *JSONRPCMessage) {
-	resp := &JSONRPCMessage{
-		JSONRPC: "2.0",
-		ID:      msg.ID,
-		Error: &JSONRPCError{
-			Code:    -32601,
-			Message: "method not found",
-		},
+	c.srhMu.RLock()
+	h := c.serverRequestHandler
+	c.srhMu.RUnlock()
+
+	resp := &JSONRPCMessage{JSONRPC: "2.0", ID: msg.ID}
+
+	if h != nil {
+		result, handled, rpcErr := h(msg.Method, msg.Params)
+		if handled {
+			if rpcErr != nil {
+				resp.Error = rpcErr
+			} else if data, err := json.Marshal(result); err != nil {
+				resp.Error = &JSONRPCError{Code: -32603, Message: "marshal server-request result: " + err.Error()}
+			} else {
+				resp.Result = data
+			}
+			if err := c.transport.Send(resp); err != nil {
+				log.Printf("lsp: failed to respond to server request %s: %v", msg.Method, err)
+			}
+			return
+		}
 	}
+
+	log.Printf("lsp: unhandled server request %s -> -32601", msg.Method)
+	resp.Error = &JSONRPCError{Code: -32601, Message: "method not found"}
 	if err := c.transport.Send(resp); err != nil {
 		log.Printf("lsp: failed to respond to server request %s: %v", msg.Method, err)
 	}

--- a/internal/lsp/client_test.go
+++ b/internal/lsp/client_test.go
@@ -3,6 +3,8 @@ package lsp
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -275,4 +277,103 @@ func TestClient_RequestTimeout(t *testing.T) {
 	_, _ = client.Hover(shortCtx, "file:///tmp/test/main.ts", 0, 0)
 
 	_ = client.Shutdown(ctx)
+}
+
+// fakeTransport is an in-process Transport for driving server-to-client requests
+// and capturing the client's responses, without a subprocess.
+type fakeTransport struct {
+	incoming chan *JSONRPCMessage // server to client (returned by Receive)
+	outgoing chan *JSONRPCMessage // client to server (captured from Send)
+	closed   chan struct{}
+	once     sync.Once
+}
+
+func newFakeTransport() *fakeTransport {
+	return &fakeTransport{
+		incoming: make(chan *JSONRPCMessage, 16),
+		outgoing: make(chan *JSONRPCMessage, 16),
+		closed:   make(chan struct{}),
+	}
+}
+
+func (f *fakeTransport) Send(msg *JSONRPCMessage) error {
+	select {
+	case f.outgoing <- msg:
+		return nil
+	case <-f.closed:
+		return io.EOF
+	}
+}
+
+func (f *fakeTransport) Receive() (*JSONRPCMessage, error) {
+	select {
+	case msg := <-f.incoming:
+		return msg, nil
+	case <-f.closed:
+		return nil, io.EOF
+	}
+}
+
+func (f *fakeTransport) Close() error {
+	f.once.Do(func() { close(f.closed) })
+	return nil
+}
+
+func TestClient_ServerConfigurationRequest_Handled(t *testing.T) {
+	transport := newFakeTransport()
+	client := NewClient(transport, nil)
+	t.Cleanup(func() { _ = transport.Close() })
+
+	client.SetServerRequestHandler(func(method string, _ json.RawMessage) (any, bool, *JSONRPCError) {
+		if method != "workspace/configuration" {
+			return nil, false, nil
+		}
+		return []any{
+			map[string]any{"pythonPath": "/proj/.venv/bin/python", "venvPath": "/proj"},
+			map[string]any{"extraPaths": []string{"src"}},
+		}, true, nil
+	})
+
+	transport.incoming <- &JSONRPCMessage{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`7`),
+		Method:  "workspace/configuration",
+		Params:  json.RawMessage(`{"items":[{"section":"python"},{"section":"python.analysis"}]}`),
+	}
+
+	select {
+	case resp := <-transport.outgoing:
+		if resp.Error != nil {
+			t.Fatalf("response had error %+v, want result", resp.Error)
+		}
+		got := string(resp.Result)
+		if !strings.Contains(got, `"pythonPath"`) || !strings.Contains(got, `"venvPath"`) || !strings.Contains(got, `"extraPaths"`) {
+			t.Fatalf("response result missing python settings: %s", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for client response to workspace/configuration")
+	}
+}
+
+func TestClient_UnknownServerRequest_MethodNotFound(t *testing.T) {
+	transport := newFakeTransport()
+	client := NewClient(transport, nil)
+	t.Cleanup(func() { _ = transport.Close() })
+	_ = client
+
+	transport.incoming <- &JSONRPCMessage{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`9`),
+		Method:  "window/showMessageRequest",
+		Params:  json.RawMessage(`{}`),
+	}
+
+	select {
+	case resp := <-transport.outgoing:
+		if resp.Error == nil || resp.Error.Code != -32601 {
+			t.Fatalf("response = %+v, want error code -32601", resp.Error)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for -32601 response")
+	}
 }

--- a/internal/lsp/config_provider.go
+++ b/internal/lsp/config_provider.go
@@ -41,6 +41,8 @@ func (p *envConfigProvider) Configuration(family, projectRoot string, items []Co
 	}
 	env := p.PythonEnv(projectRoot)
 	pythonSection, analysisSection := pythonSettingSections(env)
+	// item.ScopeURI is intentionally ignored in Phase 1: the project-level env
+	// detected from projectRoot applies uniformly to all files in the workspace.
 	for i, item := range items {
 		results[i] = settingForSection(item.Section, pythonSection, analysisSection)
 	}
@@ -50,20 +52,12 @@ func (p *envConfigProvider) Configuration(family, projectRoot string, items []Co
 // settingForSection answers a requested config section dialect-agnostically:
 // any "*.analysis" object section maps to analysis settings; the bare server
 // section (python, pyright, basedpyright) maps to interpreter settings; leaf
-// sections (python.pythonPath, python.analysis.extraPaths, etc.) return a
-// scalar/array. The client bakes in none of these names.
+// sections are matched by suffix so pyright.pythonPath and python.pythonPath
+// behave identically — the client bakes in none of these names.
 func settingForSection(section string, pythonSection, analysisSection map[string]any) any {
 	switch {
 	case section == "":
 		return nil
-	case section == "python.pythonPath":
-		return pythonSection["pythonPath"]
-	case section == "python.defaultInterpreterPath":
-		return pythonSection["defaultInterpreterPath"]
-	case section == "python.venvPath":
-		return pythonSection["venvPath"]
-	case section == "python.venv":
-		return pythonSection["venv"]
 	case strings.HasSuffix(section, ".analysis.extraPaths"):
 		return analysisSection["extraPaths"]
 	case strings.HasSuffix(section, ".analysis.pythonVersion"):
@@ -73,6 +67,14 @@ func settingForSection(section string, pythonSection, analysisSection map[string
 			return nil
 		}
 		return analysisSection
+	case strings.HasSuffix(section, ".defaultInterpreterPath"):
+		return pythonSection["defaultInterpreterPath"]
+	case strings.HasSuffix(section, ".pythonPath"):
+		return pythonSection["pythonPath"]
+	case strings.HasSuffix(section, ".venvPath"):
+		return pythonSection["venvPath"]
+	case strings.HasSuffix(section, ".venv"):
+		return pythonSection["venv"]
 	case section == "python" || section == "pyright" || section == "basedpyright":
 		if len(pythonSection) == 0 {
 			return nil

--- a/internal/lsp/config_provider.go
+++ b/internal/lsp/config_provider.go
@@ -34,6 +34,24 @@ func (p *envConfigProvider) PythonEnv(projectRoot string) pythonenv.Env {
 	return p.detectPython(projectRoot, p.pythonDeps)
 }
 
+// pythonEnvReader is satisfied by envConfigProvider and any other provider that
+// exposes PythonEnv. It is used by pythonEnvFromProvider to retrieve the
+// environment without a second independent detect call.
+type pythonEnvReader interface {
+	PythonEnv(projectRoot string) pythonenv.Env
+}
+
+// pythonEnvFromProvider retrieves the Python environment via provider if it
+// implements pythonEnvReader; otherwise falls back to a fresh OS-backed detect.
+// This ensures emitStatus enrichment reuses the same detection path as
+// workspace/configuration, so the two can never drift.
+func pythonEnvFromProvider(provider WorkspaceConfigProvider, projectRoot string) pythonenv.Env {
+	if p, ok := provider.(pythonEnvReader); ok {
+		return p.PythonEnv(projectRoot)
+	}
+	return pythonenv.Detect(projectRoot, pythonenv.OSDeps())
+}
+
 func (p *envConfigProvider) Configuration(family, projectRoot string, items []ConfigurationItem) []any {
 	results := make([]any, len(items))
 	if family != "python" {

--- a/internal/lsp/config_provider.go
+++ b/internal/lsp/config_provider.go
@@ -41,10 +41,14 @@ type pythonEnvReader interface {
 	PythonEnv(projectRoot string) pythonenv.Env
 }
 
+// envConfigProvider is the default provider; this assertion guarantees the
+// pythonEnvFromProvider fast path (no re-detection) is always taken in production.
+var _ pythonEnvReader = (*envConfigProvider)(nil)
+
 // pythonEnvFromProvider retrieves the Python environment via provider if it
-// implements pythonEnvReader; otherwise falls back to a fresh OS-backed detect.
-// This ensures emitStatus enrichment reuses the same detection path as
-// workspace/configuration, so the two can never drift.
+// implements pythonEnvReader; otherwise falls back to an independent OS-backed
+// detection run. The fallback may diverge from a custom provider's view and
+// exists only for providers that don't implement pythonEnvReader.
 func pythonEnvFromProvider(provider WorkspaceConfigProvider, projectRoot string) pythonenv.Env {
 	if p, ok := provider.(pythonEnvReader); ok {
 		return p.PythonEnv(projectRoot)

--- a/internal/lsp/config_provider.go
+++ b/internal/lsp/config_provider.go
@@ -1,0 +1,110 @@
+package lsp
+
+import (
+	"path/filepath"
+	"strings"
+
+	"firn/internal/lsp/pythonenv"
+)
+
+// WorkspaceConfigProvider answers workspace/configuration requests for a server.
+// It is language-generic: the client never interprets section names or setting
+// keys. Per-family translation (e.g. Python env to pyright settings) lives here.
+type WorkspaceConfigProvider interface {
+	// Configuration returns one entry per requested item, in the same order.
+	// A nil entry tells the server to fall back to its own defaults.
+	Configuration(family, projectRoot string, items []ConfigurationItem) []any
+}
+
+// envConfigProvider maps detected project environments onto language-server
+// settings. Python is the only family wired in Phase 1.
+type envConfigProvider struct {
+	detectPython func(projectRoot string, deps pythonenv.Deps) pythonenv.Env
+	pythonDeps   pythonenv.Deps
+}
+
+func newEnvConfigProvider() *envConfigProvider {
+	return &envConfigProvider{
+		detectPython: pythonenv.Detect,
+		pythonDeps:   pythonenv.OSDeps(),
+	}
+}
+
+func (p *envConfigProvider) PythonEnv(projectRoot string) pythonenv.Env {
+	return p.detectPython(projectRoot, p.pythonDeps)
+}
+
+func (p *envConfigProvider) Configuration(family, projectRoot string, items []ConfigurationItem) []any {
+	results := make([]any, len(items))
+	if family != "python" {
+		return results // all nil; server uses its own defaults
+	}
+	env := p.PythonEnv(projectRoot)
+	pythonSection, analysisSection := pythonSettingSections(env)
+	for i, item := range items {
+		results[i] = settingForSection(item.Section, pythonSection, analysisSection)
+	}
+	return results
+}
+
+// settingForSection answers a requested config section dialect-agnostically:
+// any "*.analysis" object section maps to analysis settings; the bare server
+// section (python, pyright, basedpyright) maps to interpreter settings; leaf
+// sections (python.pythonPath, python.analysis.extraPaths, etc.) return a
+// scalar/array. The client bakes in none of these names.
+func settingForSection(section string, pythonSection, analysisSection map[string]any) any {
+	switch {
+	case section == "":
+		return nil
+	case section == "python.pythonPath":
+		return pythonSection["pythonPath"]
+	case section == "python.defaultInterpreterPath":
+		return pythonSection["defaultInterpreterPath"]
+	case section == "python.venvPath":
+		return pythonSection["venvPath"]
+	case section == "python.venv":
+		return pythonSection["venv"]
+	case strings.HasSuffix(section, ".analysis.extraPaths"):
+		return analysisSection["extraPaths"]
+	case strings.HasSuffix(section, ".analysis.pythonVersion"):
+		return analysisSection["pythonVersion"]
+	case strings.HasSuffix(section, ".analysis"):
+		if len(analysisSection) == 0 {
+			return nil
+		}
+		return analysisSection
+	case section == "python" || section == "pyright" || section == "basedpyright":
+		if len(pythonSection) == 0 {
+			return nil
+		}
+		return pythonSection
+	default:
+		return nil
+	}
+}
+
+func pythonSettingSections(env pythonenv.Env) (pythonSection, analysisSection map[string]any) {
+	python := map[string]any{}
+	analysis := map[string]any{}
+	if env.InterpreterPath != "" {
+		python["pythonPath"] = env.InterpreterPath
+		python["defaultInterpreterPath"] = env.InterpreterPath
+	}
+	if env.VenvDir != "" {
+		python["venvPath"] = filepath.Dir(env.VenvDir)
+		python["venv"] = filepath.Base(env.VenvDir)
+	}
+	if len(env.ExtraPaths) > 0 {
+		analysis["extraPaths"] = env.ExtraPaths
+	}
+	if env.PythonVersion != "" {
+		analysis["pythonVersion"] = env.PythonVersion
+	}
+	// Nest analysis under the python section too, so servers that read the
+	// whole "python" tree (rather than pulling "python.analysis" separately)
+	// still receive extraPaths/pythonVersion.
+	if len(analysis) > 0 {
+		python["analysis"] = analysis
+	}
+	return python, analysis
+}

--- a/internal/lsp/config_provider_test.go
+++ b/internal/lsp/config_provider_test.go
@@ -1,0 +1,99 @@
+package lsp
+
+import (
+	"testing"
+
+	"firn/internal/lsp/pythonenv"
+)
+
+func stubProvider(env pythonenv.Env) *envConfigProvider {
+	return &envConfigProvider{
+		detectPython: func(string, pythonenv.Deps) pythonenv.Env { return env },
+		pythonDeps:   pythonenv.Deps{},
+	}
+}
+
+func TestEnvConfigProvider_PythonSections(t *testing.T) {
+	p := stubProvider(pythonenv.Env{
+		InterpreterPath: "/proj/.venv/bin/python",
+		VenvDir:         "/proj/.venv",
+		ExtraPaths:      []string{"src"},
+	})
+
+	results := p.Configuration("python", "/proj", []ConfigurationItem{
+		{Section: "python"},
+		{Section: "python.analysis"},
+	})
+
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	py, ok := results[0].(map[string]any)
+	if !ok {
+		t.Fatalf("results[0] type = %T, want map", results[0])
+	}
+	if py["pythonPath"] != "/proj/.venv/bin/python" {
+		t.Errorf("pythonPath = %v", py["pythonPath"])
+	}
+	if py["venvPath"] != "/proj" || py["venv"] != ".venv" {
+		t.Errorf("venvPath/venv = %v/%v, want /proj/.venv", py["venvPath"], py["venv"])
+	}
+	analysis, ok := results[1].(map[string]any)
+	if !ok {
+		t.Fatalf("results[1] type = %T, want map", results[1])
+	}
+	paths, ok := analysis["extraPaths"].([]string)
+	if !ok || len(paths) != 1 || paths[0] != "src" {
+		t.Errorf("extraPaths = %v, want [src]", analysis["extraPaths"])
+	}
+}
+
+func TestEnvConfigProvider_DialectAnalysis(t *testing.T) {
+	p := stubProvider(pythonenv.Env{ExtraPaths: []string{"src"}})
+
+	results := p.Configuration("python", "/proj", []ConfigurationItem{
+		{Section: "basedpyright.analysis"},
+	})
+
+	analysis, ok := results[0].(map[string]any)
+	if !ok {
+		t.Fatalf("results[0] type = %T, want map (dialect-agnostic analysis)", results[0])
+	}
+	if _, ok := analysis["extraPaths"]; !ok {
+		t.Errorf("basedpyright.analysis missing extraPaths: %v", analysis)
+	}
+}
+
+func TestEnvConfigProvider_LeafSections(t *testing.T) {
+	p := stubProvider(pythonenv.Env{
+		InterpreterPath: "/proj/.venv/bin/python",
+		VenvDir:         "/proj/.venv",
+		ExtraPaths:      []string{"src"},
+	})
+
+	results := p.Configuration("python", "/proj", []ConfigurationItem{
+		{Section: "python.pythonPath"},
+		{Section: "python.venvPath"},
+		{Section: "python.venv"},
+		{Section: "python.analysis.extraPaths"},
+	})
+
+	if results[0] != "/proj/.venv/bin/python" {
+		t.Fatalf("python.pythonPath = %v", results[0])
+	}
+	if results[1] != "/proj" || results[2] != ".venv" {
+		t.Fatalf("venvPath/venv = %v/%v, want /proj/.venv", results[1], results[2])
+	}
+	paths, ok := results[3].([]string)
+	if !ok || len(paths) != 1 || paths[0] != "src" {
+		t.Fatalf("python.analysis.extraPaths = %v, want [src]", results[3])
+	}
+}
+
+func TestEnvConfigProvider_NonPythonEmpty(t *testing.T) {
+	p := stubProvider(pythonenv.Env{InterpreterPath: "/x"})
+	results := p.Configuration("go", "/proj", []ConfigurationItem{{Section: "gopls"}})
+	if len(results) != 1 || results[0] != nil {
+		t.Fatalf("results = %v, want [nil] for non-python family", results)
+	}
+}

--- a/internal/lsp/config_provider_test.go
+++ b/internal/lsp/config_provider_test.go
@@ -97,3 +97,34 @@ func TestEnvConfigProvider_NonPythonEmpty(t *testing.T) {
 		t.Fatalf("results = %v, want [nil] for non-python family", results)
 	}
 }
+
+func TestEnvConfigProvider_EmptyPythonEnvReturnsNil(t *testing.T) {
+	p := stubProvider(pythonenv.Env{})
+	results := p.Configuration("python", "/proj", []ConfigurationItem{
+		{Section: "python"},
+		{Section: "python.analysis"},
+	})
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0] != nil || results[1] != nil {
+		t.Fatalf("results = %v, want [nil nil] for empty env", results)
+	}
+}
+
+func TestEnvConfigProvider_DialectLeafSections(t *testing.T) {
+	p := stubProvider(pythonenv.Env{
+		InterpreterPath: "/proj/.venv/bin/python",
+		VenvDir:         "/proj/.venv",
+	})
+	results := p.Configuration("python", "/proj", []ConfigurationItem{
+		{Section: "basedpyright.pythonPath"},
+		{Section: "pyright.venvPath"},
+	})
+	if results[0] != "/proj/.venv/bin/python" {
+		t.Errorf("basedpyright.pythonPath = %v, want /proj/.venv/bin/python", results[0])
+	}
+	if results[1] != "/proj" {
+		t.Errorf("pyright.venvPath = %v, want /proj (parent of venv dir)", results[1])
+	}
+}

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -43,8 +43,9 @@ type EventEmitter func(event string, data ...any)
 
 // Manager owns workspace-scoped language server instances.
 type Manager struct {
-	registry *Registry
-	emitter  EventEmitter
+	registry       *Registry
+	emitter        EventEmitter
+	configProvider WorkspaceConfigProvider
 
 	mu      sync.Mutex
 	servers map[serverKey]*serverEntry
@@ -94,10 +95,11 @@ type serverEntry struct {
 // NewManager creates a new LSP manager with the given event emitter.
 func NewManager(emitter EventEmitter) *Manager {
 	return &Manager{
-		registry: NewRegistry(),
-		emitter:  emitter,
-		servers:  make(map[serverKey]*serverEntry),
-		docKeys:  make(map[string]serverKey),
+		registry:       NewRegistry(),
+		emitter:        emitter,
+		configProvider: newEnvConfigProvider(),
+		servers:        make(map[serverKey]*serverEntry),
+		docKeys:        make(map[string]serverKey),
 	}
 }
 
@@ -440,6 +442,7 @@ func (m *Manager) startServer(ctx context.Context, key serverKey, config *Server
 		m.handleNotification(key, method, params)
 	})
 	entry.client = client
+	client.SetServerRequestHandler(m.serverRequestHandler(key))
 
 	rootURI, err := FileToURI(key.workspace)
 	if err != nil {
@@ -793,6 +796,22 @@ func (m *Manager) handleNotification(key serverKey, method string, params json.R
 			"version":     diagParams.Version,
 			"diagnostics": diagParams.Diagnostics,
 		})
+	}
+}
+
+// serverRequestHandler returns a ServerRequestHandler bound to a server key.
+// It answers workspace/configuration via the configProvider and declines all
+// other server-to-client methods (the client then replies -32601).
+func (m *Manager) serverRequestHandler(key serverKey) ServerRequestHandler {
+	return func(method string, params json.RawMessage) (any, bool, *JSONRPCError) {
+		if method != "workspace/configuration" {
+			return nil, false, nil
+		}
+		var cfgParams ConfigurationParams
+		if err := json.Unmarshal(params, &cfgParams); err != nil {
+			return nil, true, &JSONRPCError{Code: -32602, Message: "invalid workspace/configuration params: " + err.Error()}
+		}
+		return m.configProvider.Configuration(key.family, key.workspace, cfgParams.Items), true, nil
 	}
 }
 

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -823,7 +823,8 @@ func (m *Manager) serverRequestHandler(key serverKey) ServerRequestHandler {
 	}
 }
 
-// emitStatus emits an lsp:status event.
+// emitStatus emits an lsp:status event. Must NOT be called while m.mu is held
+// (enrichPythonSetup performs filesystem detection for the Python family).
 func (m *Manager) emitStatus(family, workspace, state, errMsg string, command ...string) {
 	if m.emitter == nil {
 		return
@@ -856,11 +857,13 @@ func (m *Manager) enrichPythonSetup(status *ServerStatus) {
 	if status.Family != "python" {
 		return
 	}
-	status.ProjectRoot = status.Workspace
 
 	switch status.State {
 	case "error":
-		if strings.Contains(strings.ToLower(status.Error), "not found") {
+		status.ProjectRoot = status.Workspace
+		errLower := strings.ToLower(status.Error)
+		cmdBase := strings.ToLower(filepath.Base(status.Command))
+		if cmdBase != "" && strings.Contains(errLower, cmdBase) && strings.Contains(errLower, "not found") {
 			status.SetupState = "missing_server"
 			status.DetailCode = "server_not_found"
 		} else {
@@ -869,6 +872,7 @@ func (m *Manager) enrichPythonSetup(status *ServerStatus) {
 			status.Action = "retry"
 		}
 	case "ready":
+		status.ProjectRoot = status.Workspace
 		env := pythonEnvFromProvider(m.configProvider, status.Workspace)
 		status.InterpreterPath = env.InterpreterPath
 		status.ExtraPaths = env.ExtraPaths

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -352,7 +352,6 @@ func (m *Manager) ResolveCompletionItem(ctx context.Context, path string, item C
 // GetStatus returns the status of all running language servers.
 func (m *Manager) GetStatus() []ServerStatus {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	statuses := make([]ServerStatus, 0, len(m.servers))
 	for key, entry := range m.servers {
@@ -380,6 +379,12 @@ func (m *Manager) GetStatus() []ServerStatus {
 		}
 		statuses = append(statuses, status)
 	}
+	m.mu.Unlock()
+
+	for i := range statuses {
+		m.enrichPythonSetup(&statuses[i])
+	}
+
 	return statuses
 }
 

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -36,6 +36,14 @@ type ServerStatus struct {
 	State                       string   `json:"state"` // "starting", "ready", "stopping", "stopped", "error"
 	Error                       string   `json:"error,omitempty"`
 	CompletionTriggerCharacters []string `json:"completionTriggerCharacters,omitempty"`
+	SetupState                  string   `json:"setupState,omitempty"` // ready|missing_server|missing_interpreter|misconfigured_env|config_degraded|retryable
+	InterpreterPath             string   `json:"interpreterPath,omitempty"`
+	ProjectRoot                 string   `json:"projectRoot,omitempty"`
+	ConfigSource                string   `json:"configSource,omitempty"`
+	ExtraPaths                  []string `json:"extraPaths,omitempty"`
+	PythonVersion               string   `json:"pythonVersion,omitempty"`
+	Action                      string   `json:"action,omitempty"` // create_venv|select_interpreter|retry|""
+	DetailCode                  string   `json:"detailCode,omitempty"`
 }
 
 // EventEmitter is the callback signature for emitting events to the frontend.
@@ -837,7 +845,56 @@ func (m *Manager) emitStatus(family, workspace, state, errMsg string, command ..
 		}
 		m.mu.Unlock()
 	}
+	m.enrichPythonSetup(&status)
 	m.emitter("lsp:status", status)
+}
+
+// enrichPythonSetup populates typed setup-status fields for the Python family
+// so the frontend can render an actionable card instead of a raw error string.
+// Other families are left untouched.
+func (m *Manager) enrichPythonSetup(status *ServerStatus) {
+	if status.Family != "python" {
+		return
+	}
+	status.ProjectRoot = status.Workspace
+
+	switch status.State {
+	case "error":
+		if strings.Contains(strings.ToLower(status.Error), "not found") {
+			status.SetupState = "missing_server"
+			status.DetailCode = "server_not_found"
+		} else {
+			status.SetupState = "retryable"
+			status.DetailCode = "server_start_failed"
+			status.Action = "retry"
+		}
+	case "ready":
+		env := pythonEnvFromProvider(m.configProvider, status.Workspace)
+		status.InterpreterPath = env.InterpreterPath
+		status.ExtraPaths = env.ExtraPaths
+		status.PythonVersion = env.PythonVersion
+		if env.InterpreterPath == "" {
+			status.ConfigSource = "none"
+		} else {
+			status.ConfigSource = "detected"
+		}
+		switch {
+		case len(env.Diagnostics) > 0:
+			status.SetupState = "misconfigured_env"
+			status.DetailCode = "venv_without_interpreter"
+			status.Action = "select_interpreter"
+		case env.Source == "none" || env.InterpreterPath == "":
+			status.SetupState = "missing_interpreter"
+			status.DetailCode = "no_interpreter"
+			status.Action = "create_venv"
+		case env.Confidence == "low":
+			status.SetupState = "config_degraded"
+			status.DetailCode = "system_fallback"
+			status.Action = "select_interpreter"
+		default:
+			status.SetupState = "ready"
+		}
+	}
 }
 
 // emitError emits an lsp:error event with a user-facing message.

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -1675,6 +1675,9 @@ func TestEmitStatus_PythonReadyEnriched(t *testing.T) {
 	if len(got.ExtraPaths) != 1 || got.ExtraPaths[0] != "src" {
 		t.Errorf("ExtraPaths = %v, want [src]", got.ExtraPaths)
 	}
+	if got.ConfigSource != "detected" {
+		t.Errorf("ConfigSource = %q, want detected", got.ConfigSource)
+	}
 }
 
 func TestEmitStatus_PythonMisconfiguredVenv(t *testing.T) {
@@ -1727,6 +1730,9 @@ func TestEmitStatus_PythonMissingInterpreter(t *testing.T) {
 	if got.Action != "create_venv" {
 		t.Errorf("Action = %q, want create_venv", got.Action)
 	}
+	if got.ConfigSource != "none" {
+		t.Errorf("ConfigSource = %q, want none", got.ConfigSource)
+	}
 }
 
 func TestEmitStatus_PythonConfigDegraded(t *testing.T) {
@@ -1762,6 +1768,8 @@ func TestEmitStatus_PythonMissingServer(t *testing.T) {
 		}
 	})
 
+	// The error path does not invoke pythonEnvFromProvider, so no configProvider
+	// override is needed here.
 	m.emitStatus("python", "/proj", "error", "pyright-langserver not found: install it", "pyright-langserver")
 
 	if got.SetupState != "missing_server" {

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -1794,3 +1794,44 @@ func TestEmitStatus_NonPythonUnaffected(t *testing.T) {
 		t.Fatalf("SetupState = %q, want empty for non-python", got.SetupState)
 	}
 }
+
+func TestGetStatus_PythonReadyEnriched(t *testing.T) {
+	m := NewManager(nil)
+	m.configProvider = &envConfigProvider{
+		detectPython: func(string, pythonenv.Deps) pythonenv.Env {
+			return pythonenv.Env{
+				InterpreterPath: "/proj/.venv/bin/python",
+				VenvDir:         "/proj/.venv",
+				ExtraPaths:      []string{"src"},
+				Source:          ".venv",
+				Confidence:      "high",
+			}
+		},
+		pythonDeps: pythonenv.Deps{},
+	}
+
+	m.mu.Lock()
+	m.servers[serverKey{family: "python", workspace: "/proj"}] = &serverEntry{
+		client: &Client{state: ClientStateReady},
+		config: &ServerConfig{Command: "pyright-langserver"},
+	}
+	m.mu.Unlock()
+
+	statuses := m.GetStatus()
+	if len(statuses) != 1 {
+		t.Fatalf("len(statuses) = %d, want 1", len(statuses))
+	}
+	got := statuses[0]
+	if got.SetupState != "ready" {
+		t.Fatalf("SetupState = %q, want ready", got.SetupState)
+	}
+	if got.InterpreterPath != "/proj/.venv/bin/python" {
+		t.Errorf("InterpreterPath = %q", got.InterpreterPath)
+	}
+	if len(got.ExtraPaths) != 1 || got.ExtraPaths[0] != "src" {
+		t.Errorf("ExtraPaths = %v, want [src]", got.ExtraPaths)
+	}
+	if got.ConfigSource != "detected" {
+		t.Errorf("ConfigSource = %q, want detected", got.ConfigSource)
+	}
+}

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"firn/internal/lsp/pythonenv"
 )
 
 // newTestManager creates a Manager with a mock transport factory.
@@ -1637,5 +1639,150 @@ func TestManager_ShutdownAllTearsDownAllRoots(t *testing.T) {
 	mgr.mu.Unlock()
 	if afterCount != 0 {
 		t.Errorf("expected 0 servers after ShutdownAll, got %d", afterCount)
+	}
+}
+
+func TestEmitStatus_PythonReadyEnriched(t *testing.T) {
+	var got ServerStatus
+	m := NewManager(func(event string, data ...any) {
+		if event == "lsp:status" && len(data) > 0 {
+			if s, ok := data[0].(ServerStatus); ok {
+				got = s
+			}
+		}
+	})
+	m.configProvider = &envConfigProvider{
+		detectPython: func(string, pythonenv.Deps) pythonenv.Env {
+			return pythonenv.Env{
+				InterpreterPath: "/proj/.venv/bin/python",
+				VenvDir:         "/proj/.venv",
+				ExtraPaths:      []string{"src"},
+				Source:          ".venv",
+				Confidence:      "high",
+			}
+		},
+		pythonDeps: pythonenv.Deps{},
+	}
+
+	m.emitStatus("python", "/proj", "ready", "", "pyright-langserver")
+
+	if got.SetupState != "ready" {
+		t.Fatalf("SetupState = %q, want ready", got.SetupState)
+	}
+	if got.InterpreterPath != "/proj/.venv/bin/python" {
+		t.Errorf("InterpreterPath = %q", got.InterpreterPath)
+	}
+	if len(got.ExtraPaths) != 1 || got.ExtraPaths[0] != "src" {
+		t.Errorf("ExtraPaths = %v, want [src]", got.ExtraPaths)
+	}
+}
+
+func TestEmitStatus_PythonMisconfiguredVenv(t *testing.T) {
+	var got ServerStatus
+	m := NewManager(func(event string, data ...any) {
+		if event == "lsp:status" && len(data) > 0 {
+			got, _ = data[0].(ServerStatus)
+		}
+	})
+	m.configProvider = &envConfigProvider{
+		detectPython: func(string, pythonenv.Deps) pythonenv.Env {
+			return pythonenv.Env{
+				Source:      "none",
+				Confidence:  "low",
+				Diagnostics: []string{"venv_without_interpreter:/proj/.venv"},
+			}
+		},
+		pythonDeps: pythonenv.Deps{},
+	}
+
+	m.emitStatus("python", "/proj", "ready", "", "pyright-langserver")
+
+	if got.SetupState != "misconfigured_env" {
+		t.Fatalf("SetupState = %q, want misconfigured_env", got.SetupState)
+	}
+	if got.DetailCode != "venv_without_interpreter" {
+		t.Errorf("DetailCode = %q, want venv_without_interpreter", got.DetailCode)
+	}
+}
+
+func TestEmitStatus_PythonMissingInterpreter(t *testing.T) {
+	var got ServerStatus
+	m := NewManager(func(event string, data ...any) {
+		if event == "lsp:status" && len(data) > 0 {
+			got, _ = data[0].(ServerStatus)
+		}
+	})
+	m.configProvider = &envConfigProvider{
+		detectPython: func(string, pythonenv.Deps) pythonenv.Env {
+			return pythonenv.Env{Source: "none", Confidence: "low"}
+		},
+		pythonDeps: pythonenv.Deps{},
+	}
+
+	m.emitStatus("python", "/proj", "ready", "", "pyright-langserver")
+
+	if got.SetupState != "missing_interpreter" {
+		t.Fatalf("SetupState = %q, want missing_interpreter", got.SetupState)
+	}
+	if got.Action != "create_venv" {
+		t.Errorf("Action = %q, want create_venv", got.Action)
+	}
+}
+
+func TestEmitStatus_PythonConfigDegraded(t *testing.T) {
+	var got ServerStatus
+	m := NewManager(func(event string, data ...any) {
+		if event == "lsp:status" && len(data) > 0 {
+			got, _ = data[0].(ServerStatus)
+		}
+	})
+	m.configProvider = &envConfigProvider{
+		detectPython: func(string, pythonenv.Deps) pythonenv.Env {
+			return pythonenv.Env{
+				InterpreterPath: "/proj/.venv/bin/python",
+				Source:          "system",
+				Confidence:      "low",
+			}
+		},
+		pythonDeps: pythonenv.Deps{},
+	}
+
+	m.emitStatus("python", "/proj", "ready", "", "pyright-langserver")
+
+	if got.SetupState != "config_degraded" {
+		t.Fatalf("SetupState = %q, want config_degraded", got.SetupState)
+	}
+}
+
+func TestEmitStatus_PythonMissingServer(t *testing.T) {
+	var got ServerStatus
+	m := NewManager(func(event string, data ...any) {
+		if event == "lsp:status" && len(data) > 0 {
+			got, _ = data[0].(ServerStatus)
+		}
+	})
+
+	m.emitStatus("python", "/proj", "error", "pyright-langserver not found: install it", "pyright-langserver")
+
+	if got.SetupState != "missing_server" {
+		t.Fatalf("SetupState = %q, want missing_server", got.SetupState)
+	}
+	if got.DetailCode != "server_not_found" {
+		t.Errorf("DetailCode = %q, want server_not_found", got.DetailCode)
+	}
+}
+
+func TestEmitStatus_NonPythonUnaffected(t *testing.T) {
+	var got ServerStatus
+	m := NewManager(func(event string, data ...any) {
+		if event == "lsp:status" && len(data) > 0 {
+			got, _ = data[0].(ServerStatus)
+		}
+	})
+
+	m.emitStatus("go", "/proj", "error", "gopls not found", "gopls")
+
+	if got.SetupState != "" {
+		t.Fatalf("SetupState = %q, want empty for non-python", got.SetupState)
 	}
 }

--- a/internal/lsp/pythonenv/detector.go
+++ b/internal/lsp/pythonenv/detector.go
@@ -181,7 +181,7 @@ func readPythonVersionFile(projectRoot string, deps Deps) string {
 		return ""
 	}
 	for _, line := range strings.Split(string(data), "\n") {
-		if line = strings.TrimSpace(line); line != "" {
+		if line = strings.TrimSpace(line); line != "" && !strings.HasPrefix(line, "#") {
 			return line
 		}
 	}
@@ -237,7 +237,9 @@ func tomlSectionHasKey(content, section, key string) bool {
 	for _, line := range strings.Split(content, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "[") {
-			inSection = trimmed == header
+			inSection = trimmed == header ||
+				(strings.HasPrefix(trimmed, header) &&
+					(trimmed[len(header)] == ' ' || trimmed[len(header)] == '\t' || trimmed[len(header)] == '#'))
 			continue
 		}
 		if inSection {
@@ -251,7 +253,7 @@ func tomlSectionHasKey(content, section, key string) bool {
 	return false
 }
 
-var requiresPythonRe = regexp.MustCompile(`(\d+\.\d+)`)
+var requiresPythonRe = regexp.MustCompile(`[><=!~^]+\s*(\d+\.\d+)`)
 
 func requiresPythonVersion(projectRoot string, deps Deps) string {
 	if projectRoot == "" {
@@ -263,8 +265,8 @@ func requiresPythonVersion(projectRoot string, deps Deps) string {
 	}
 	for _, line := range strings.Split(string(data), "\n") {
 		if strings.HasPrefix(strings.TrimSpace(line), "requires-python") {
-			if m := requiresPythonRe.FindString(line); m != "" {
-				return m
+			if m := requiresPythonRe.FindStringSubmatch(line); m != nil {
+				return m[1]
 			}
 		}
 	}

--- a/internal/lsp/pythonenv/detector.go
+++ b/internal/lsp/pythonenv/detector.go
@@ -1,0 +1,298 @@
+// Package pythonenv resolves the Python analysis environment (interpreter,
+// extra paths, version) for a project root WITHOUT executing any tool. It only
+// stats/reads the filesystem and resolves executable names via an injected
+// LookPath, so it is pure and deterministic in tests.
+package pythonenv
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+// Env is the detected Python analysis environment for a project root.
+type Env struct {
+	InterpreterPath string   // venv/system interpreter; the primary lever for pyright
+	VenvDir         string   // venv root (e.g. <root>/.venv); empty for system/none
+	ExtraPaths      []string // e.g. ["src"]; empty when project config already declares extraPaths
+	PythonVersion   string   // fallback only; set when no interpreter resolves and requires-python is known
+	Source          string   // "VIRTUAL_ENV" | ".venv" | "venv" | "pyenv" | "system" | "none"
+	Confidence      string   // "high" | "low"
+	Diagnostics     []string // machine-readable detector notes (not user-facing prose)
+}
+
+// Deps are the injected, side-effect-bearing operations Detect needs.
+// Injection keeps Detect deterministic and hermetic in tests.
+type Deps struct {
+	Getenv   func(string) string
+	Stat     func(string) (os.FileInfo, error)
+	ReadFile func(string) ([]byte, error)
+	ReadDir  func(string) ([]os.DirEntry, error)
+	LookPath func(string) (string, error) // resolves/stat-checks executables; never executes them
+}
+
+// OSDeps returns Deps backed by the real OS. It never executes Python or any tool.
+func OSDeps() Deps {
+	return Deps{
+		Getenv:   os.Getenv,
+		Stat:     os.Stat,
+		ReadFile: os.ReadFile,
+		ReadDir:  os.ReadDir,
+		LookPath: exec.LookPath,
+	}
+}
+
+// Detect resolves the analysis environment for projectRoot.
+func Detect(projectRoot string, deps Deps) Env {
+	env := Env{Source: "none", Confidence: "low"}
+
+	// 1. Project-local venv (in-root VIRTUAL_ENV -> .venv -> venv).
+	if dir, source := resolveVenvDir(projectRoot, deps); dir != "" {
+		if interp, ok := interpreterInVenv(dir, deps); ok {
+			env.InterpreterPath = interp
+			env.VenvDir = dir
+			env.Source = source
+			env.Confidence = "high"
+		} else {
+			env.Diagnostics = append(env.Diagnostics, "venv_without_interpreter:"+dir)
+		}
+	}
+
+	// 2. pyenv (.python-version) - only if a matching interpreter can be stat-checked.
+	if env.InterpreterPath == "" {
+		if interp, ok := resolvePyenv(projectRoot, deps); ok {
+			env.InterpreterPath = interp
+			env.Source = "pyenv"
+			env.Confidence = "high"
+		}
+	}
+
+	// 3. System python on PATH (low confidence; may not match the project).
+	if env.InterpreterPath == "" {
+		if sys, ok := lookupSystemPython(deps); ok {
+			env.InterpreterPath = sys
+			env.Source = "system"
+			env.Confidence = "low"
+		}
+	}
+
+	// 4. extraPaths: inject "src" only when no project config already declares it.
+	if !projectConfigDeclaresExtraPaths(projectRoot, deps) && srcLayoutPresent(projectRoot, deps) {
+		env.ExtraPaths = []string{"src"}
+	}
+
+	// 5. pythonVersion fallback when no interpreter resolved.
+	if env.InterpreterPath == "" {
+		env.Source = "none"
+		env.PythonVersion = requiresPythonVersion(projectRoot, deps)
+	}
+
+	return env
+}
+
+// resolveVenvDir returns the project-local venv directory and its source.
+// In-root VIRTUAL_ENV beats .venv beats venv. An out-of-root VIRTUAL_ENV is
+// ignored: an unrelated active venv must not silently miswire the workspace.
+func resolveVenvDir(projectRoot string, deps Deps) (string, string) {
+	if active := deps.Getenv("VIRTUAL_ENV"); active != "" && pathInside(projectRoot, active) && isDir(active, deps) {
+		return active, "VIRTUAL_ENV"
+	}
+	if projectRoot != "" {
+		if d := filepath.Join(projectRoot, ".venv"); isDir(d, deps) {
+			return d, ".venv"
+		}
+		if d := filepath.Join(projectRoot, "venv"); isDir(d, deps) {
+			return d, "venv"
+		}
+	}
+	return "", ""
+}
+
+func interpreterInVenv(venv string, deps Deps) (string, bool) {
+	for _, rel := range venvInterpreterRelPaths() {
+		candidate := filepath.Join(venv, rel)
+		if isFile(candidate, deps) {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+func venvInterpreterRelPaths() []string {
+	if runtime.GOOS == "windows" {
+		return []string{
+			filepath.Join("Scripts", "python.exe"),
+			filepath.Join("Scripts", "python3.exe"),
+		}
+	}
+	return []string{
+		filepath.Join("bin", "python"),
+		filepath.Join("bin", "python3"),
+	}
+}
+
+func lookupSystemPython(deps Deps) (string, bool) {
+	for _, name := range []string{"python3", "python"} {
+		if p, err := deps.LookPath(name); err == nil && p != "" {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+// resolvePyenv resolves an interpreter from .python-version, but only if it can
+// be located on disk via PYENV_ROOT / HOME without executing pyenv.
+func resolvePyenv(projectRoot string, deps Deps) (string, bool) {
+	ver := readPythonVersionFile(projectRoot, deps)
+	if ver == "" {
+		return "", false
+	}
+	root := deps.Getenv("PYENV_ROOT")
+	if root == "" {
+		home := deps.Getenv("HOME")
+		if home == "" {
+			home = deps.Getenv("USERPROFILE")
+		}
+		if home == "" {
+			return "", false
+		}
+		root = filepath.Join(home, ".pyenv")
+	}
+	interp := filepath.Join(root, "versions", ver, "bin", "python")
+	if runtime.GOOS == "windows" {
+		interp = filepath.Join(root, "versions", ver, "python.exe")
+	}
+	if isFile(interp, deps) {
+		return interp, true
+	}
+	return "", false
+}
+
+func readPythonVersionFile(projectRoot string, deps Deps) string {
+	if projectRoot == "" {
+		return ""
+	}
+	data, err := deps.ReadFile(filepath.Join(projectRoot, ".python-version"))
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+func srcLayoutPresent(projectRoot string, deps Deps) bool {
+	if projectRoot == "" {
+		return false
+	}
+	srcDir := filepath.Join(projectRoot, "src")
+	if !isDir(srcDir, deps) {
+		return false
+	}
+	entries, err := deps.ReadDir(srcDir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() || strings.HasSuffix(e.Name(), ".py") {
+			return true
+		}
+	}
+	return false
+}
+
+func projectConfigDeclaresExtraPaths(projectRoot string, deps Deps) bool {
+	if projectRoot == "" {
+		return false
+	}
+	if data, err := deps.ReadFile(filepath.Join(projectRoot, "pyrightconfig.json")); err == nil {
+		var cfg map[string]json.RawMessage
+		if json.Unmarshal(data, &cfg) == nil {
+			if _, ok := cfg["extraPaths"]; ok {
+				return true
+			}
+		}
+	}
+	if data, err := deps.ReadFile(filepath.Join(projectRoot, "pyproject.toml")); err == nil {
+		if tomlSectionHasKey(string(data), "tool.pyright", "extraPaths") {
+			return true
+		}
+	}
+	return false
+}
+
+// tomlSectionHasKey reports whether the named TOML table (e.g. "tool.pyright")
+// contains the given key. Heuristic scan: adequate for detecting that a user
+// already declared a key, but not a full TOML parser (no TOML dep in the module).
+func tomlSectionHasKey(content, section, key string) bool {
+	inSection := false
+	header := "[" + section + "]"
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			inSection = trimmed == header
+			continue
+		}
+		if inSection {
+			if eq := strings.Index(trimmed, "="); eq > 0 {
+				if strings.TrimSpace(trimmed[:eq]) == key {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+var requiresPythonRe = regexp.MustCompile(`(\d+\.\d+)`)
+
+func requiresPythonVersion(projectRoot string, deps Deps) string {
+	if projectRoot == "" {
+		return ""
+	}
+	data, err := deps.ReadFile(filepath.Join(projectRoot, "pyproject.toml"))
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "requires-python") {
+			if m := requiresPythonRe.FindString(line); m != "" {
+				return m
+			}
+		}
+	}
+	return ""
+}
+
+func pathInside(root, p string) bool {
+	if root == "" || p == "" {
+		return false
+	}
+	root = filepath.Clean(root)
+	p = filepath.Clean(p)
+	if p == root {
+		return true
+	}
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func isDir(path string, deps Deps) bool {
+	info, err := deps.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func isFile(path string, deps Deps) bool {
+	info, err := deps.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/internal/lsp/pythonenv/detector_test.go
+++ b/internal/lsp/pythonenv/detector_test.go
@@ -180,6 +180,36 @@ func TestDetect_NoInterpreterFallsBackToVersion(t *testing.T) {
 	}
 }
 
+func TestDetect_PyenvResolvesFromVersionFile(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".python-version"), []byte("3.11.2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pyenvRoot := t.TempDir()
+	interp := filepath.Join(pyenvRoot, "versions", "3.11.2", "bin", "python")
+	if runtime.GOOS == "windows" {
+		interp = filepath.Join(pyenvRoot, "versions", "3.11.2", "python.exe")
+	}
+	if err := os.MkdirAll(filepath.Dir(interp), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(interp, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	env := pythonenv.Detect(root, depsWith(map[string]string{"PYENV_ROOT": pyenvRoot}, noPython))
+
+	if env.Source != "pyenv" {
+		t.Fatalf("Source = %q, want pyenv", env.Source)
+	}
+	if env.Confidence != "high" {
+		t.Errorf("Confidence = %q, want high", env.Confidence)
+	}
+	if env.InterpreterPath != interp {
+		t.Errorf("InterpreterPath = %q, want %q", env.InterpreterPath, interp)
+	}
+}
+
 func TestDetect_SystemFallbackIsLowConfidence(t *testing.T) {
 	root := t.TempDir()
 	lookPath := func(name string) (string, error) {

--- a/internal/lsp/pythonenv/detector_test.go
+++ b/internal/lsp/pythonenv/detector_test.go
@@ -1,0 +1,202 @@
+package pythonenv_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"firn/internal/lsp/pythonenv"
+)
+
+// depsWith builds Deps backed by the real filesystem but with deterministic
+// Getenv and LookPath, so no host environment or installed Python leaks in.
+func depsWith(env map[string]string, lookPath func(string) (string, error)) pythonenv.Deps {
+	d := pythonenv.OSDeps()
+	d.Getenv = func(k string) string { return env[k] }
+	if lookPath != nil {
+		d.LookPath = lookPath
+	}
+	return d
+}
+
+func noPython(string) (string, error) { return "", os.ErrNotExist }
+
+func writeFakeInterpreter(t *testing.T, venvDir string) {
+	t.Helper()
+	rel := filepath.Join("bin", "python")
+	if runtime.GOOS == "windows" {
+		rel = filepath.Join("Scripts", "python.exe")
+	}
+	full := filepath.Join(venvDir, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDetect_DotVenvPreferred(t *testing.T) {
+	root := t.TempDir()
+	venv := filepath.Join(root, ".venv")
+	writeFakeInterpreter(t, venv)
+
+	env := pythonenv.Detect(root, depsWith(nil, noPython))
+
+	if env.Source != ".venv" {
+		t.Fatalf("Source = %q, want .venv", env.Source)
+	}
+	if env.VenvDir != venv {
+		t.Errorf("VenvDir = %q, want %q", env.VenvDir, venv)
+	}
+	if env.InterpreterPath == "" {
+		t.Error("InterpreterPath empty, want venv interpreter")
+	}
+	if env.Confidence != "high" {
+		t.Errorf("Confidence = %q, want high", env.Confidence)
+	}
+}
+
+func TestDetect_VenvFallbackWhenNoDotVenv(t *testing.T) {
+	root := t.TempDir()
+	venv := filepath.Join(root, "venv")
+	writeFakeInterpreter(t, venv)
+
+	env := pythonenv.Detect(root, depsWith(nil, noPython))
+
+	if env.Source != "venv" {
+		t.Fatalf("Source = %q, want venv", env.Source)
+	}
+}
+
+func TestDetect_BrokenDotVenvRecordsDiagnostic(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".venv"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	env := pythonenv.Detect(root, depsWith(nil, noPython))
+
+	if env.Source != "none" {
+		t.Fatalf("Source = %q, want none when .venv has no interpreter", env.Source)
+	}
+	if len(env.Diagnostics) == 0 || !strings.HasPrefix(env.Diagnostics[0], "venv_without_interpreter:") {
+		t.Fatalf("Diagnostics = %v, want venv_without_interpreter note", env.Diagnostics)
+	}
+}
+
+func TestDetect_OutOfRootVirtualEnvDoesNotBeatDotVenv(t *testing.T) {
+	root := t.TempDir()
+	dotVenv := filepath.Join(root, ".venv")
+	writeFakeInterpreter(t, dotVenv)
+
+	outside := t.TempDir() // a different tree, simulating an unrelated active venv
+	writeFakeInterpreter(t, outside)
+
+	env := pythonenv.Detect(root, depsWith(map[string]string{"VIRTUAL_ENV": outside}, noPython))
+
+	if env.Source != ".venv" {
+		t.Fatalf("Source = %q, want .venv (out-of-root VIRTUAL_ENV must not win)", env.Source)
+	}
+	if env.VenvDir != dotVenv {
+		t.Errorf("VenvDir = %q, want %q", env.VenvDir, dotVenv)
+	}
+}
+
+func TestDetect_InRootVirtualEnvWins(t *testing.T) {
+	root := t.TempDir()
+	active := filepath.Join(root, ".cache-venv")
+	writeFakeInterpreter(t, active)
+
+	env := pythonenv.Detect(root, depsWith(map[string]string{"VIRTUAL_ENV": active}, noPython))
+
+	if env.Source != "VIRTUAL_ENV" {
+		t.Fatalf("Source = %q, want VIRTUAL_ENV", env.Source)
+	}
+	if env.VenvDir != active {
+		t.Errorf("VenvDir = %q, want %q", env.VenvDir, active)
+	}
+}
+
+func TestDetect_SrcLayoutInjectsExtraPaths(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "src", "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	env := pythonenv.Detect(root, depsWith(nil, noPython))
+
+	if len(env.ExtraPaths) != 1 || env.ExtraPaths[0] != "src" {
+		t.Fatalf("ExtraPaths = %v, want [src]", env.ExtraPaths)
+	}
+}
+
+func TestDetect_NoDoubleInjectWhenConfigDeclaresExtraPaths(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "src", "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "pyrightconfig.json"),
+		[]byte(`{"extraPaths":["lib"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	env := pythonenv.Detect(root, depsWith(nil, noPython))
+
+	if len(env.ExtraPaths) != 0 {
+		t.Fatalf("ExtraPaths = %v, want empty (project config already declares extraPaths)", env.ExtraPaths)
+	}
+}
+
+func TestDetect_NoDoubleInjectWhenPyprojectToolPyrightDeclaresExtraPaths(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "src", "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "pyproject.toml"),
+		[]byte("[tool.pyright]\nextraPaths = [\"lib\"]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	env := pythonenv.Detect(root, depsWith(nil, noPython))
+
+	if len(env.ExtraPaths) != 0 {
+		t.Fatalf("ExtraPaths = %v, want empty ([tool.pyright] already declares extraPaths)", env.ExtraPaths)
+	}
+}
+
+func TestDetect_NoInterpreterFallsBackToVersion(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "pyproject.toml"),
+		[]byte("[project]\nrequires-python = \">=3.11\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	env := pythonenv.Detect(root, depsWith(nil, noPython))
+
+	if env.Source != "none" {
+		t.Fatalf("Source = %q, want none", env.Source)
+	}
+	if env.PythonVersion != "3.11" {
+		t.Errorf("PythonVersion = %q, want 3.11", env.PythonVersion)
+	}
+}
+
+func TestDetect_SystemFallbackIsLowConfidence(t *testing.T) {
+	root := t.TempDir()
+	lookPath := func(name string) (string, error) {
+		if name == "python3" {
+			return "/usr/bin/python3", nil
+		}
+		return "", os.ErrNotExist
+	}
+	env := pythonenv.Detect(root, depsWith(nil, lookPath))
+
+	if env.Source != "system" {
+		t.Fatalf("Source = %q, want system", env.Source)
+	}
+	if env.Confidence != "low" {
+		t.Errorf("Confidence = %q, want low", env.Confidence)
+	}
+	if env.InterpreterPath != "/usr/bin/python3" {
+		t.Errorf("InterpreterPath = %q, want /usr/bin/python3", env.InterpreterPath)
+	}
+}

--- a/internal/lsp/types.go
+++ b/internal/lsp/types.go
@@ -219,6 +219,18 @@ type CompletionParams struct {
 	Context      *CompletionContext     `json:"context,omitempty"`
 }
 
+// ConfigurationItem identifies a configuration section the server wants to read
+// via a workspace/configuration request.
+type ConfigurationItem struct {
+	ScopeURI string `json:"scopeUri,omitempty"`
+	Section  string `json:"section,omitempty"`
+}
+
+// ConfigurationParams are the params of a workspace/configuration request.
+type ConfigurationParams struct {
+	Items []ConfigurationItem `json:"items"`
+}
+
 // --- JSON-RPC types ---
 
 // JSONRPCMessage is a raw JSON-RPC 2.0 message.


### PR DESCRIPTION
## Summary
Phase 1 of #112: pyright now resolves imports/types in a standard `src`-layout Python project with **zero per-project Firn config**. Previously, even when the `pyright-langserver` binary was found, Firn forwarded no interpreter/venv/paths, so pyright analyzed with defaults and emitted false diagnostics (`import asyncpg`, `from quantum_trader... import`, `from datetime import UTC`).

## What changed
- **`internal/lsp/pythonenv`** — new pure (no command execution) filesystem detector. Interpreter precedence: in-root `VIRTUAL_ENV` → `.venv` → `venv` → `.python-version`/pyenv (stat-checked) → system `python3` → none. Out-of-root `VIRTUAL_ENV` is ignored (so a stray active venv can't miswire the workspace). Injects `extraPaths:["src"]` for src-layout only when no `pyrightconfig.json`/`[tool.pyright]` already declares it.
- **Client server→client dispatch** — `respondToServerRequest` gains a registrable `ServerRequestHandler` (explicit `handled` flag); advertises the `workspace.configuration` capability; adds `DidChangeConfiguration`. Unknown methods still reply `-32601`.
- **`WorkspaceConfigProvider`** — Manager-owned, language-generic seam; Python translation maps the detected env onto pyright settings (`pythonPath`, `venvPath`, `analysis.extraPaths`) and answers config sections **dialect-agnostically** (object + leaf, `python`/`pyright`/`basedpyright`), so a future basedpyright switch needs no protocol change.
- **Typed setup status** — raw error strings replaced with `ServerStatus` fields (`setupState`, `interpreterPath`, `extraPaths`, `action`, `detailCode`, …): `ready | missing_server | missing_interpreter | misconfigured_env | config_degraded | retryable`. Frontend renders a non-blocking `LSPSetupCard` above the editor; `useLSPEvents` suppresses the raw Toast when a typed status is present.

The single highest-value lever is `python.pythonPath` → the venv interpreter: pyright introspects it for both site-packages (third-party imports) and version (`datetime.UTC`); `extraPaths:["src"]` covers first-party imports.

## Tests
- Go: `go test ./...` 399 pass; `golangci-lint` (v2.11.4) 0 issues. Includes the `workspace/configuration` round-trip regression (fails pre-change), the pure-detector table tests, provider/dialect tests, and status classification.
- Frontend: `npx jest` 893 pass; `tsc --noEmit` clean (pre-existing TS5107 aside); `npm run lint` 0 errors.

## Deferred
- **Phase 2:** managed/pinned server auto-provision (`~/.firn/servers`), `download_available`/`offline` states.
- **Follow-up:** command-backed uv/poetry env discovery outside the project root; interactive interpreter picker / Doctor panel (the `action`/`detailCode` fields are carried for it).

Part of #112 (Phase 1).

Generated with [Claude Code](https://claude.com/claude-code)