### PR TITLE
feat(runprofiles): header run-profile selector + Cmd+R target (#18 P3)

### DIFF
--- a/frontend/src/__tests__/components/Header.test.tsx
+++ b/frontend/src/__tests__/components/Header.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { Header } from '../../components/Header/Header';
+import { useIDEStore } from '../../stores/ideStore';
+
+jest.mock('../../../wailsjs/go/main/App', () => ({
+  StartRunProfile: jest.fn().mockResolvedValue(undefined),
+  StopRunProfile: jest.fn().mockResolvedValue(undefined),
+  RestartRunProfile: jest.fn().mockResolvedValue(undefined),
+  SetActiveVariant: jest.fn().mockResolvedValue(undefined),
+  OpenFolderDialog: jest.fn().mockResolvedValue(''),
+}));
+
+jest.mock('../../../wailsjs/runtime/runtime', () => ({
+  EventsOn: jest.fn(() => jest.fn()),
+  EventsOff: jest.fn(),
+  WindowSetTitle: jest.fn(),
+}));
+
+beforeEach(() => {
+  useIDEStore.setState({
+    runProfiles: [{ id: 'p1', name: 'dev', type: 'single', source: 'user', workspaceId: 'ws1' }],
+    runProfileState: {},
+    runOutputs: {},
+    hiddenProfileIds: [],
+    stoppingProfileIds: [],
+    restartingProfileIds: [],
+    activeWorkspaceId: 'ws1',
+    workspaces: [{ id: 'ws1', name: 'frontend', path: '/x', accent: 'blue' }] as never,
+    selectedProfileId: null,
+    recentWorkspaces: [],
+  });
+});
+
+test('renders the run-profile selector in the header', () => {
+  render(<Header />);
+  expect(screen.getByRole('button', { name: /Run selected profile: dev/i })).toBeInTheDocument();
+});

--- a/frontend/src/__tests__/components/RunProfileCardSelected.test.tsx
+++ b/frontend/src/__tests__/components/RunProfileCardSelected.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RunProfileCard } from '../../components/RunProfiles/RunProfileCard';
+import { useIDEStore } from '../../stores/ideStore';
+import type { RunProfile } from '../../types/runProfile';
+
+jest.mock('../../../wailsjs/go/main/App', () => ({
+  StartRunProfile: jest.fn(() => Promise.resolve()),
+  StopRunProfile: jest.fn(() => Promise.resolve()),
+  RestartRunProfile: jest.fn(() => Promise.resolve()),
+  PinRunProfile: jest.fn(() => Promise.resolve()),
+  UnpinRunProfile: jest.fn(() => Promise.resolve()),
+  SetActiveVariant: jest.fn(() => Promise.resolve()),
+  AdoptRunProfile: jest.fn(() => Promise.resolve()),
+  UnadoptRunProfile: jest.fn(() => Promise.resolve()),
+}));
+
+const profile: RunProfile = { id: 'p1', name: 'dev', type: 'single', source: 'user' };
+const common = {
+  profile,
+  visualState: 'idle' as const,
+  runOutput: undefined,
+  runHistory: [],
+  isDormant: false,
+  isDuplicate: false,
+  onFocusOutput: jest.fn(),
+};
+
+beforeEach(() => useIDEStore.setState({ selectedProfileId: null }));
+
+test('renders the target toggle; pressed state reflects isSelectedTarget', () => {
+  const { rerender } = render(<RunProfileCard {...common} isSelectedTarget={false} />);
+  const toggle = screen.getByRole('button', { name: /set as run target|run target/i });
+  expect(toggle).toHaveAttribute('aria-pressed', 'false');
+  rerender(<RunProfileCard {...common} isSelectedTarget={true} />);
+  expect(screen.getByRole('button', { name: /run target/i })).toHaveAttribute(
+    'aria-pressed',
+    'true'
+  );
+});
+
+test('clicking the toggle selects the profile and does not expand the card', () => {
+  render(<RunProfileCard {...common} isSelectedTarget={false} />);
+  fireEvent.click(screen.getByRole('button', { name: /run target/i }));
+  expect(useIDEStore.getState().selectedProfileId).toBe('p1');
+});

--- a/frontend/src/__tests__/components/RunProfileSelector.test.tsx
+++ b/frontend/src/__tests__/components/RunProfileSelector.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RunProfileSelector } from '../../components/Header/RunProfileSelector';
+import { useIDEStore } from '../../stores/ideStore';
+
+const mockStart = jest.fn().mockResolvedValue(undefined);
+const mockRestart = jest.fn().mockResolvedValue(undefined);
+const mockStop = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../wailsjs/go/main/App', () => ({
+  StartRunProfile: (...a: unknown[]) => mockStart(...a),
+  StopRunProfile: (...a: unknown[]) => mockStop(...a),
+  RestartRunProfile: (...a: unknown[]) => mockRestart(...a),
+  SetActiveVariant: jest.fn().mockResolvedValue(undefined),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useIDEStore.setState({
+    runProfiles: [{ id: 'p1', name: 'dev', type: 'single', source: 'user', workspaceId: 'ws1' }],
+    runProfileState: {},
+    runOutputs: {},
+    hiddenProfileIds: [],
+    stoppingProfileIds: [],
+    restartingProfileIds: [],
+    activeWorkspaceId: 'ws1', // drives workspace view (NOT a treeViewMode field)
+    workspaces: [{ id: 'ws1', name: 'frontend', path: '/x', accent: 'blue' }] as never,
+    selectedProfileId: null,
+  });
+});
+
+test('shows the effective target name and a Run action', () => {
+  render(<RunProfileSelector />);
+  expect(screen.getByText('dev')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /Run selected profile: dev/i })).toBeEnabled();
+});
+
+test('clicking the action segment starts the target', () => {
+  render(<RunProfileSelector />);
+  fireEvent.click(screen.getByRole('button', { name: /Run selected profile: dev/i }));
+  expect(mockStart).toHaveBeenCalledWith('p1');
+});
+
+test('with no profiles, shows disabled No profile state', () => {
+  useIDEStore.setState({ runProfiles: [] });
+  render(<RunProfileSelector />);
+  expect(screen.getByText(/No profile/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /No run profile selected/i })).toBeDisabled();
+});

--- a/frontend/src/__tests__/components/RunProfileSelectorPopover.test.tsx
+++ b/frontend/src/__tests__/components/RunProfileSelectorPopover.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { RunProfileSelector } from '../../components/Header/RunProfileSelector';
+import { useIDEStore } from '../../stores/ideStore';
+
+const mockStart = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../wailsjs/go/main/App', () => ({
+  StartRunProfile: (...a: unknown[]) => mockStart(...a),
+  StopRunProfile: jest.fn().mockResolvedValue(undefined),
+  RestartRunProfile: jest.fn().mockResolvedValue(undefined),
+  SetActiveVariant: jest.fn().mockResolvedValue(undefined),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useIDEStore.setState({
+    runProfiles: [
+      { id: 'p1', name: 'dev', type: 'single', source: 'user', workspaceId: 'ws1' },
+      { id: 'p2', name: 'test', type: 'single', source: 'user', workspaceId: 'ws1' },
+    ],
+    runProfileState: {},
+    runOutputs: {},
+    hiddenProfileIds: [],
+    stoppingProfileIds: [],
+    restartingProfileIds: [],
+    activeWorkspaceId: 'ws1', // workspace view (NOT a treeViewMode field)
+    workspaces: [{ id: 'ws1', name: 'frontend', path: '/x', accent: 'blue' }] as never,
+    selectedProfileId: 'p1',
+  });
+});
+
+function open() {
+  render(<RunProfileSelector />);
+  fireEvent.click(screen.getByRole('button', { name: /No profile|dev|test/i, expanded: false }));
+}
+
+test('opens popover and lists profiles as rows', () => {
+  open();
+  const pop = screen.getByRole('dialog', { name: /run profiles/i });
+  expect(within(pop).getByText('dev')).toBeInTheDocument();
+  expect(within(pop).getByText('test')).toBeInTheDocument();
+});
+
+test('row click selects the profile without running it', () => {
+  open();
+  const pop = screen.getByRole('dialog');
+  fireEvent.click(within(pop).getByText('test'));
+  expect(useIDEStore.getState().selectedProfileId).toBe('p2');
+  expect(mockStart).not.toHaveBeenCalled();
+});
+
+test('inline run button runs that row immediately', () => {
+  open();
+  const pop = screen.getByRole('dialog');
+  fireEvent.click(within(pop).getByRole('button', { name: /Run test/i }));
+  expect(mockStart).toHaveBeenCalledWith('p2');
+});
+
+test('Escape closes the popover', () => {
+  open();
+  fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+});

--- a/frontend/src/__tests__/components/RunProfileSelectorPopover.test.tsx
+++ b/frontend/src/__tests__/components/RunProfileSelectorPopover.test.tsx
@@ -3,11 +3,13 @@ import { RunProfileSelector } from '../../components/Header/RunProfileSelector';
 import { useIDEStore } from '../../stores/ideStore';
 
 const mockStart = jest.fn().mockResolvedValue(undefined);
+const mockStop = jest.fn().mockResolvedValue(undefined);
+const mockRestart = jest.fn().mockResolvedValue(undefined);
 const mockSetVariant = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../../wailsjs/go/main/App', () => ({
   StartRunProfile: (...a: unknown[]) => mockStart(...a),
-  StopRunProfile: jest.fn().mockResolvedValue(undefined),
-  RestartRunProfile: jest.fn().mockResolvedValue(undefined),
+  StopRunProfile: (...a: unknown[]) => mockStop(...a),
+  RestartRunProfile: (...a: unknown[]) => mockRestart(...a),
   SetActiveVariant: (...a: unknown[]) => mockSetVariant(...a),
 }));
 
@@ -58,9 +60,55 @@ test('inline run button runs that row immediately', () => {
   expect(mockStart).toHaveBeenCalledWith('p2');
 });
 
+test('inline action stops a running row', () => {
+  useIDEStore.setState({
+    runOutputs: {
+      p2: {
+        profileId: 'p2',
+        state: 'running',
+        exitCode: 0,
+        runCount: 1,
+        entries: [],
+        previousEntries: [],
+      },
+    },
+  });
+  open();
+  fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /Stop test/i }));
+  expect(mockStop).toHaveBeenCalledWith('p2');
+});
+
+test('inline action restarts a failed row', () => {
+  useIDEStore.setState({
+    runOutputs: {
+      p2: {
+        profileId: 'p2',
+        state: 'failed',
+        exitCode: 1,
+        runCount: 1,
+        entries: [],
+        previousEntries: [],
+      },
+    },
+  });
+  open();
+  fireEvent.click(
+    within(screen.getByRole('dialog')).getByRole('button', { name: /Restart test/i })
+  );
+  expect(mockRestart).toHaveBeenCalledWith('p2');
+});
+
 test('Escape closes the popover', () => {
   open();
   fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /dev/i, expanded: false })).toHaveFocus();
+});
+
+test('clicking the trigger again closes the popover', () => {
+  open();
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: /dev/i, expanded: true }));
   expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 });
 
@@ -123,6 +171,36 @@ test('changing the env variant calls SetActiveVariant', () => {
     target: { value: 'prod' },
   });
   expect(mockSetVariant).toHaveBeenCalledWith('p1', 'prod');
+});
+
+test('env variant selector preserves base as the empty value', () => {
+  useIDEStore.setState({
+    runProfiles: [
+      {
+        id: 'p1',
+        name: 'dev',
+        type: 'single',
+        source: 'user',
+        workspaceId: 'ws1',
+        envVariants: [
+          { name: 'dev', envFile: '.env' },
+          { name: 'prod', envFile: '.env.prod' },
+        ],
+      },
+    ],
+    activeWorkspaceId: 'ws1',
+    selectedProfileId: 'p1',
+  });
+  open();
+  const select = within(screen.getByRole('dialog')).getByLabelText(
+    'Env variant for dev'
+  ) as HTMLSelectElement;
+  expect(select.value).toBe('');
+  expect(within(select).getByRole('option', { name: 'base' })).toHaveValue('');
+
+  fireEvent.change(select, { target: { value: 'prod' } });
+  fireEvent.change(select, { target: { value: '' } });
+  expect(mockSetVariant).toHaveBeenLastCalledWith('p1', '');
 });
 
 test('shows the selected target as an outside-view row when it is in another workspace', () => {

--- a/frontend/src/__tests__/components/RunProfileSelectorPopover.test.tsx
+++ b/frontend/src/__tests__/components/RunProfileSelectorPopover.test.tsx
@@ -3,11 +3,12 @@ import { RunProfileSelector } from '../../components/Header/RunProfileSelector';
 import { useIDEStore } from '../../stores/ideStore';
 
 const mockStart = jest.fn().mockResolvedValue(undefined);
+const mockSetVariant = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../../wailsjs/go/main/App', () => ({
   StartRunProfile: (...a: unknown[]) => mockStart(...a),
   StopRunProfile: jest.fn().mockResolvedValue(undefined),
   RestartRunProfile: jest.fn().mockResolvedValue(undefined),
-  SetActiveVariant: jest.fn().mockResolvedValue(undefined),
+  SetActiveVariant: (...a: unknown[]) => mockSetVariant(...a),
 }));
 
 beforeEach(() => {
@@ -30,7 +31,9 @@ beforeEach(() => {
 
 function open() {
   render(<RunProfileSelector />);
-  fireEvent.click(screen.getByRole('button', { name: /No profile|dev|test/i, expanded: false }));
+  fireEvent.click(
+    screen.getByRole('button', { name: /No profile|dev|test|api/i, expanded: false })
+  );
 }
 
 test('opens popover and lists profiles as rows', () => {
@@ -59,4 +62,80 @@ test('Escape closes the popover', () => {
   open();
   fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
   expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+});
+
+test('project view groups rows by workspace', () => {
+  useIDEStore.setState({
+    runProfiles: [
+      {
+        id: 'p1',
+        name: 'dev',
+        type: 'single',
+        source: 'user',
+        workspaceId: 'ws1',
+        workspaceName: 'frontend',
+      },
+      {
+        id: 'p2',
+        name: 'api',
+        type: 'single',
+        source: 'user',
+        workspaceId: 'ws2',
+        workspaceName: 'backend',
+      },
+    ],
+    workspaces: [
+      { id: 'ws1', name: 'frontend', path: '/x', accent: 'blue' },
+      { id: 'ws2', name: 'backend', path: '/y', accent: 'green' },
+    ] as never,
+    activeWorkspaceId: 'project', // project view
+    selectedProfileId: null,
+  });
+  open();
+  const pop = screen.getByRole('dialog');
+  expect(within(pop).getByText('frontend')).toBeInTheDocument();
+  expect(within(pop).getByText('backend')).toBeInTheDocument();
+  expect(within(pop).getByText('dev')).toBeInTheDocument();
+  expect(within(pop).getByText('api')).toBeInTheDocument();
+});
+
+test('changing the env variant calls SetActiveVariant', () => {
+  useIDEStore.setState({
+    runProfiles: [
+      {
+        id: 'p1',
+        name: 'dev',
+        type: 'single',
+        source: 'user',
+        workspaceId: 'ws1',
+        envVariants: [
+          { name: 'dev', envFile: '.env' },
+          { name: 'prod', envFile: '.env.prod' },
+        ],
+      },
+    ],
+    activeWorkspaceId: 'ws1',
+    selectedProfileId: 'p1',
+  });
+  open();
+  const pop = screen.getByRole('dialog');
+  fireEvent.change(within(pop).getByLabelText('Env variant for dev'), {
+    target: { value: 'prod' },
+  });
+  expect(mockSetVariant).toHaveBeenCalledWith('p1', 'prod');
+});
+
+test('shows the selected target as an outside-view row when it is in another workspace', () => {
+  useIDEStore.setState({
+    runProfiles: [
+      { id: 'p1', name: 'dev', type: 'single', source: 'user', workspaceId: 'ws1' },
+      { id: 'p2', name: 'api', type: 'single', source: 'user', workspaceId: 'ws2' },
+    ],
+    activeWorkspaceId: 'ws1', // workspace view scoped to ws1
+    selectedProfileId: 'p2', // lives in ws2 -> outside this view
+  });
+  open();
+  const pop = screen.getByRole('dialog');
+  expect(within(pop).getByText(/Selected \(outside this view\)/i)).toBeInTheDocument();
+  expect(within(pop).getByText('api')).toBeInTheDocument();
 });

--- a/frontend/src/__tests__/components/RunProfiles.test.tsx
+++ b/frontend/src/__tests__/components/RunProfiles.test.tsx
@@ -215,6 +215,21 @@ describe('RunProfiles panel — empty state', () => {
   });
 });
 
+test('marks the effective run target card as selected', () => {
+  useIDEStore.setState({
+    runProfiles: [{ id: 'p1', name: 'dev', type: 'single', source: 'user', workspaceId: WS }],
+    runProfileState: {},
+    hiddenProfileIds: [],
+    activeWorkspaceId: WS,
+    selectedProfileId: 'p1',
+  });
+  render(<RunProfiles />);
+  expect(screen.getByRole('button', { name: /Run target: dev/i })).toHaveAttribute(
+    'aria-pressed',
+    'true'
+  );
+});
+
 describe('RunProfiles panel — view toggle', () => {
   it('renders a Workspace/Project segmented toggle and switching to Project drives setTreeViewMode', async () => {
     const user = userEvent.setup();

--- a/frontend/src/__tests__/hooks/useEffectiveRunTarget.test.ts
+++ b/frontend/src/__tests__/hooks/useEffectiveRunTarget.test.ts
@@ -1,0 +1,27 @@
+import { renderHook } from '@testing-library/react';
+import { useEffectiveRunTarget } from '../../hooks/useEffectiveRunTarget';
+import { useIDEStore } from '../../stores/ideStore';
+
+beforeEach(() => {
+  useIDEStore.setState({
+    selectedProfileId: null,
+    runProfiles: [
+      { id: 'a', name: 'a', type: 'single', source: 'user', workspaceId: 'ws1' },
+      { id: 'b', name: 'b', type: 'single', source: 'detected', workspaceId: 'ws1' },
+    ],
+    runProfileState: { b: { lastRunAt: 99 } },
+    hiddenProfileIds: [],
+    activeWorkspaceId: 'ws1',
+  });
+});
+
+test('returns recency default when nothing selected', () => {
+  const { result } = renderHook(() => useEffectiveRunTarget());
+  expect(result.current).toBe('b'); // b ran most recently
+});
+
+test('reflects explicit selection', () => {
+  useIDEStore.getState().setSelectedProfile('a');
+  const { result } = renderHook(() => useEffectiveRunTarget());
+  expect(result.current).toBe('a');
+});

--- a/frontend/src/__tests__/hooks/useKeyboardShortcuts.test.ts
+++ b/frontend/src/__tests__/hooks/useKeyboardShortcuts.test.ts
@@ -6,9 +6,14 @@ import { useSearchStore } from '../../stores/searchStore';
 // Mock Wails bindings
 const mockOpenFolderDialog = jest.fn();
 const mockNavigateToEditorLocation = jest.fn();
+const mockStartProfile = jest.fn().mockResolvedValue(undefined);
+const mockRestartProfile = jest.fn().mockResolvedValue(undefined);
 jest.mock('../../../wailsjs/go/main/App', () => ({
   OpenFolderDialog: (...args: unknown[]) => mockOpenFolderDialog(...args),
   ReadDirectory: jest.fn().mockResolvedValue([]),
+  StartRunProfile: (...a: unknown[]) => mockStartProfile(...a),
+  RestartRunProfile: (...a: unknown[]) => mockRestartProfile(...a),
+  StopRunProfile: jest.fn().mockResolvedValue(undefined),
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -258,5 +263,60 @@ describe('useKeyboardShortcuts', () => {
       { fileId: '/definition-source.ts', line: 3, column: 2 },
     ]);
     expect(useIDEStore.getState().navigationForward).toEqual([]);
+  });
+});
+
+function runShortcutEvent(): KeyboardEvent {
+  return new KeyboardEvent('keydown', {
+    key: 'r',
+    ctrlKey: !isMac,
+    metaKey: isMac,
+    bubbles: true,
+    cancelable: true,
+  });
+}
+
+describe('Cmd/Ctrl+R run target', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useIDEStore.setState({
+      runProfiles: [{ id: 'p1', name: 'dev', type: 'single', source: 'user', workspaceId: 'ws1' }],
+      runProfileState: {},
+      runOutputs: {},
+      hiddenProfileIds: [],
+      stoppingProfileIds: [],
+      restartingProfileIds: [],
+      activeWorkspaceId: 'ws1',
+      selectedProfileId: 'p1',
+    });
+  });
+
+  test('starts the target when idle and prevents default (no page reload)', () => {
+    renderHook(() => useKeyboardShortcuts());
+    const ev = runShortcutEvent();
+    act(() => {
+      window.dispatchEvent(ev);
+    });
+    expect(mockStartProfile).toHaveBeenCalledWith('p1');
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  test('restarts the target when running', () => {
+    useIDEStore.setState({ runOutputs: { p1: { state: 'running' } } as never });
+    renderHook(() => useKeyboardShortcuts());
+    act(() => {
+      window.dispatchEvent(runShortcutEvent());
+    });
+    expect(mockRestartProfile).toHaveBeenCalledWith('p1');
+  });
+
+  test('no-op while stopping', () => {
+    useIDEStore.setState({ stoppingProfileIds: ['p1'] });
+    renderHook(() => useKeyboardShortcuts());
+    act(() => {
+      window.dispatchEvent(runShortcutEvent());
+    });
+    expect(mockStartProfile).not.toHaveBeenCalled();
+    expect(mockRestartProfile).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/__tests__/stores/runProfileSelection.test.ts
+++ b/frontend/src/__tests__/stores/runProfileSelection.test.ts
@@ -1,0 +1,17 @@
+// frontend/src/__tests__/stores/runProfileSelection.test.ts
+import { useIDEStore } from '../../stores/ideStore';
+
+beforeEach(() => {
+  useIDEStore.setState({ selectedProfileId: null });
+});
+
+test('selectedProfileId defaults to null', () => {
+  expect(useIDEStore.getState().selectedProfileId).toBeNull();
+});
+
+test('setSelectedProfile sets and clears the id', () => {
+  useIDEStore.getState().setSelectedProfile('p1');
+  expect(useIDEStore.getState().selectedProfileId).toBe('p1');
+  useIDEStore.getState().setSelectedProfile(null);
+  expect(useIDEStore.getState().selectedProfileId).toBeNull();
+});

--- a/frontend/src/__tests__/utils/profileActions.test.ts
+++ b/frontend/src/__tests__/utils/profileActions.test.ts
@@ -1,0 +1,33 @@
+const mockStart = jest.fn().mockResolvedValue(undefined);
+const mockStop = jest.fn().mockResolvedValue(undefined);
+const mockRestart = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../wailsjs/go/main/App', () => ({
+  StartRunProfile: (...a: unknown[]) => mockStart(...a),
+  StopRunProfile: (...a: unknown[]) => mockStop(...a),
+  RestartRunProfile: (...a: unknown[]) => mockRestart(...a),
+}));
+
+import { startProfile, stopProfile, restartProfile } from '../../utils/profileActions';
+import { useIDEStore } from '../../stores/ideStore';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useIDEStore.setState({ stoppingProfileIds: [], restartingProfileIds: [] });
+});
+
+test('startProfile calls the binding', () => {
+  startProfile('p1', 'Dev');
+  expect(mockStart).toHaveBeenCalledWith('p1');
+});
+
+test('stopProfile flags stopping then calls the binding', () => {
+  stopProfile('p1', 'Dev');
+  expect(useIDEStore.getState().stoppingProfileIds).toContain('p1');
+  expect(mockStop).toHaveBeenCalledWith('p1');
+});
+
+test('restartProfile flags restarting then calls the binding', () => {
+  restartProfile('p1', 'Dev');
+  expect(useIDEStore.getState().restartingProfileIds).toContain('p1');
+  expect(mockRestart).toHaveBeenCalledWith('p1');
+});

--- a/frontend/src/__tests__/utils/resolveEffectiveRunTarget.test.ts
+++ b/frontend/src/__tests__/utils/resolveEffectiveRunTarget.test.ts
@@ -17,6 +17,14 @@ test('explicit selection wins when visible', () => {
   ).toBe('b');
 });
 
+test('explicit selection wins even when profile is in a different workspace', () => {
+  // Selection is global, NOT workspace-scoped (spec §5 step 1).
+  const profiles = [p('a', { workspaceId: 'ws1' }), p('b', { workspaceId: 'ws2' })];
+  expect(
+    resolveEffectiveRunTargetId({ ...base, selectedProfileId: 'b', profiles, profileState: {} })
+  ).toBe('b');
+});
+
 test('hidden explicit selection falls through to default', () => {
   const profiles = [p('a', { source: 'user' }), p('b')];
   const r = resolveEffectiveRunTargetId({

--- a/frontend/src/__tests__/utils/resolveEffectiveRunTarget.test.ts
+++ b/frontend/src/__tests__/utils/resolveEffectiveRunTarget.test.ts
@@ -1,0 +1,65 @@
+import { resolveEffectiveRunTargetId } from '../../utils/resolveEffectiveRunTarget';
+import type { RunProfile, RunProfileUIState } from '../../types/runProfile';
+
+function p(id: string, over: Partial<RunProfile> = {}): RunProfile {
+  return { id, name: id, type: 'single', source: 'detected', ...over };
+}
+const base = {
+  selectedProfileId: null as string | null,
+  hiddenProfileIds: [] as string[],
+  activeWorkspaceId: 'ws1',
+};
+
+test('explicit selection wins when visible', () => {
+  const profiles = [p('a'), p('b')];
+  expect(
+    resolveEffectiveRunTargetId({ ...base, selectedProfileId: 'b', profiles, profileState: {} })
+  ).toBe('b');
+});
+
+test('hidden explicit selection falls through to default', () => {
+  const profiles = [p('a', { source: 'user' }), p('b')];
+  const r = resolveEffectiveRunTargetId({
+    ...base,
+    selectedProfileId: 'b',
+    hiddenProfileIds: ['b'],
+    profiles,
+    profileState: {},
+  });
+  expect(r).toBe('a'); // first pinned (user) profile
+});
+
+test('default = most-recently-run adopted', () => {
+  const profiles = [p('a', { workspaceId: 'ws1' }), p('b', { workspaceId: 'ws1' })];
+  const state: Record<string, RunProfileUIState> = {
+    a: { adopted: true, lastRunAt: 10 },
+    b: { adopted: true, lastRunAt: 20 },
+  };
+  expect(resolveEffectiveRunTargetId({ ...base, profiles, profileState: state })).toBe('b');
+});
+
+test('falls to most-recent-run of any source when no adopted', () => {
+  const profiles = [p('a', { workspaceId: 'ws1' }), p('b', { workspaceId: 'ws1' })];
+  const state = { a: { lastRunAt: 5 }, b: { lastRunAt: 9 } };
+  expect(resolveEffectiveRunTargetId({ ...base, profiles, profileState: state })).toBe('b');
+});
+
+test('falls to first pinned then first detected when nothing ran', () => {
+  const profiles = [
+    p('d1', { workspaceId: 'ws1' }),
+    p('u1', { source: 'user', workspaceId: 'ws1' }),
+  ];
+  expect(resolveEffectiveRunTargetId({ ...base, profiles, profileState: {} })).toBe('u1');
+});
+
+test('prefers active workspace before falling back globally', () => {
+  const profiles = [
+    p('other', { workspaceId: 'ws2', source: 'user' }),
+    p('mine', { workspaceId: 'ws1', source: 'detected' }),
+  ];
+  expect(resolveEffectiveRunTargetId({ ...base, profiles, profileState: {} })).toBe('mine');
+});
+
+test('returns null when no visible profiles', () => {
+  expect(resolveEffectiveRunTargetId({ ...base, profiles: [], profileState: {} })).toBeNull();
+});

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -7,6 +7,7 @@ import { openWorkspaceByPath } from '../../utils/workspace';
 import { formatShortcut, isMac } from '../../utils/platform';
 import firnIcon from '../../assets/branding/icon.svg';
 import { WorkspaceSelector } from './WorkspaceSelector';
+import { RunProfileSelector } from './RunProfileSelector';
 
 const MENU_ID = 'workspace-menu';
 
@@ -201,6 +202,9 @@ export function Header() {
 
       {/* Spacer */}
       <div className={styles.spacer} />
+
+      {/* Run-profile selector (right-aligned) */}
+      <RunProfileSelector />
     </>
   );
 }

--- a/frontend/src/components/Header/RunProfileSelector.module.css
+++ b/frontend/src/components/Header/RunProfileSelector.module.css
@@ -108,7 +108,7 @@
   background: rgba(255, 255, 255, 0.05);
 }
 .rowSel {
-  box-shadow: inset 2px 0 0 var(--accent-blue, #6ea8fe);
+  box-shadow: inset 2px 0 0 var(--accent);
 }
 .rowSelect {
   flex: 1;
@@ -125,7 +125,7 @@
 }
 .mk {
   width: 11px;
-  color: var(--accent-blue, #6ea8fe);
+  color: var(--accent);
   text-align: center;
 }
 .rowName {

--- a/frontend/src/components/Header/RunProfileSelector.module.css
+++ b/frontend/src/components/Header/RunProfileSelector.module.css
@@ -1,0 +1,56 @@
+.wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+.action,
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+  background: var(--bg-elevated, rgba(255, 255, 255, 0.04));
+  color: var(--text-primary, #e6e6e6);
+  cursor: pointer;
+  font-size: 12px;
+}
+.action {
+  border-radius: 6px 0 0 6px;
+  border-right: none;
+  padding: 0 8px;
+}
+.trigger {
+  border-radius: 0 6px 6px 0;
+  padding: 0 8px;
+  font-weight: 600;
+  max-width: 180px;
+}
+.action:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.chevron {
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+.dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: transparent;
+}
+.dot[data-state='running'] {
+  background: var(--status-running, #5fd08a);
+}
+.dot[data-state='failed'] {
+  background: var(--status-failed, #e06c6c);
+}
+.dot[data-state='stopping'] {
+  background: var(--status-warn, #e0a458);
+}

--- a/frontend/src/components/Header/RunProfileSelector.module.css
+++ b/frontend/src/components/Header/RunProfileSelector.module.css
@@ -54,3 +54,123 @@
 .dot[data-state='stopping'] {
   background: var(--status-warn, #e0a458);
 }
+.popover {
+  position: absolute;
+  top: 32px;
+  right: 0;
+  z-index: 50;
+  width: 300px;
+  max-height: 60vh;
+  overflow-y: auto;
+  padding: 4px 0;
+  background: var(--bg-popover, #1b1d22);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.14));
+  border-radius: 9px;
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.5);
+}
+.group {
+  padding: 4px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+.group:first-child {
+  border-top: none;
+}
+.groupHead {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px 3px;
+  font-size: 11px;
+  font-weight: 600;
+}
+.wsDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+.section {
+  padding: 2px 0;
+}
+.sectionLabel {
+  padding: 3px 10px 1px 16px;
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.45;
+}
+.row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px 0 10px;
+}
+.row:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+.rowSel {
+  box-shadow: inset 2px 0 0 var(--accent-blue, #6ea8fe);
+}
+.rowSelect {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 6px 2px;
+  font-size: 12px;
+  text-align: left;
+}
+.mk {
+  width: 11px;
+  color: var(--accent-blue, #6ea8fe);
+  text-align: center;
+}
+.rowName {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.env {
+  font-size: 10px;
+  background: transparent;
+  color: var(--status-warn, #e0a458);
+  border: 1px solid rgba(224, 164, 88, 0.4);
+  border-radius: 9px;
+}
+.rowRun {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  background: none;
+  border: none;
+  color: var(--status-running, #5fd08a);
+  cursor: pointer;
+  border-radius: 4px;
+}
+.rowRun:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.footer {
+  padding: 7px 10px;
+  font-size: 11px;
+  opacity: 0.6;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/frontend/src/components/Header/RunProfileSelector.tsx
+++ b/frontend/src/components/Header/RunProfileSelector.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { PlayIcon, StopIcon, RestartIcon, LoaderIcon, ChevronDownIcon } from '../icons';
+import { useIDEStore } from '../../stores/ideStore';
+import { useEffectiveRunTarget } from '../../hooks/useEffectiveRunTarget';
+import { getVisualState } from '../../utils/visualState';
+import { startProfile, stopProfile, restartProfile } from '../../utils/profileActions';
+import styles from './RunProfileSelector.module.css';
+
+export function RunProfileSelector() {
+  const [isOpen, setIsOpen] = useState(false);
+  const profiles = useIDEStore((s) => s.runProfiles);
+  const runOutputs = useIDEStore((s) => s.runOutputs);
+  const stoppingIds = useIDEStore((s) => s.stoppingProfileIds);
+  const restartingIds = useIDEStore((s) => s.restartingProfileIds);
+  const effectiveId = useEffectiveRunTarget();
+
+  const target = profiles.find((p) => p.id === effectiveId) ?? null;
+  const vs = target
+    ? getVisualState(target.id, runOutputs[target.id]?.state, stoppingIds, restartingIds)
+    : 'idle';
+
+  const onAction = () => {
+    if (!target) return;
+    if (vs === 'stopping') return;
+    if (vs === 'running') stopProfile(target.id, target.name);
+    else if (vs === 'failed' || vs === 'stopped') restartProfile(target.id, target.name);
+    else startProfile(target.id, target.name);
+  };
+
+  const actionIcon =
+    vs === 'stopping' ? (
+      <LoaderIcon aria-hidden="true" />
+    ) : vs === 'running' ? (
+      <StopIcon aria-hidden="true" />
+    ) : vs === 'failed' || vs === 'stopped' ? (
+      <RestartIcon aria-hidden="true" />
+    ) : (
+      <PlayIcon aria-hidden="true" />
+    );
+
+  const actionLabel = !target
+    ? 'No run profile selected'
+    : vs === 'running'
+      ? `Stop selected profile: ${target.name}`
+      : vs === 'stopping'
+        ? `Stopping ${target.name}`
+        : vs === 'failed' || vs === 'stopped'
+          ? `Restart selected profile: ${target.name}`
+          : `Run selected profile: ${target.name}`;
+
+  return (
+    <div className={styles.wrap}>
+      <button
+        type="button"
+        className={`${styles.action} ${styles[`state_${vs}`] ?? ''}`}
+        onClick={onAction}
+        disabled={!target || vs === 'stopping'}
+        aria-label={actionLabel}
+      >
+        <span className={styles.dot} data-state={vs} aria-hidden="true" />
+        {actionIcon}
+      </button>
+      <button
+        type="button"
+        className={styles.trigger}
+        onClick={() => setIsOpen((o) => !o)}
+        aria-haspopup="dialog"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? 'run-profile-popover' : undefined}
+      >
+        <span className={styles.name}>{target ? target.name : 'No profile'}</span>
+        <ChevronDownIcon className={styles.chevron} aria-hidden="true" />
+      </button>
+      {/* Popover added in Task 9 */}
+    </div>
+  );
+}

--- a/frontend/src/components/Header/RunProfileSelector.tsx
+++ b/frontend/src/components/Header/RunProfileSelector.tsx
@@ -27,6 +27,7 @@ export function RunProfileSelector() {
   const activeWorkspaceId = useActiveWorkspaceId();
   const workspaces = useWorkspaces();
   const popRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const effectiveId = useEffectiveRunTarget();
 
   const target = profiles.find((p) => p.id === effectiveId) ?? null;
@@ -45,7 +46,15 @@ export function RunProfileSelector() {
   useEffect(() => {
     if (!isOpen) return;
     const onDown = (e: MouseEvent) => {
-      if (popRef.current && !popRef.current.contains(e.target as Node)) setIsOpen(false);
+      const node = e.target as Node;
+      if (
+        popRef.current &&
+        !popRef.current.contains(node) &&
+        triggerRef.current &&
+        !triggerRef.current.contains(node)
+      ) {
+        setIsOpen(false);
+      }
     };
     document.addEventListener('mousedown', onDown);
     return () => document.removeEventListener('mousedown', onDown);
@@ -54,8 +63,14 @@ export function RunProfileSelector() {
   const selectRow = (id: string) => {
     setSelectedProfile(id);
     setIsOpen(false);
+    triggerRef.current?.focus();
   };
-  const runRow = (p: RunProfile) => startProfile(p.id, p.name);
+  const actOnRow = (p: RunProfile, visualState: ReturnType<typeof getVisualState>) => {
+    if (visualState === 'stopping') return;
+    if (visualState === 'running') stopProfile(p.id, p.name);
+    else if (visualState === 'failed' || visualState === 'stopped') restartProfile(p.id, p.name);
+    else startProfile(p.id, p.name);
+  };
   const onVariantChange = (p: RunProfile, value: string) => {
     SetActiveVariant(p.id, value)
       .then(() => useIDEStore.getState().addOrUpdateProfile({ ...p, activeVariant: value }))
@@ -71,6 +86,16 @@ export function RunProfileSelector() {
   const renderRow = (p: RunProfile) => {
     const rvs = getVisualState(p.id, runOutputs[p.id]?.state, stoppingIds, restartingIds);
     const variants = (p.envVariants ?? []).filter((v) => v.name);
+    const rowActionLabel =
+      rvs === 'running'
+        ? `Stop ${p.name}`
+        : rvs === 'stopping'
+          ? `Stopping ${p.name}`
+          : rvs === 'failed' || rvs === 'stopped'
+            ? `Restart ${p.name}`
+            : `Run ${p.name}`;
+    const RowActionIcon =
+      rvs === 'running' ? StopIcon : rvs === 'failed' || rvs === 'stopped' ? RestartIcon : PlayIcon;
     return (
       <div key={p.id} className={`${styles.row} ${p.id === effectiveId ? styles.rowSel : ''}`}>
         <button
@@ -80,7 +105,7 @@ export function RunProfileSelector() {
           aria-pressed={p.id === effectiveId}
         >
           <span className={styles.mk} aria-hidden="true">
-            {p.id === effectiveId ? '◉' : ''}
+            {p.id === effectiveId ? '◎' : ''}
           </span>
           <span className={styles.rowName}>{p.name}</span>
           {p.id === effectiveId && <span className={styles.srOnly}>Selected target</span>}
@@ -88,10 +113,11 @@ export function RunProfileSelector() {
         {variants.length > 0 && (
           <select
             className={styles.env}
-            value={p.activeVariant ?? variants[0].name}
+            value={p.activeVariant ?? ''}
             aria-label={`Env variant for ${p.name}`}
             onChange={(e) => onVariantChange(p, e.currentTarget.value)}
           >
+            <option value="">base</option>
             {variants.map((v) => (
               <option key={v.name} value={v.name}>
                 {v.name}
@@ -102,11 +128,11 @@ export function RunProfileSelector() {
         <button
           type="button"
           className={styles.rowRun}
-          onClick={() => runRow(p)}
-          disabled={rvs === 'running' || rvs === 'stopping'}
-          aria-label={`Run ${p.name}`}
+          onClick={() => actOnRow(p, rvs)}
+          disabled={rvs === 'stopping'}
+          aria-label={rowActionLabel}
         >
-          <PlayIcon aria-hidden="true" />
+          <RowActionIcon aria-hidden="true" />
         </button>
       </div>
     );
@@ -187,6 +213,7 @@ export function RunProfileSelector() {
         {actionIcon}
       </button>
       <button
+        ref={triggerRef}
         type="button"
         className={styles.trigger}
         onClick={() => setIsOpen((o) => !o)}
@@ -205,7 +232,10 @@ export function RunProfileSelector() {
           role="dialog"
           aria-label="Run profiles"
           onKeyDown={(e) => {
-            if (e.key === 'Escape') setIsOpen(false);
+            if (e.key === 'Escape') {
+              setIsOpen(false);
+              triggerRef.current?.focus();
+            }
           }}
         >
           {targetOutsideView && (
@@ -216,7 +246,7 @@ export function RunProfileSelector() {
           )}
           {renderSections(visible)}
           <div className={styles.footer}>
-            <span>⌘R runs ◉ selected</span>
+            <span>⌘R runs ◎ selected</span>
           </div>
         </div>
       )}

--- a/frontend/src/components/Header/RunProfileSelector.tsx
+++ b/frontend/src/components/Header/RunProfileSelector.tsx
@@ -1,9 +1,17 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { PlayIcon, StopIcon, RestartIcon, LoaderIcon, ChevronDownIcon } from '../icons';
-import { useIDEStore } from '../../stores/ideStore';
+import {
+  useIDEStore,
+  useTreeViewMode,
+  useActiveWorkspaceId,
+  useWorkspaces,
+} from '../../stores/ideStore';
 import { useEffectiveRunTarget } from '../../hooks/useEffectiveRunTarget';
 import { getVisualState } from '../../utils/visualState';
 import { startProfile, stopProfile, restartProfile } from '../../utils/profileActions';
+import { SetActiveVariant } from '../../../wailsjs/go/main/App';
+import { groupProfiles, SECTION_LABEL, type ProfileSection } from '../../utils/groupProfiles';
+import type { RunProfile } from '../../types/runProfile';
 import styles from './RunProfileSelector.module.css';
 
 export function RunProfileSelector() {
@@ -12,9 +20,117 @@ export function RunProfileSelector() {
   const runOutputs = useIDEStore((s) => s.runOutputs);
   const stoppingIds = useIDEStore((s) => s.stoppingProfileIds);
   const restartingIds = useIDEStore((s) => s.restartingProfileIds);
+  const setSelectedProfile = useIDEStore((s) => s.setSelectedProfile);
+  const runProfileState = useIDEStore((s) => s.runProfileState);
+  const hiddenProfileIds = useIDEStore((s) => s.hiddenProfileIds);
+  const viewMode = useTreeViewMode();
+  const activeWorkspaceId = useActiveWorkspaceId();
+  const workspaces = useWorkspaces();
+  const popRef = useRef<HTMLDivElement>(null);
   const effectiveId = useEffectiveRunTarget();
 
   const target = profiles.find((p) => p.id === effectiveId) ?? null;
+  const visible = profiles.filter((p) => !hiddenProfileIds.includes(p.id));
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (popRef.current && !popRef.current.contains(e.target as Node)) setIsOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [isOpen]);
+
+  const selectRow = (id: string) => {
+    setSelectedProfile(id);
+    setIsOpen(false);
+  };
+  const runRow = (p: RunProfile) => startProfile(p.id, p.name);
+  const onVariantChange = (p: RunProfile, value: string) => {
+    SetActiveVariant(p.id, value)
+      .then(() => useIDEStore.getState().addOrUpdateProfile({ ...p, activeVariant: value }))
+      .catch((err: unknown) =>
+        useIDEStore
+          .getState()
+          .showToast(
+            `Failed to switch "${p.name}" env: ${err instanceof Error ? err.message : String(err)}`,
+            'error'
+          )
+      );
+  };
+  const renderRow = (p: RunProfile) => {
+    const rvs = getVisualState(p.id, runOutputs[p.id]?.state, stoppingIds, restartingIds);
+    const variants = (p.envVariants ?? []).filter((v) => v.name);
+    return (
+      <div key={p.id} className={`${styles.row} ${p.id === effectiveId ? styles.rowSel : ''}`}>
+        <button
+          type="button"
+          className={styles.rowSelect}
+          onClick={() => selectRow(p.id)}
+          aria-pressed={p.id === effectiveId}
+        >
+          <span className={styles.mk} aria-hidden="true">
+            {p.id === effectiveId ? '◉' : ''}
+          </span>
+          <span className={styles.rowName}>{p.name}</span>
+          {p.id === effectiveId && <span className={styles.srOnly}>Selected target</span>}
+        </button>
+        {variants.length > 0 && (
+          <select
+            className={styles.env}
+            value={p.activeVariant ?? variants[0].name}
+            aria-label={`Env variant for ${p.name}`}
+            onChange={(e) => onVariantChange(p, e.currentTarget.value)}
+          >
+            {variants.map((v) => (
+              <option key={v.name} value={v.name}>
+                {v.name}
+              </option>
+            ))}
+          </select>
+        )}
+        <button
+          type="button"
+          className={styles.rowRun}
+          onClick={() => runRow(p)}
+          disabled={rvs === 'running' || rvs === 'stopping'}
+          aria-label={`Run ${p.name}`}
+        >
+          <PlayIcon aria-hidden="true" />
+        </button>
+      </div>
+    );
+  };
+
+  const renderSectionRows = (key: ProfileSection, list: RunProfile[]) =>
+    list.length > 0 ? (
+      <div key={key} className={styles.section}>
+        <div className={styles.sectionLabel}>{SECTION_LABEL[key]}</div>
+        {list.map(renderRow)}
+      </div>
+    ) : null;
+
+  const renderSections = (list: RunProfile[]) => {
+    const grouped = groupProfiles(list, runProfileState, { viewMode, activeWorkspaceId });
+    if (viewMode === 'project') {
+      return grouped.workspaceGroups.map((wg) => (
+        <div key={wg.workspaceId} className={styles.group}>
+          <div className={styles.groupHead}>
+            <span
+              className={styles.wsDot}
+              style={{
+                background: `var(--accent-${workspaces.find((w) => w.id === wg.workspaceId)?.accent ?? 'project'})`,
+              }}
+            />
+            {wg.workspaceName}
+          </div>
+          {wg.sections.map((s) => renderSectionRows(s.key, s.profiles))}
+        </div>
+      ));
+    }
+    return grouped.sections.map((s) => renderSectionRows(s.key, s.profiles));
+  };
+
   const vs = target
     ? getVisualState(target.id, runOutputs[target.id]?.state, stoppingIds, restartingIds)
     : 'idle';
@@ -52,7 +168,7 @@ export function RunProfileSelector() {
     <div className={styles.wrap}>
       <button
         type="button"
-        className={`${styles.action} ${styles[`state_${vs}`] ?? ''}`}
+        className={styles.action}
         onClick={onAction}
         disabled={!target || vs === 'stopping'}
         aria-label={actionLabel}
@@ -71,7 +187,29 @@ export function RunProfileSelector() {
         <span className={styles.name}>{target ? target.name : 'No profile'}</span>
         <ChevronDownIcon className={styles.chevron} aria-hidden="true" />
       </button>
-      {/* Popover added in Task 9 */}
+      {isOpen && (
+        <div
+          ref={popRef}
+          id="run-profile-popover"
+          className={styles.popover}
+          role="dialog"
+          aria-label="Run profiles"
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') setIsOpen(false);
+          }}
+        >
+          {target && !visible.some((p) => p.id === target.id) && (
+            <div className={styles.section}>
+              <div className={styles.sectionLabel}>Selected (outside this view)</div>
+              {renderRow(target)}
+            </div>
+          )}
+          {renderSections(visible)}
+          <div className={styles.footer}>
+            <span>⌘R runs ◉ selected</span>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/Header/RunProfileSelector.tsx
+++ b/frontend/src/components/Header/RunProfileSelector.tsx
@@ -31,6 +31,16 @@ export function RunProfileSelector() {
 
   const target = profiles.find((p) => p.id === effectiveId) ?? null;
   const visible = profiles.filter((p) => !hiddenProfileIds.includes(p.id));
+  // Ids actually rendered by renderSections(visible): workspace view scopes to the
+  // active workspace; project view shows all. The effective target may sit outside
+  // this set (a pick in another workspace) — surface it explicitly so it's never hidden.
+  const renderedIds = new Set(
+    (viewMode === 'workspace'
+      ? visible.filter((p) => (p.workspaceId ?? '') === activeWorkspaceId)
+      : visible
+    ).map((p) => p.id)
+  );
+  const targetOutsideView = !!target && !renderedIds.has(target.id);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -198,7 +208,7 @@ export function RunProfileSelector() {
             if (e.key === 'Escape') setIsOpen(false);
           }}
         >
-          {target && !visible.some((p) => p.id === target.id) && (
+          {targetOutsideView && (
             <div className={styles.section}>
               <div className={styles.sectionLabel}>Selected (outside this view)</div>
               {renderRow(target)}

--- a/frontend/src/components/RunProfiles/RunProfileCard.module.css
+++ b/frontend/src/components/RunProfiles/RunProfileCard.module.css
@@ -507,3 +507,29 @@
   color: var(--accent);
   white-space: nowrap;
 }
+
+/* ── Selected-target toggle ─────────────────────────────────── */
+
+.targetToggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: none;
+  background: transparent;
+  color: var(--text-tertiary, #888);
+  cursor: pointer;
+  border-radius: 4px;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+.targetToggle:hover {
+  color: var(--text-secondary, #bbb);
+}
+.targetToggleOn {
+  color: var(--accent-blue, #6ea8fe);
+}
+.selectedTarget {
+  box-shadow: inset 2px 0 0 var(--accent-blue, #6ea8fe);
+}

--- a/frontend/src/components/RunProfiles/RunProfileCard.tsx
+++ b/frontend/src/components/RunProfiles/RunProfileCard.tsx
@@ -318,7 +318,7 @@ export function RunProfileCard({
           }
           title="Cmd+R target"
         >
-          <span aria-hidden="true">{isSelectedTarget ? '◉' : '○'}</span>
+          <span aria-hidden="true">{isSelectedTarget ? '◎' : '○'}</span>
         </button>
         {renderActionButton()}
         <span className={styles.name}>{profile.name}</span>

--- a/frontend/src/components/RunProfiles/RunProfileCard.tsx
+++ b/frontend/src/components/RunProfiles/RunProfileCard.tsx
@@ -5,9 +5,6 @@ import { getTagColor } from '../../utils/tagColors';
 import { formatDuration } from '../../utils/formatDuration';
 import { PlayIcon, StopIcon, RestartIcon, LoaderIcon } from '../icons';
 import {
-  StartRunProfile,
-  StopRunProfile,
-  RestartRunProfile,
   PinRunProfile,
   UnpinRunProfile,
   SetActiveVariant,
@@ -15,6 +12,7 @@ import {
   UnadoptRunProfile,
 } from '../../../wailsjs/go/main/App';
 import { useIDEStore } from '../../stores/ideStore';
+import { useProfileActions } from '../../hooks/useProfileActions';
 import type { RunProfile } from '../../types/runProfile';
 import type { VisualState, RunHistoryEntry, RunOutput } from '../../types/runOutput';
 import type { ProfileSection } from '../../utils/groupProfiles';
@@ -112,10 +110,6 @@ export function RunProfileCard({
   section,
   isFreshestRun,
 }: RunProfileCardProps) {
-  const setProfileStopping = useIDEStore((s) => s.setProfileStopping);
-  const clearProfileStopping = useIDEStore((s) => s.clearProfileStopping);
-  const setProfileRestarting = useIDEStore((s) => s.setProfileRestarting);
-  const clearProfileRestarting = useIDEStore((s) => s.clearProfileRestarting);
   const addOrUpdateProfile = useIDEStore((s) => s.addOrUpdateProfile);
   const showToast = useIDEStore((s) => s.showToast);
 
@@ -129,30 +123,11 @@ export function RunProfileCard({
   );
 
   // Shared action handlers — used by both inline action button and ExpandedPanel
-  const handleStart = () => {
-    StartRunProfile(profile.id).catch((err: unknown) => {
-      const message = err instanceof Error ? err.message : String(err);
-      showToast(`Failed to start "${profile.name}": ${message}`, 'error');
-    });
-  };
-
-  const handleStop = () => {
-    setProfileStopping(profile.id);
-    StopRunProfile(profile.id).catch((err: unknown) => {
-      clearProfileStopping(profile.id);
-      const message = err instanceof Error ? err.message : String(err);
-      showToast(`Failed to stop "${profile.name}": ${message}`, 'error');
-    });
-  };
-
-  const handleRestart = () => {
-    setProfileRestarting(profile.id);
-    RestartRunProfile(profile.id).catch((err: unknown) => {
-      clearProfileRestarting(profile.id);
-      const message = err instanceof Error ? err.message : String(err);
-      showToast(`Failed to restart "${profile.name}": ${message}`, 'error');
-    });
-  };
+  const {
+    start: handleStart,
+    stop: handleStop,
+    restart: handleRestart,
+  } = useProfileActions(profile);
 
   const handlePin = () => {
     PinRunProfile(profile.id).catch((err: unknown) => {

--- a/frontend/src/components/RunProfiles/RunProfileCard.tsx
+++ b/frontend/src/components/RunProfiles/RunProfileCard.tsx
@@ -51,6 +51,7 @@ interface RunProfileCardProps {
   onFocusOutput: (profileId: string) => void;
   section?: ProfileSection;
   isFreshestRun?: boolean;
+  isSelectedTarget?: boolean;
 }
 
 function getStateClass(visualState: VisualState): string {
@@ -109,6 +110,7 @@ export function RunProfileCard({
   onFocusOutput,
   section,
   isFreshestRun,
+  isSelectedTarget,
 }: RunProfileCardProps) {
   const addOrUpdateProfile = useIDEStore((s) => s.addOrUpdateProfile);
   const showToast = useIDEStore((s) => s.showToast);
@@ -169,6 +171,11 @@ export function RunProfileCard({
     });
   };
 
+  const handleSelectTarget = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    useIDEStore.getState().setSelectedProfile(profile.id);
+  };
+
   const envVariants = (profile.envVariants ?? []).filter((variant) => variant.name);
   const hasEnvVariants = envVariants.length > 0;
 
@@ -226,6 +233,7 @@ export function RunProfileCard({
     isActiveState ? styles.forceExpand : '',
     !isActiveState && isExpanded ? styles.expanded : '',
     isFreshestRun ? styles.justRan : '',
+    isSelectedTarget ? styles.selectedTarget : '',
   ]
     .filter(Boolean)
     .join(' ');
@@ -300,6 +308,18 @@ export function RunProfileCard({
     >
       {/* Row 1: action button + name + duration */}
       <div className={styles.row1}>
+        <button
+          type="button"
+          className={`${styles.targetToggle} ${isSelectedTarget ? styles.targetToggleOn : ''}`}
+          onClick={handleSelectTarget}
+          aria-pressed={isSelectedTarget ? true : false}
+          aria-label={
+            isSelectedTarget ? `Run target: ${profile.name}` : `Set as run target: ${profile.name}`
+          }
+          title="Cmd+R target"
+        >
+          <span aria-hidden="true">{isSelectedTarget ? '◉' : '○'}</span>
+        </button>
         {renderActionButton()}
         <span className={styles.name}>{profile.name}</span>
         <StatusBadge visualState={visualState} profile={profile} runHistory={runHistory} />

--- a/frontend/src/components/RunProfiles/RunProfiles.tsx
+++ b/frontend/src/components/RunProfiles/RunProfiles.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useEffectiveRunTarget } from '../../hooks/useEffectiveRunTarget';
 import { Panel } from '../layout';
 import { RunProfileCard } from './RunProfileCard';
 import { ProfileBrowser } from './ProfileBrowser';
@@ -58,6 +59,7 @@ export function RunProfiles() {
   const viewMode = useTreeViewMode(); // 'project' | 'workspace'
   const activeWorkspaceId = useActiveWorkspaceId();
   const workspaces = useWorkspaces();
+  const effectiveTargetId = useEffectiveRunTarget();
 
   // Render-time "now" for the just-ran recency window. Kept out of any memo deps
   // so grouping stays pure/memoized; recomputed each render (e.g. via etaTick).
@@ -151,6 +153,7 @@ export function RunProfiles() {
         isDormant={isDormant}
         isDuplicate={isDuplicate}
         section={section}
+        isSelectedTarget={effectiveTargetId === profile.id}
         isFreshestRun={
           grouped.freshestRunId === profile.id &&
           isJustRan(runProfileState[profile.id]?.lastRunAt, nowMs)

--- a/frontend/src/hooks/useEffectiveRunTarget.ts
+++ b/frontend/src/hooks/useEffectiveRunTarget.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { useIDEStore } from '../stores/ideStore';
+import { resolveEffectiveRunTargetId } from '../utils/resolveEffectiveRunTarget';
+
+/** The id of the profile the header button + Cmd+R act on (spec §5). */
+export function useEffectiveRunTarget(): string | null {
+  const selectedProfileId = useIDEStore((s) => s.selectedProfileId);
+  const profiles = useIDEStore((s) => s.runProfiles);
+  const profileState = useIDEStore((s) => s.runProfileState);
+  const hiddenProfileIds = useIDEStore((s) => s.hiddenProfileIds);
+  const activeWorkspaceId = useIDEStore((s) => s.activeWorkspaceId);
+
+  return useMemo(
+    () =>
+      resolveEffectiveRunTargetId({
+        selectedProfileId,
+        profiles,
+        profileState,
+        hiddenProfileIds,
+        activeWorkspaceId,
+      }),
+    [selectedProfileId, profiles, profileState, hiddenProfileIds, activeWorkspaceId]
+  );
+}

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -5,6 +5,9 @@ import { useIDEStore, type NavigationLocation } from '../stores/ideStore';
 import { useSearchStore } from '../stores/searchStore';
 import { navigateToEditorLocation } from '../utils/editorNavigation';
 import { EventsOn } from '../../wailsjs/runtime/runtime';
+import { resolveEffectiveRunTargetId } from '../utils/resolveEffectiveRunTarget';
+import { getVisualState } from '../utils/visualState';
+import { startProfile, restartProfile } from '../utils/profileActions';
 
 function navigateBack() {
   const state = useIDEStore.getState();
@@ -48,6 +51,34 @@ export function useKeyboardShortcuts() {
       if (modifier && e.key === 'o') {
         e.preventDefault();
         openFolder();
+        return;
+      }
+
+      // Cmd+R / Ctrl+R — run (or restart) the selected run-profile target.
+      // preventDefault is essential: WKWebView treats Cmd+R as page reload.
+      if (modifier && (e.key === 'r' || e.key === 'R') && !e.shiftKey) {
+        e.preventDefault();
+        const s = useIDEStore.getState();
+        const id = resolveEffectiveRunTargetId({
+          selectedProfileId: s.selectedProfileId,
+          profiles: s.runProfiles,
+          profileState: s.runProfileState,
+          hiddenProfileIds: s.hiddenProfileIds,
+          activeWorkspaceId: s.activeWorkspaceId,
+        });
+        if (!id) return;
+        if (s.restartingProfileIds.includes(id)) return; // restart already in flight
+        const target = s.runProfiles.find((p) => p.id === id);
+        if (!target) return;
+        const vs = getVisualState(
+          id,
+          s.runOutputs[id]?.state,
+          s.stoppingProfileIds,
+          s.restartingProfileIds
+        );
+        if (vs === 'stopping') return; // includes stop-in-flight
+        if (vs === 'running') restartProfile(id, target.name);
+        else startProfile(id, target.name);
         return;
       }
 

--- a/frontend/src/hooks/useProfileActions.ts
+++ b/frontend/src/hooks/useProfileActions.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import type { RunProfile } from '../types/runProfile';
+import { startProfile, stopProfile, restartProfile } from '../utils/profileActions';
+
+export interface ProfileActions {
+  start: () => void;
+  stop: () => void;
+  restart: () => void;
+}
+
+/** Component-friendly wrapper around the imperative profile-action core (spec §6). */
+export function useProfileActions(profile: Pick<RunProfile, 'id' | 'name'>): ProfileActions {
+  return useMemo(
+    () => ({
+      start: () => startProfile(profile.id, profile.name),
+      stop: () => stopProfile(profile.id, profile.name),
+      restart: () => restartProfile(profile.id, profile.name),
+    }),
+    [profile.id, profile.name]
+  );
+}

--- a/frontend/src/stores/ideStore.ts
+++ b/frontend/src/stores/ideStore.ts
@@ -163,6 +163,9 @@ interface IDEState {
   runProfileState: Record<string, RunProfileUIState>;
   isLoadingProfiles: boolean;
   profilesError: string | null;
+  // Header selector: session-only single Cmd+R target. Not persisted; the
+  // effective target re-resolves from recency on launch (see resolveEffectiveRunTarget).
+  selectedProfileId: string | null;
 
   // Run Output
   runOutputs: Record<string, RunOutput>;
@@ -255,6 +258,7 @@ interface IDEActions {
     profiles: RunProfile[],
     profileState: Record<string, RunProfileUIState>
   ) => void;
+  setSelectedProfile: (id: string | null) => void;
   adoptProfileLocal: (id: string) => void;
   unadoptProfileLocal: (id: string) => void;
   setProfilesLoading: (loading: boolean) => void;
@@ -413,6 +417,7 @@ export const useIDEStore = create<IDEStore>()(
       runProfileState: {},
       isLoadingProfiles: false,
       profilesError: null,
+      selectedProfileId: null,
       runOutputs: {},
       runCompounds: {},
       activeRunOutputId: null,
@@ -711,6 +716,8 @@ export const useIDEStore = create<IDEStore>()(
           false,
           'setRunProfilesSnapshot'
         ),
+
+      setSelectedProfile: (id) => set({ selectedProfileId: id }, false, 'setSelectedProfile'),
 
       adoptProfileLocal: (id) =>
         set(
@@ -1635,6 +1642,8 @@ export const useActiveWorkspace = () =>
   useIDEStore((state) => state.workspaces.find((w) => w.id === state.activeWorkspaceId) ?? null);
 export const useTreeViewMode = (): 'project' | 'workspace' =>
   useIDEStore((state) => (state.activeWorkspaceId === 'project' ? 'project' : 'workspace'));
+export const useSelectedProfileId = (): string | null =>
+  useIDEStore((state) => state.selectedProfileId);
 export const useCanFocusWorkspace = (): boolean =>
   useIDEStore((state) => state.workspaces.some((w) => w.id !== 'project'));
 export const useActiveAccent = (): WorkspaceAccent =>

--- a/frontend/src/utils/profileActions.ts
+++ b/frontend/src/utils/profileActions.ts
@@ -1,0 +1,28 @@
+import { StartRunProfile, StopRunProfile, RestartRunProfile } from '../../wailsjs/go/main/App';
+import { useIDEStore } from '../stores/ideStore';
+
+const msg = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+export function startProfile(id: string, name: string): void {
+  StartRunProfile(id).catch((err: unknown) => {
+    useIDEStore.getState().showToast(`Failed to start "${name}": ${msg(err)}`, 'error');
+  });
+}
+
+export function stopProfile(id: string, name: string): void {
+  const store = useIDEStore.getState();
+  store.setProfileStopping(id);
+  StopRunProfile(id).catch((err: unknown) => {
+    useIDEStore.getState().clearProfileStopping(id);
+    useIDEStore.getState().showToast(`Failed to stop "${name}": ${msg(err)}`, 'error');
+  });
+}
+
+export function restartProfile(id: string, name: string): void {
+  const store = useIDEStore.getState();
+  store.setProfileRestarting(id);
+  RestartRunProfile(id).catch((err: unknown) => {
+    useIDEStore.getState().clearProfileRestarting(id);
+    useIDEStore.getState().showToast(`Failed to restart "${name}": ${msg(err)}`, 'error');
+  });
+}

--- a/frontend/src/utils/resolveEffectiveRunTarget.ts
+++ b/frontend/src/utils/resolveEffectiveRunTarget.ts
@@ -1,0 +1,53 @@
+import type { RunProfile, RunProfileUIState } from '../types/runProfile';
+
+export interface ResolveEffectiveRunTargetArgs {
+  selectedProfileId: string | null;
+  profiles: RunProfile[];
+  profileState: Record<string, RunProfileUIState>;
+  hiddenProfileIds: string[];
+  activeWorkspaceId: string;
+}
+
+const lastRunAt = (state: Record<string, RunProfileUIState>, id: string): number =>
+  state[id]?.lastRunAt ?? 0;
+
+// Pick a default target from a candidate list, in preference order (spec §5.2–5.4):
+//   1. most-recently-run adopted   2. most-recently-run any source
+//   3. first pinned (user)         4. first detected
+function pickDefault(
+  list: RunProfile[],
+  state: Record<string, RunProfileUIState>
+): RunProfile | null {
+  if (list.length === 0) return null;
+
+  const ran = (p: RunProfile) => lastRunAt(state, p.id) > 0;
+  const byRecencyDesc = (a: RunProfile, b: RunProfile) =>
+    lastRunAt(state, b.id) - lastRunAt(state, a.id);
+
+  const adoptedRan = list.filter((p) => state[p.id]?.adopted && ran(p)).sort(byRecencyDesc);
+  if (adoptedRan.length) return adoptedRan[0];
+
+  const anyRan = list.filter(ran).sort(byRecencyDesc);
+  if (anyRan.length) return anyRan[0];
+
+  const pinned = list.find((p) => p.source === 'user');
+  if (pinned) return pinned;
+
+  const detected = list.find((p) => p.source === 'detected');
+  return detected ?? null;
+}
+
+export function resolveEffectiveRunTargetId(args: ResolveEffectiveRunTargetArgs): string | null {
+  const { selectedProfileId, profiles, profileState, hiddenProfileIds, activeWorkspaceId } = args;
+  const hidden = new Set(hiddenProfileIds);
+  const visible = profiles.filter((p) => !hidden.has(p.id));
+
+  // 1. Explicit selection wins when it still exists and is visible.
+  if (selectedProfileId && visible.some((p) => p.id === selectedProfileId)) {
+    return selectedProfileId;
+  }
+
+  // 2–4. Prefer the active workspace, then fall back across all workspaces.
+  const inActive = visible.filter((p) => (p.workspaceId ?? '') === activeWorkspaceId);
+  return (pickDefault(inActive, profileState) ?? pickDefault(visible, profileState))?.id ?? null;
+}


### PR DESCRIPTION
## Summary

Implements M4 #18 P3 — a header split control that names one selected run profile (the single Cmd+R target), with a grouped dropdown to pick/run any profile. Selection is shared state with the four-section Run Profiles panel.

- New `RunProfileSelector` in the header: action segment (Run/Stop/Restart on the effective target by its live status) + menu trigger opening a popover grouped via the shared `groupProfiles` (Project view -> by workspace, Workspace view -> active workspace, with a "Selected (outside this view)" row so the target is never hidden). Rows offer select, inline run, and an env-variant `select`.
- Shared selection: panel `RunProfileCard` gains a target toggle and marker; header and panel both derive the effective target from one pure resolver (`resolveEffectiveRunTargetId`) and write one session-only store scalar (`selectedProfileId`).
- Effective-target resolution: explicit pick (global, survives view switches) else most-recent-run adopted, else most-recent-run any, else first pinned/detected, active-workspace-first.
- Cmd+R / Ctrl+R runs the selected target (restart when running, no-op while stopping/restarting), always calling `preventDefault()` so the webview never reloads.
- Start/Stop/Restart extracted to a shared `utils/profileActions` core + `useProfileActions` hook; `RunProfileCard` refactored onto it (behavior-preserving).
- No backend or contract change. Consumes the existing `RunProfilesSnapshot` + bindings.

## Test plan

Automated (all green on this branch):
- [x] `npx jest` — 958 passing, 0 failing (new: resolver fallback incl. cross-workspace selection, useEffectiveRunTarget, profileActions, card marker/toggle, panel wiring, selector closed state + popover incl. project-view grouping / env change / outside-view row, header mount, Cmd+R start/restart/no-op + preventDefault)
- [x] `npm run build` (tsc && vite build) — passes
- [x] `npm run lint` — 0 errors (pre-existing warnings only)

Manual (need a packaged macOS build / running app):
- [ ] Cmd+R in a packaged build starts/restarts the selected profile and does NOT reload the window. If it reloads, add a native `CmdOrCtrl+R` menu item in `main.go` emitting `run:selected` (mirror the existing `navigate:back`/`navigate:forward` accelerators) and listen for it in `useKeyboardShortcuts`.
- [ ] Keyboard a11y: action and menu are two separately-focusable buttons with distinct names; popover opens from the trigger, Escape closes and returns focus; selected row exposes aria-pressed; no menuitemradio / nested-interactive markup.