### PR TITLE
chore(hooks): mirror CI lint+test jobs in pre-push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,7 +1,45 @@
-# Run golangci-lint before pushing so the GitHub Actions "Lint / golangci-lint"
-# job passes on the PR. The repo is lint-clean under golangci-lint v2 (pinned in
-# .golangci.yml + .github/workflows/lint.yml), so this runs the full check —
-# identical to CI. Bypass with `git push --no-verify`.
+# Mirror the GitHub Actions checks locally so a push doesn't turn the PR red.
+# Mirrors: Lint (eslint + golangci-lint) and Tests (jest + go test). The Wails
+# build job is intentionally NOT mirrored — it installs wails + system GTK deps
+# and is too heavy for a hook; CI keeps that one. Bypass all of this with
+# `git push --no-verify`.
+
+set -e
+
+# --- Frontend: ESLint + Jest (test.yml + lint.yml, frontend jobs) -----------
+# Guard on the tool first: git hooks run with a minimal PATH (no login shell),
+# so npm may be absent under GUI git clients / nvm even when deps are installed.
+# Skip cleanly rather than fail the push for a tooling reason, not a code one.
+if ! command -v npm >/dev/null 2>&1; then
+  echo "pre-push: npm not on PATH — skipping eslint + jest."
+  echo "  GUI git clients may lack your shell PATH; fix via ~/.config/husky/init.sh"
+elif [ ! -d frontend/node_modules ]; then
+  echo "pre-push: frontend/node_modules missing — skipping eslint + jest."
+  echo "  Install deps to enable them on push: (cd frontend && npm ci)"
+else
+  echo "pre-push: eslint ."
+  (cd frontend && npm run lint)
+
+  echo "pre-push: jest"
+  (cd frontend && npm test)
+fi
+
+# --- Backend: golangci-lint + go test (lint.yml + test.yml, Go jobs) --------
+if ! command -v go >/dev/null 2>&1; then
+  echo "pre-push: go not on PATH — skipping go test + golangci-lint."
+  exit 0
+fi
+
+# main.go does `//go:embed all:frontend/dist`, so Go cannot typecheck or test
+# the main package until the frontend has been built. Skip cleanly if absent.
+if [ ! -d frontend/dist ]; then
+  echo "pre-push: frontend/dist missing — skipping go test + golangci-lint."
+  echo "  Build it to enable them on push: (cd frontend && npm run build)"
+  exit 0
+fi
+
+echo "pre-push: go test ./..."
+go test ./...
 
 if ! command -v golangci-lint >/dev/null 2>&1; then
   echo "pre-push: golangci-lint not installed — skipping Go lint."
@@ -10,18 +48,5 @@ if ! command -v golangci-lint >/dev/null 2>&1; then
   exit 0
 fi
 
-# main.go does `//go:embed all:frontend/dist`, so the linter cannot typecheck the
-# main package until the frontend has been built. Skip cleanly if it is absent.
-if [ ! -d frontend/dist ]; then
-  echo "pre-push: frontend/dist missing — skipping Go lint."
-  echo "  Build it to enable lint on push: (cd frontend && npm run build)"
-  exit 0
-fi
-
 echo "pre-push: golangci-lint run ./..."
-if ! golangci-lint run ./...; then
-  echo ""
-  echo "pre-push: golangci-lint found issues above. Fix them, or bypass with:"
-  echo "    git push --no-verify"
-  exit 1
-fi
+golangci-lint run ./...


### PR DESCRIPTION
## What

Extend the `.husky/pre-push` hook beyond `golangci-lint` to mirror the GitHub Actions Lint and Tests workflows locally, so a push catches what would otherwise turn the PR red:

- frontend `eslint .` (lint.yml)
- frontend `jest` (test.yml)
- `go test ./...` (test.yml)
- `golangci-lint run ./...` (unchanged)

The Wails build job (build.yml) is intentionally left to CI — it installs wails + system GTK deps and is too heavy for a hook.

## Why guarded

Each external tool (`npm`, `go`, `golangci-lint`) is PATH-guarded with `command -v` so a missing tool skips cleanly instead of failing the push with code 127. Git hooks run with a minimal PATH (husky runs `sh -e` and only prepends `node_modules/.bin`), so `npm`/`go` can be absent under GUI git clients or nvm shells even when deps are installed. Failing the push for a tooling reason — not a code reason — would just train everyone to reflexively `--no-verify`.

`go test` + `golangci-lint` stay gated on `frontend/dist` because `main.go` embeds it via `//go:embed all:frontend/dist`; Go cannot compile the main package without it. When dist is absent both are skipped with a clear message.

Bypass everything with `git push --no-verify`.

## Verification

Self-tested on this push: eslint clean, 999/999 jest tests pass, `go test ./...` ok, golangci-lint 0 issues.