### PR TITLE
docs(roadmap): #71 P2 closed via #127 (recency sidecar); refresh priorities

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,7 +25,7 @@ Firn IDE brings the focused, keyboard-first productivity of JetBrains IDEs to a 
 | UI/UX Polish | **COMPLETE** | #35-36 |
 | Milestone 2: Terminal Integration | **IN PROGRESS** | #10-12 + #116 complete, #47 open |
 | Milestone 3: Workspace Management | **COMPLETE** | #13-15, #53-54 complete |
-| Milestone 4: Run Profiles | **IN PROGRESS** | #16-17, #59-64 complete; #18/#71 Phase 1 (#123) + #71 P2 panel (#125) shipped; #18 P3/P4, #103, #107 open |
+| Milestone 4: Run Profiles | **IN PROGRESS** | #16-17, #59-64 complete; #18/#71 Phase 1 (#123) + #71 P2 panel (#125) + P2 review follow-ups/recency sidecar (#127) shipped → #71 closed; #18 P3/P4, #103, #107 open |
 | Milestone 5: Language Server Protocol | **COMPLETE** | #19-22, #73-76 complete |
 | Milestone 6: Search | **COMPLETE** | #23-25 |
 | Milestone 7: Git Integration | Not started | #26-27 |
@@ -41,7 +41,9 @@ Firn IDE brings the focused, keyboard-first productivity of JetBrains IDEs to a 
 
 ## Next Priorities
 
-Current status: **Milestone 4 #71 P2 (Run Profiles panel UX) shipped via PR #125** — the panel is now a four-section working set (Working Set / Pinned / RECENT / Detected) driven by a pure `groupProfiles` selector, with per-workspace adoption persisted in `.firn/run-profiles.json` **v3** and run recency persisted in `.firn/run-recency.json`, a `RunProfilesSnapshot{profiles, profileState}` single hydration contract emitted on every `runprofiles:changed`, Workspace/Project views (reusing the tree-view toggle, single source of truth), view-scoped `● N running · M total` counters, and a 5-min-windowed workspace-accent "just-ran" highlight. New app bindings `AdoptRunProfile`/`UnadoptRunProfile`/`GetRunProfilesSnapshot`. Earlier: **Phase 1 (workspace-owned detection + identity) shipped via #123** — repo-scoped `ProjectRunProfileManager`, owning-workspace identity + workspace-scoped IDs, per-workspace store with v1→v2 migration, owner-routed save/pin/delete, plus detector hardening (language markers beat infra; infra split Docker/Terraform; dot-dirs skipped). Remaining Run Profiles UI: **P3** header `[▶ Profile ▾]` selector (#18) and **P4** create/edit form (#18).
+Current status: **Milestone 4 #71 P2 closed — review follow-ups + recency sidecar shipped via PR #127** (on top of the P2 panel, PR #125). #127 closes the three open P2 review follow-ups: a nil-`executor` guard in `StartRunProfile` (mirrors `StopRunProfile`); **run recency split into the `.firn/run-recency.json` sidecar**, separate from `run-profiles.json` (now profile definitions + adoption only), so stamping a run writes the tiny sidecar *synchronously* and never rewrites profile definitions — fixing per-run write amplification at the root with no debounce timer (and therefore no orphaned-write race, no lost-on-SIGKILL window, and write errors surfaced to the caller); legacy v3 files that embedded recency migrate into the sidecar on load; and `Store.PruneState` drops stale recency-only `profileState` entries on load (saved+detected IDs valid) while preserving `adopted` entries through branch churn. Also a repo-hygiene commit: a `trimws` git clean filter + `.gitattributes` kills the perpetual trailing-whitespace churn Wails emits into `wailsjs/go/*.ts` on every build.
+
+The **P2 panel (PR #125)** is a four-section working set (Working Set / Pinned / RECENT / Detected) driven by a pure `groupProfiles` selector, with per-workspace adoption persisted in `.firn/run-profiles.json` **v3** and run recency in the `.firn/run-recency.json` sidecar, a `RunProfilesSnapshot{profiles, profileState}` single hydration contract emitted on every `runprofiles:changed`, Workspace/Project views (reusing the tree-view toggle, single source of truth), view-scoped `● N running · M total` counters, and a 5-min-windowed workspace-accent "just-ran" highlight. New app bindings `AdoptRunProfile`/`UnadoptRunProfile`/`GetRunProfilesSnapshot`. Earlier: **Phase 1 (workspace-owned detection + identity) shipped via #123** — repo-scoped `ProjectRunProfileManager`, owning-workspace identity + workspace-scoped IDs, per-workspace store with v1→v2 migration, owner-routed save/pin/delete, plus detector hardening (language markers beat infra; infra split Docker/Terraform; dot-dirs skipped). Remaining Run Profiles UI: **P3** header `[▶ Profile ▾]` selector (#18) and **P4** create/edit form (#18).
 
 Earlier: **#112 Phase 1 (Python LSP environment auto-wiring) shipped via PR #121** — pyright now resolves imports/types in a standard `src`-layout uv/venv project with zero per-project config. New pure `internal/lsp/pythonenv` interpreter/venv detector; the client answers pyright's `workspace/configuration` pull (was replying `-32601` to all server requests — the root cause) and advertises the capability + `didChangeConfiguration`; a Manager-owned, dialect-agnostic `WorkspaceConfigProvider` forwards `pythonPath`/`venvPath`/`analysis.extraPaths`; raw server errors are replaced by a typed setup status + non-blocking `LSPSetupCard`. Earlier shipped: **editor theme system + diagnostic tooltip (#113/#114, PR #117)** with #119 picker focus polish, **terminal PTY-exhaustion actionable error (#116)**, **file-tree / tab-bar scrollbar fixes (#118)**. Milestone 3 (Workspace Management) complete; file-tree virtualization shipped (#37/#38, PR #111). The #17 Run Profiles Execution Engine epic (#59-64) is complete; remaining Run Profiles work is the UI layer. Lazy-loading (#37 Phase 2) deferred to its own spec.
 
@@ -188,14 +190,15 @@ Backend prerequisite for the Run Profiles UI — profiles now carry an owning wo
 - [x] Load resilience: atomic build-then-swap, degrade-on-corrupt-store, non-fatal migration persist, surfaced warnings
 - [x] Workspace detector fixes: language markers beat infra; infra split → Docker (purple) / Terraform (amber); dot-directories skipped (no phantom `.worktrees` workspaces); duplicate workspace names disambiguated; file-explorer tree hides dot-folders (dot-files stay)
 
-### #71: Run Profiles - Activated State, Section Reorganization, and Selection Persistence (P2) ✅ (PR #125)
+### #71: Run Profiles - Activated State, Section Reorganization, and Selection Persistence (P2) ✅ CLOSED (PR #125 panel + PR #127 follow-ups)
 - [x] Activated profile working set (adopt/unadopt; persisted per workspace)
 - [x] Reorganize sections into Working Set / Pinned / RECENT / Detected (four-section cascade via pure `groupProfiles`)
 - [x] RECENT section: a just-run profile floats above Detected unless already saved/pinned
-- [x] Persist activation + run-recency per workspace (`.firn/run-profiles.json` v3 + `.firn/run-recency.json`, atomic writes)
+- [x] Persist activation in `.firn/run-profiles.json` v3 (definitions + adoption) and run recency in the `.firn/run-recency.json` sidecar (split in #127), both atomic temp+rename writes
 - [x] Header counter with running/total counts (view-scoped)
 - [x] Workspace/Project view filter & grouping (reuses tree-view toggle, single source of truth)
 - [x] Workspace-accent just-ran highlight (5-min window) to distinguish the just-ran profile
+- [x] **P2 review follow-ups (PR #127):** nil-`executor` guard in `StartRunProfile`; recency moved to a synchronous sidecar (no per-run profiles-file rewrite, no debounce timer); legacy-recency migration on load; `Store.PruneState` drops stale recency-only state on load while preserving adopted entries
 
 ### #18: Run Profiles - UI Integration
 - [ ] Profile selector dropdown in header toolbar (`[▶ Profile ▾]`)


### PR DESCRIPTION
Refreshes the roadmap after PR #127 merged and #71 was closed.

- **M4 status row + Next Priorities lead:** #71 P2 fully shipped (panel #125 + review follow-ups/recency sidecar #127) → #71 closed.
- Documents the **`.firn/run-recency.json` sidecar split** — `run-profiles.json` now carries profile definitions + adoption only; recency is written synchronously to the sidecar (no per-run profiles-file rewrite, no debounce timer).
- **#71 section:** P2 review follow-ups checked off (nil-`executor` guard, recency sidecar, prune-on-load).

Docs-only.

Generated with [Claude Code](https://claude.com/claude-code)