### PR TITLE
Roll back run-profile store on persist failure

### DIFF
--- a/internal/runprofile/store.go
+++ b/internal/runprofile/store.go
@@ -169,19 +169,31 @@ func (s *Store) Save(profile RunProfile) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// Apply to a fresh slice so a persist failure can restore the prior in-memory
+	// state — otherwise memory and disk diverge (and the emit-on-change path would
+	// surface a profile that was never written).
+	prev := s.profiles
+	updated := make([]RunProfile, len(s.profiles))
+	copy(updated, s.profiles)
+
 	found := false
-	for i, p := range s.profiles {
+	for i, p := range updated {
 		if p.ID == profile.ID {
-			s.profiles[i] = profile
+			updated[i] = profile
 			found = true
 			break
 		}
 	}
 	if !found {
-		s.profiles = append(s.profiles, profile)
+		updated = append(updated, profile)
 	}
+	s.profiles = updated
 
-	return s.persist()
+	if err := s.persist(); err != nil {
+		s.profiles = prev
+		return err
+	}
+	return nil
 }
 
 // Delete removes a profile by ID and persists to disk.
@@ -200,8 +212,19 @@ func (s *Store) Delete(id string) error {
 		return fmt.Errorf("profile not found: %s", id)
 	}
 
-	s.profiles = append(s.profiles[:idx], s.profiles[idx+1:]...)
-	return s.persist()
+	// Remove into a fresh slice so a persist failure can restore the original
+	// (the prior in-place splice mutated the backing array, corrupting any rollback).
+	prev := s.profiles
+	updated := make([]RunProfile, 0, len(s.profiles)-1)
+	updated = append(updated, s.profiles[:idx]...)
+	updated = append(updated, s.profiles[idx+1:]...)
+	s.profiles = updated
+
+	if err := s.persist(); err != nil {
+		s.profiles = prev
+		return err
+	}
+	return nil
 }
 
 // GetAll returns a copy of all stored profiles.

--- a/internal/runprofile/store_test.go
+++ b/internal/runprofile/store_test.go
@@ -50,6 +50,67 @@ func newMockFSWithFiles() (*filesystem.Mock, map[string][]byte) {
 	return m, files
 }
 
+func TestStoreSaveRollsBackOnPersistError(t *testing.T) {
+	mockFS, _ := newMockFSWithFiles()
+	store := NewStore(mockFS, "/workspace")
+
+	mockFS.WriteFileFunc = func(string, []byte, fs.FileMode) error {
+		return errors.New("disk full")
+	}
+
+	err := store.Save(RunProfile{ID: "p1", Name: "Dev", Type: ProfileTypeSingle, Command: "x"})
+	if err == nil {
+		t.Fatal("expected Save to return an error when persist fails")
+	}
+	if store.Contains("p1") {
+		t.Fatal("Save must not leave a profile in memory when the disk write fails")
+	}
+	if got := store.GetAll(); len(got) != 0 {
+		t.Fatalf("expected empty store after a failed save, got %d profiles", len(got))
+	}
+}
+
+func TestStoreSaveRollsBackUpdateOnPersistError(t *testing.T) {
+	mockFS, _ := newMockFSWithFiles()
+	store := NewStore(mockFS, "/workspace")
+	if err := store.Save(RunProfile{ID: "p1", Name: "Old", Type: ProfileTypeSingle, Command: "x"}); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	mockFS.WriteFileFunc = func(string, []byte, fs.FileMode) error {
+		return errors.New("disk full")
+	}
+
+	err := store.Save(RunProfile{ID: "p1", Name: "New", Type: ProfileTypeSingle, Command: "y"})
+	if err == nil {
+		t.Fatal("expected error when persisting an update fails")
+	}
+	got := store.GetAll()
+	if len(got) != 1 || got[0].Name != "Old" || got[0].Command != "x" {
+		t.Fatalf("a failed update must restore the prior value, got %+v", got)
+	}
+}
+
+func TestStoreDeleteRollsBackOnPersistError(t *testing.T) {
+	mockFS, _ := newMockFSWithFiles()
+	store := NewStore(mockFS, "/workspace")
+	if err := store.Save(RunProfile{ID: "p1", Name: "Dev", Type: ProfileTypeSingle, Command: "x"}); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	mockFS.WriteFileFunc = func(string, []byte, fs.FileMode) error {
+		return errors.New("disk full")
+	}
+
+	err := store.Delete("p1")
+	if err == nil {
+		t.Fatal("expected Delete to return an error when persist fails")
+	}
+	if !store.Contains("p1") {
+		t.Fatal("Delete must keep the profile in memory when the disk write fails")
+	}
+}
+
 func TestStoreLoadNoFile(t *testing.T) {
 	mockFS := newMockFS()
 	store := NewStore(mockFS, "/workspace")


### PR DESCRIPTION
Backend data-consistency fix surfaced by an adversarial review of the #18 P4 edit-form branch. The gap predates that feature.

## Problem
Store.Save and Store.Delete (internal/runprofile/store.go) mutated the in-memory profiles slice before calling persist(), with no rollback on a disk-write failure:
- A failed Save left a profile in memory that was never written to .firn/run-profiles.json. With the new emit-on-change path (SaveRunProfile emits a memory snapshot), that phantom profile would appear in the UI and then vanish on the next reload.
- A failed Delete removed a profile from memory that was still on disk.

## Fix
Apply each change to a fresh slice and restore the prior slice when persist() returns an error, so memory and disk stay consistent. State (adoption) already commits only on a successful write, so only the profiles slice needs rollback.

## Test plan
- TDD: three new tests in store_test.go inject a failing WriteFileFunc and assert that a failed create does not leave the profile, a failed update restores the prior value, and a failed delete keeps the profile. They fail against the old code and pass with the fix.
- go test ./... and go vet ./... pass.

Generated with Claude Code