### PR TITLE
Run profiles: form and card UI polish (#18 P4 follow-up)

### DIFF
--- a/frontend/src/__tests__/components/RunProfileCardSelected.test.tsx
+++ b/frontend/src/__tests__/components/RunProfileCardSelected.test.tsx
@@ -43,3 +43,9 @@ test('clicking the toggle selects the profile and does not expand the card', () 
   fireEvent.click(screen.getByRole('button', { name: /run target/i }));
   expect(useIDEStore.getState().selectedProfileId).toBe('p1');
 });
+
+test('dormant cards can be selected from the keyboard', () => {
+  render(<RunProfileCard {...common} isDormant={true} isSelectedTarget={false} />);
+  fireEvent.keyDown(screen.getByRole('button', { name: /^dev$/ }), { key: 'Enter' });
+  expect(useIDEStore.getState().selectedProfileId).toBe('p1');
+});

--- a/frontend/src/components/Header/RunProfileSelector.module.css
+++ b/frontend/src/components/Header/RunProfileSelector.module.css
@@ -19,6 +19,9 @@
   border-radius: 6px 0 0 6px;
   border-right: none;
   padding: 0 8px;
+  /* Center the play/stop glyph; the status dot is a corner pip (absolute below). */
+  justify-content: center;
+  position: relative;
 }
 .trigger {
   border-radius: 0 6px 6px 0;
@@ -30,6 +33,11 @@
   opacity: 0.5;
   cursor: default;
 }
+.action svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
 .name {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -40,8 +48,11 @@
   flex-shrink: 0;
 }
 .dot {
-  width: 7px;
-  height: 7px;
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background: transparent;
 }

--- a/frontend/src/components/RunProfiles/RunProfileCard.module.css
+++ b/frontend/src/components/RunProfiles/RunProfileCard.module.css
@@ -54,7 +54,12 @@
   padding: 14px 16px;
   margin-bottom: 8px;
   border-radius: 10px;
-  background: var(--surface-hover);
+  /* Per-card accent: the card's own workspace color in Project View (set on the
+     group), the active workspace accent elsewhere. Drives hover/play/target. */
+  --card-accent: var(--region-accent, var(--accent));
+  /* Deep navy card surface (matches the bottom output panel), recessed below the
+     --list field. Status/selection states tint this base rather than replacing it. */
+  background: var(--surface-base);
   border: 1px solid var(--surface-border);
   transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
   overflow: hidden;
@@ -73,10 +78,10 @@
   will-change: transform, opacity;
 }
 
-/* Default hover — subtle lift + border */
+/* Default hover — dark base tinted toward the workspace accent + accent border */
 .card:hover {
-  border-color: rgba(56, 189, 248, 0.35);
-  background: var(--surface-active);
+  border-color: color-mix(in srgb, var(--card-accent) 45%, transparent);
+  background: color-mix(in srgb, var(--card-accent) 16%, var(--surface-base));
 }
 
 /* ── Layout Rows ────────────────────────────────────────────── */
@@ -112,14 +117,16 @@
 .duration {
   font-size: 10px;
   font-family: 'SF Mono', 'Fira Code', var(--font-mono), monospace;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   flex-shrink: 0;
 }
 
 .cmd {
   font-size: 11px;
   font-family: 'SF Mono', 'Fira Code', var(--font-mono), monospace;
-  color: var(--text-secondary);
+  /* slate-300 — one step brighter than --text-secondary so the command (the
+     line users scan most) stays legible on the flattened surface. */
+  color: #cbd5e1;
   margin-top: 3px;
   margin-left: 34px;
   white-space: nowrap;
@@ -129,7 +136,7 @@
 
 .cmdSource {
   display: block;
-  color: var(--text-muted, #2a2a2a);
+  color: var(--text-secondary);
   font-size: 10px;
   margin-top: 1px;
 }
@@ -160,14 +167,14 @@
   stroke-linejoin: round;
 }
 
-/* Play — sky blue */
+/* Play — workspace accent */
 .actionBtnPlay {
-  background: rgba(56, 189, 248, 0.1);
-  color: #38bdf8;
+  background: color-mix(in srgb, var(--card-accent) 12%, transparent);
+  color: var(--card-accent);
 }
 
 .actionBtnPlay:hover {
-  background: rgba(56, 189, 248, 0.22);
+  background: color-mix(in srgb, var(--card-accent) 24%, transparent);
   transform: scale(1.08);
 }
 
@@ -253,15 +260,15 @@
 }
 
 .variantSelect:focus {
-  outline: 1px solid rgba(56, 189, 248, 0.45);
+  outline: 1px solid var(--card-accent);
   outline-offset: 1px;
 }
 
 /* ── State: Running ─────────────────────────────────────────── */
 
 .running {
-  background: var(--surface-active);
-  border-color: rgba(34, 197, 94, 0.35);
+  background: color-mix(in srgb, var(--status-success) 12%, var(--surface-base));
+  border-color: color-mix(in srgb, var(--status-success) 45%, transparent);
   box-shadow:
     0 2px 12px rgba(34, 197, 94, 0.06),
     0 1px 3px rgba(0, 0, 0, 0.2);
@@ -313,17 +320,17 @@
 /* ── State: Failed ──────────────────────────────────────────── */
 
 .failed {
-  border-color: rgba(239, 68, 68, 0.3);
-  background: linear-gradient(135deg, var(--surface-hover), rgba(239, 68, 68, 0.07));
+  border-color: var(--status-error);
+  background: color-mix(in srgb, var(--status-error) 14%, var(--surface-base));
   animation: failedPulse 1s ease-out 1;
 }
 
 .failed .duration {
-  color: #ef4444;
+  color: var(--status-error);
 }
 
 .failed:hover {
-  border-color: rgba(239, 68, 68, 0.25);
+  border-color: var(--status-error);
 }
 
 /* ── State: Success ─────────────────────────────────────────── */
@@ -340,9 +347,9 @@
 }
 
 .dormant:hover {
-  border-color: rgba(56, 189, 248, 0.35);
+  border-color: color-mix(in srgb, var(--card-accent) 45%, transparent);
   border-style: solid;
-  background: var(--surface-active);
+  background: color-mix(in srgb, var(--card-accent) 16%, var(--surface-base));
 }
 
 .dormant .cmd {
@@ -481,15 +488,15 @@
 }
 
 .adoptBtn:hover {
-  border-color: var(--accent);
-  color: var(--accent);
+  border-color: var(--card-accent);
+  color: var(--card-accent);
 }
 
 /* ── Just-ran highlight: workspace-accent tint + accent left rail ── */
 
 .justRan {
-  background: var(--accent-dim);
-  border-left: 2px solid var(--accent);
+  background: color-mix(in srgb, var(--card-accent) 12%, transparent);
+  border-left: 2px solid var(--card-accent);
   /* Compensate left padding so inner content stays aligned */
   padding-left: 14px;
 }
@@ -503,8 +510,8 @@
   text-transform: lowercase;
   padding: 1px 6px;
   border-radius: 9px;
-  background: var(--accent-dim);
-  color: var(--accent);
+  background: color-mix(in srgb, var(--card-accent) 14%, transparent);
+  color: var(--card-accent);
   white-space: nowrap;
 }
 
@@ -524,12 +531,33 @@
   font-size: 12px;
   flex-shrink: 0;
 }
-.targetToggle:hover {
-  color: var(--text-secondary, #bbb);
+/* Hollow ring by default; fills solid with the workspace accent when this is the
+   Cmd+R target, so the selected profile reads at a glance. */
+.targetDot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  box-sizing: border-box;
+  border: 1.5px solid var(--text-muted);
+  background: transparent;
+  transition: all 0.15s ease;
 }
-.targetToggleOn {
-  color: var(--accent-blue, #6ea8fe);
+.targetToggle:hover .targetDot {
+  border-color: var(--card-accent);
 }
+.targetToggleOn .targetDot {
+  background: var(--card-accent);
+  border-color: var(--card-accent);
+  box-shadow: 0 0 7px color-mix(in srgb, var(--card-accent) 65%, transparent);
+}
+/* Selected Cmd+R target: highlight the whole card (accent border + ring + wash).
+   border-style:solid overrides the dormant dashed outline when active. */
 .selectedTarget {
-  box-shadow: inset 2px 0 0 var(--accent-blue, #6ea8fe);
+  border-color: var(--card-accent);
+  border-style: solid;
+  background: color-mix(in srgb, var(--card-accent) 14%, var(--surface-base));
+  box-shadow: 0 0 0 1px var(--card-accent);
+}
+.selectedTarget:hover {
+  border-color: var(--card-accent);
 }

--- a/frontend/src/components/RunProfiles/RunProfileCard.tsx
+++ b/frontend/src/components/RunProfiles/RunProfileCard.tsx
@@ -204,6 +204,9 @@ export function RunProfileCard({
   const isExpanded = !isActiveState && manualExpanded;
 
   const handleCardClick = () => {
+    // Clicking anywhere on the card selects it as the Cmd+R target...
+    useIDEStore.getState().setSelectedProfile(profile.id);
+    // ...and still toggles the expanded detail for non-dormant, non-active cards.
     if (!isDormant && !isActiveState) {
       setManualExpanded((prev) => !prev);
     }
@@ -294,7 +297,7 @@ export function RunProfileCard({
   return (
     <div
       className={cardClassName}
-      onClick={isDormant ? undefined : handleCardClick}
+      onClick={handleCardClick}
       tabIndex={isDormant ? undefined : 0}
       onKeyDown={
         isDormant
@@ -321,7 +324,7 @@ export function RunProfileCard({
           }
           title="Cmd+R target"
         >
-          <span aria-hidden="true">{isSelectedTarget ? '◎' : '○'}</span>
+          <span className={styles.targetDot} aria-hidden="true" />
         </button>
         {renderActionButton()}
         <span className={styles.name}>{profile.name}</span>

--- a/frontend/src/components/RunProfiles/RunProfileCard.tsx
+++ b/frontend/src/components/RunProfiles/RunProfileCard.tsx
@@ -298,18 +298,14 @@ export function RunProfileCard({
     <div
       className={cardClassName}
       onClick={handleCardClick}
-      tabIndex={isDormant ? undefined : 0}
-      onKeyDown={
-        isDormant
-          ? undefined
-          : (e) => {
-              if ((e.key === 'Enter' || e.key === ' ') && e.target === e.currentTarget) {
-                e.preventDefault();
-                handleCardClick();
-              }
-            }
-      }
-      role={isDormant ? undefined : 'button'}
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if ((e.key === 'Enter' || e.key === ' ') && e.target === e.currentTarget) {
+          e.preventDefault();
+          handleCardClick();
+        }
+      }}
+      role="button"
       aria-label={profile.name}
     >
       {/* Row 1: action button + name + duration */}

--- a/frontend/src/components/RunProfiles/RunProfileForm.module.css
+++ b/frontend/src/components/RunProfiles/RunProfileForm.module.css
@@ -3,40 +3,44 @@
   flex-direction: column;
   height: 100%;
   font-size: 12px;
-  color: #cfcfcf;
+  color: var(--text-primary);
 }
 .header {
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 9px 11px;
-  background: #161616;
-  border-bottom: 1px solid #232323;
+  background: var(--surface-elevated);
+  border-bottom: 1px solid var(--surface-border);
 }
 .back {
   background: none;
   border: none;
-  color: #38bdf8;
+  color: var(--accent);
   cursor: pointer;
   font-size: 14px;
 }
 .title {
   flex: 1;
   font-weight: 600;
-  color: #e6e6e6;
+  color: var(--text-primary);
 }
 .cancel {
-  background: #222;
-  color: #aaa;
+  background: var(--surface-hover);
+  color: var(--text-secondary);
   border: none;
   border-radius: 5px;
   padding: 3px 10px;
   cursor: pointer;
   font-size: 11px;
 }
+.cancel:hover {
+  background: var(--surface-active);
+  color: var(--text-primary);
+}
 .save {
-  background: #38bdf8;
-  color: #06222e;
+  background: var(--accent);
+  color: var(--surface-base);
   font-weight: 600;
   border: none;
   border-radius: 5px;
@@ -45,8 +49,8 @@
   font-size: 11px;
 }
 .save:disabled {
-  background: #2a3942;
-  color: #5e7986;
+  background: var(--surface-active);
+  color: var(--text-disabled);
   cursor: not-allowed;
 }
 .body {
@@ -63,22 +67,42 @@
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: #7a7a7a;
+  color: var(--text-secondary);
   margin-bottom: 4px;
 }
 .required::after {
   content: ' *';
-  color: #f87171;
+  color: var(--status-error);
 }
 .input {
   width: 100%;
   box-sizing: border-box;
-  background: #161616;
-  border: 1px solid #2e2e2e;
+  background: var(--surface-base);
+  border: 1px solid var(--surface-border);
   border-radius: 5px;
   padding: 6px 8px;
-  color: #ddd;
+  color: var(--text-primary);
   font-size: 12px;
+}
+.input::placeholder {
+  color: var(--text-muted);
+}
+.input:focus,
+.input:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+/* Native <select> draws its own border/arrow/focus ring, which clashes with the
+   themed inputs. Strip the OS chrome and supply a matching arrow + focus style. */
+.select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 26px;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="10" height="6" viewBox="0 0 10 6" fill="none" stroke="%2394a3b8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M1 1l4 4 4-4"/></svg>');
+  background-repeat: no-repeat;
+  background-position: right 9px center;
+  cursor: pointer;
 }
 .mono {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -93,35 +117,50 @@
   margin-bottom: 5px;
 }
 .eq {
-  color: #555;
+  color: var(--text-muted);
 }
 .browse {
   white-space: nowrap;
   font-size: 11px;
   padding: 6px 10px;
   border-radius: 5px;
-  background: #1d2630;
-  color: #7fb6cc;
-  border: 1px solid #2a3a42;
+  background: var(--accent-dim);
+  color: var(--accent);
+  border: 1px solid var(--surface-border);
   cursor: pointer;
+}
+.browse:hover {
+  background: var(--accent-glow);
 }
 .removeRow {
   background: none;
   border: none;
-  color: #666;
+  color: var(--text-muted);
   font-size: 14px;
   cursor: pointer;
 }
+.removeRow:hover {
+  color: var(--text-primary);
+}
 .addRow {
   font-size: 10px;
-  color: #38bdf8;
+  color: var(--accent);
   background: none;
-  border: 1px dashed #2e3a40;
+  border: 1px dashed var(--surface-border);
   border-radius: 5px;
   padding: 4px 8px;
   width: 100%;
   cursor: pointer;
   margin-top: 2px;
+}
+.addRow:hover {
+  background: var(--accent-dim);
+}
+.hint {
+  display: block;
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-top: 4px;
 }
 .tags {
   display: flex;
@@ -132,21 +171,21 @@
   font-size: 10px;
   padding: 3px 9px;
   border-radius: 11px;
-  background: rgba(56, 189, 248, 0.14);
-  color: #38bdf8;
-  border: 1px solid rgba(56, 189, 248, 0.4);
+  background: var(--accent-dim);
+  color: var(--accent);
+  border: 1px solid var(--accent-glow);
 }
 .fieldError {
   display: block;
   font-size: 10px;
-  color: #f87171;
+  color: var(--status-error);
   margin-top: 3px;
 }
 .formError {
   font-size: 11px;
-  color: #f87171;
-  background: #1c1212;
-  border: 1px solid #3a2222;
+  color: var(--status-error);
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
   border-radius: 5px;
   padding: 6px 8px;
   margin-bottom: 11px;
@@ -157,8 +196,8 @@
   align-items: center;
   gap: 8px;
   padding: 10px 11px;
-  border-top: 1px solid #232323;
-  background: #120e0e;
+  border-top: 1px solid var(--surface-border);
+  background: rgba(239, 68, 68, 0.05);
 }
 .delete,
 .deleteConfirm {
@@ -168,16 +207,23 @@
   cursor: pointer;
 }
 .delete {
-  color: #f87171;
+  color: var(--status-error);
   background: none;
-  border: 1px solid #3a2222;
+  border: 1px solid rgba(239, 68, 68, 0.35);
+}
+.delete:hover {
+  background: rgba(239, 68, 68, 0.12);
 }
 .deleteConfirm {
-  color: #fff;
-  background: #b91c1c;
+  color: var(--text-primary);
+  background: var(--status-error);
   border: none;
+}
+.deleteConfirm:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 .variantNote {
   font-size: 10px;
-  color: #5f5f5f;
+  color: var(--text-muted);
 }

--- a/frontend/src/components/RunProfiles/RunProfileForm.tsx
+++ b/frontend/src/components/RunProfiles/RunProfileForm.tsx
@@ -236,7 +236,7 @@ export function RunProfileForm({ state }: RunProfileFormProps) {
           <label className={styles.group}>
             <span className={styles.label}>Start from</span>
             <select
-              className={styles.input}
+              className={`${styles.input} ${styles.select}`}
               defaultValue=""
               onChange={(e) => onPickStartFrom(e.target.value)}
               aria-label="Start from detected command"
@@ -256,7 +256,7 @@ export function RunProfileForm({ state }: RunProfileFormProps) {
           <label className={styles.group}>
             <span className={styles.label}>Workspace</span>
             <select
-              className={styles.input}
+              className={`${styles.input} ${styles.select}`}
               value={values.workspaceId}
               onChange={(e) => patch({ workspaceId: e.target.value })}
               aria-label="Workspace"
@@ -345,7 +345,7 @@ export function RunProfileForm({ state }: RunProfileFormProps) {
           </button>
         </div>
 
-        <label className={styles.group}>
+        <div className={styles.group}>
           <span className={styles.label}>Env file</span>
           <input
             className={`${styles.input} ${styles.mono}`}
@@ -354,7 +354,8 @@ export function RunProfileForm({ state }: RunProfileFormProps) {
             onChange={(e) => patch({ envFile: e.target.value })}
             aria-label="Env file"
           />
-        </label>
+          <span className={styles.hint}>Relative to the working directory.</span>
+        </div>
 
         {values.tags.length > 0 && (
           <div className={styles.group}>

--- a/frontend/src/components/RunProfiles/RunProfiles.module.css
+++ b/frontend/src/components/RunProfiles/RunProfiles.module.css
@@ -2,6 +2,9 @@
   padding: 8px;
   height: 100%;
   overflow-y: auto;
+  /* Darker than the --surface-panel section so the panel reads recessed and the
+     flat (transparent) cards sit on a uniform dark field like the file tree. */
+  background: var(--surface-frame);
 }
 
 .group {

--- a/frontend/src/components/RunProfiles/RunProfiles.tsx
+++ b/frontend/src/components/RunProfiles/RunProfiles.tsx
@@ -279,7 +279,13 @@ export function RunProfiles() {
               const counts = groupCounts(wg);
               const accent = workspaces.find((w) => w.id === wg.workspaceId)?.accent;
               return (
-                <div key={wg.workspaceId} className={styles.workspaceGroup}>
+                <div
+                  key={wg.workspaceId}
+                  className={styles.workspaceGroup}
+                  style={
+                    { ['--region-accent' as string]: accentVar(accent) } as React.CSSProperties
+                  }
+                >
                   <div className={styles.workspaceHeader}>
                     <span
                       className={styles.workspaceDot}


### PR DESCRIPTION
Post-merge UI/UX polish on the #18 P4 run-profile form and cards, from live feedback. Frontend-only (CSS + small TSX); no backend changes.

## Form
- Migrate the form's hard-coded neutral grays to the slate design tokens (--text-*, --surface-*, --accent) so it matches the rest of the app's brightness instead of reading dim and off-theme.
- Fix the native <select> chrome on the Start-from / Workspace dropdowns (appearance:none + a matching chevron + a focus ring shared with the text inputs) so the outline is consistent.
- Add a hint under Env file: "Relative to the working directory." (the backend resolves a relative envFile against the effective working dir).

## Cards
- Card surface is the deep navy --surface-base (matches the bottom output panel); the list field is --surface-frame. Hover / selected / failed / running tint that dark base toward the accent or status color rather than going translucent over the panel. Running no longer uses the lighter --surface-active (read as a translucent cover).
- Workspace palette: a --card-accent variable (the card's --region-accent, set per group in Project View, falling back to --accent) drives the hover border, play button, variant focus, target dot, selected highlight, and just-ran tint. Every hard-coded cyan rgba(56,189,248,..) is gone; mirrors the file tree.
- Cmd+R target: the toggle is a hollow ring that fills solid and glows when selected, and the whole card highlights (accent border + ring + wash). A selected card forces a solid border over the dormant dashed outline.
- Clicking anywhere on a card selects it as the Cmd+R target; detected/dormant cards (which had no onClick) are now clickable. Inner buttons stop propagation.
- Failed cards drop the faded diagonal gradient for a flat red tint + solid red border.

## Header
- Size the run/stop button's SVG (the icon components have no intrinsic size and the header never sized it, so it rendered as a blank square) and center the glyph, moving the status dot to a corner pip.

## Test plan
- Frontend: 998 Jest tests pass; tsc clean apart from the pre-existing esModuleInterop deprecation.
- Manual: hover a card (accent tint), select a target via the circle or by clicking the card body, view a failed and a running card, and check the header run button shows a centered play/stop icon.

Generated with Claude Code