### PR TITLE
fix(runprofiles): skip npm lifecycle scripts in detection

### DIFF
--- a/internal/runprofile/detector.go
+++ b/internal/runprofile/detector.go
@@ -118,6 +118,29 @@ func IsConfigFile(filename string) bool {
 	return false
 }
 
+// npmLifecycleScripts are npm-managed install/publish/pack lifecycle hooks that
+// npm runs automatically and are not manual run targets, so they are not
+// surfaced as run profiles (e.g. a polyglot root whose only package.json script
+// is husky "prepare"). Manual targets like start/test/stop/restart/build are
+// intentionally absent so they keep being detected.
+var npmLifecycleScripts = map[string]bool{
+	"prepare":        true,
+	"prepublish":     true,
+	"prepublishOnly": true,
+	"prepack":        true,
+	"postpack":       true,
+	"dependencies":   true,
+	"preinstall":     true,
+	"install":        true,
+	"postinstall":    true,
+	"preuninstall":   true,
+	"uninstall":      true,
+	"postuninstall":  true,
+	"preversion":     true,
+	"version":        true,
+	"postversion":    true,
+}
+
 func (d *Detector) detectPackageJSON(path string) []RunProfile {
 	data, err := d.fs.ReadFile(path)
 	if err != nil {
@@ -143,6 +166,9 @@ func (d *Detector) detectPackageJSON(path string) []RunProfile {
 	var profiles []RunProfile
 	order := 0
 	for _, name := range scriptNames {
+		if npmLifecycleScripts[name] {
+			continue
+		}
 		order++
 		profiles = append(profiles, RunProfile{
 			ID:           d.profileID("package.json", name),

--- a/internal/runprofile/detector.go
+++ b/internal/runprofile/detector.go
@@ -118,24 +118,25 @@ func IsConfigFile(filename string) bool {
 	return false
 }
 
-// npmLifecycleScripts are npm-managed install/publish/pack lifecycle hooks that
-// npm runs automatically and are not manual run targets, so they are not
+// npmLifecycleScripts are npm-managed install/publish/pack/version lifecycle hooks
+// that npm runs automatically and are not manual run targets, so they are not
 // surfaced as run profiles (e.g. a polyglot root whose only package.json script
-// is husky "prepare"). Manual targets like start/test/stop/restart/build are
-// intentionally absent so they keep being detected.
+// is husky "prepare"). Manual targets like start/test/stop/restart/build and
+// npm v7+ uninstall names are intentionally absent so they keep being detected.
 var npmLifecycleScripts = map[string]bool{
 	"prepare":        true,
+	"preprepare":     true,
+	"postprepare":    true,
 	"prepublish":     true,
 	"prepublishOnly": true,
+	"publish":        true,
+	"postpublish":    true,
 	"prepack":        true,
 	"postpack":       true,
 	"dependencies":   true,
 	"preinstall":     true,
 	"install":        true,
 	"postinstall":    true,
-	"preuninstall":   true,
-	"uninstall":      true,
-	"postuninstall":  true,
 	"preversion":     true,
 	"version":        true,
 	"postversion":    true,

--- a/internal/runprofile/detector_test.go
+++ b/internal/runprofile/detector_test.go
@@ -94,9 +94,16 @@ func TestDetectPackageJSONSkipsLifecycleScripts(t *testing.T) {
 		"/workspace/package.json": []byte(`{
 			"scripts": {
 				"prepare": "husky",
+				"preprepare": "echo preprepare",
+				"postprepare": "echo postprepare",
 				"preinstall": "echo pre",
 				"postinstall": "echo post",
 				"prepublishOnly": "echo pub",
+				"publish": "echo publish",
+				"postpublish": "echo postpublish",
+				"preuninstall": "echo before cleanup",
+				"uninstall": "node cleanup.js",
+				"postuninstall": "echo after cleanup",
 				"build": "tsc",
 				"start": "node .",
 				"test": "jest"
@@ -110,8 +117,12 @@ func TestDetectPackageJSONSkipsLifecycleScripts(t *testing.T) {
 		names[p.Name] = true
 	}
 
-	// Real run targets are still detected (start/test are not lifecycle hooks).
-	for _, want := range []string{"npm run build", "npm run start", "npm run test"} {
+	// Real run targets are still detected (start/test are not lifecycle hooks, and
+	// uninstall scripts are not implemented by npm v7+).
+	for _, want := range []string{
+		"npm run build", "npm run start", "npm run test",
+		"npm run preuninstall", "npm run uninstall", "npm run postuninstall",
+	} {
 		if !names[want] {
 			t.Errorf("expected %q to be detected", want)
 		}
@@ -119,7 +130,9 @@ func TestDetectPackageJSONSkipsLifecycleScripts(t *testing.T) {
 	// npm install/publish lifecycle hooks run automatically and are not run
 	// targets, so they must not surface as profiles (e.g. husky "prepare").
 	for _, skip := range []string{
-		"npm run prepare", "npm run preinstall", "npm run postinstall", "npm run prepublishOnly",
+		"npm run prepare", "npm run preprepare", "npm run postprepare",
+		"npm run preinstall", "npm run postinstall", "npm run prepublishOnly",
+		"npm run publish", "npm run postpublish",
 	} {
 		if names[skip] {
 			t.Errorf("expected lifecycle script %q to be skipped", skip)

--- a/internal/runprofile/detector_test.go
+++ b/internal/runprofile/detector_test.go
@@ -89,6 +89,44 @@ func TestDetectPackageJSON(t *testing.T) {
 	}
 }
 
+func TestDetectPackageJSONSkipsLifecycleScripts(t *testing.T) {
+	files := map[string][]byte{
+		"/workspace/package.json": []byte(`{
+			"scripts": {
+				"prepare": "husky",
+				"preinstall": "echo pre",
+				"postinstall": "echo post",
+				"prepublishOnly": "echo pub",
+				"build": "tsc",
+				"start": "node .",
+				"test": "jest"
+			}
+		}`),
+	}
+	detector := NewDetector(newDetectorMockFS(files), "/workspace")
+
+	names := map[string]bool{}
+	for _, p := range detector.DetectAll() {
+		names[p.Name] = true
+	}
+
+	// Real run targets are still detected (start/test are not lifecycle hooks).
+	for _, want := range []string{"npm run build", "npm run start", "npm run test"} {
+		if !names[want] {
+			t.Errorf("expected %q to be detected", want)
+		}
+	}
+	// npm install/publish lifecycle hooks run automatically and are not run
+	// targets, so they must not surface as profiles (e.g. husky "prepare").
+	for _, skip := range []string{
+		"npm run prepare", "npm run preinstall", "npm run postinstall", "npm run prepublishOnly",
+	} {
+		if names[skip] {
+			t.Errorf("expected lifecycle script %q to be skipped", skip)
+		}
+	}
+}
+
 func TestDetectGoMod(t *testing.T) {
 	files := map[string][]byte{
 		"/workspace/go.mod": []byte("module example.com/foo\n\ngo 1.21\n"),


### PR DESCRIPTION
## Summary

Fixes a polyglot-root case where a workspace classified as Go listed `npm run prepare`. The repo root has both `go.mod` and a `package.json` whose only script is husky `prepare`. Workspace classification intentionally types such a root as Go (go.mod precedence, see `internal/workspace/detect.go`), but run-profile detection scanned the same dir and emitted a profile for the root `package.json` script too — attributed to the Go root workspace, so it showed under the Go tab.

npm install/publish/pack/version lifecycle hooks run automatically and are not manual run targets, so they should not be surfaced as run profiles at all. This skips them in `detectPackageJSON`:

`prepare`, `preprepare`, `postprepare`, `prepublish`, `prepublishOnly`, `publish`, `postpublish`, `prepack`, `postpack`, `dependencies`, `preinstall`, `install`, `postinstall`, `preversion`, `version`, `postversion`.

Manual targets (`start`, `test`, `stop`, `restart`, `build`, `dev`, `lint`, etc.) are intentionally not in the skip set and keep being detected. npm v7+ uninstall names (`preuninstall`, `uninstall`, `postuninstall`) are also kept because npm no longer runs uninstall lifecycle hooks automatically.

This is a pre-existing detection behavior (M4 #71 P2), independent of the header run-profile selector in #129, though it removes the same noise from that selector's dropdown.

## Test plan

- [x] `go test ./internal/runprofile` — new `TestDetectPackageJSONSkipsLifecycleScripts` asserts manual build/start/test and npm v7+ uninstall names are detected, while install/publish lifecycle hooks are skipped.
- [x] `go vet ./internal/runprofile`
- [x] `git diff --check` for the run-profile diff
- [x] pre-push hook ran `golangci-lint run ./...` — 0 issues