### PR TITLE
feat(runoutput): LANES output polish — resizable lanes, sticky-header isolation (#107)

### DIFF
--- a/frontend/src/__tests__/components/RunOutput/LanesView.test.tsx
+++ b/frontend/src/__tests__/components/RunOutput/LanesView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { LanesView, clampSplit } from '../../../components/RunOutput/LanesView';
 import type { OutputEntry } from '../../../types/runOutput';
 
@@ -24,6 +24,10 @@ describe('clampSplit', () => {
 });
 
 describe('LanesView', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('renders both lane headers and a resize separator', () => {
     render(
       <LanesView
@@ -37,5 +41,57 @@ describe('LanesView', () => {
     expect(
       screen.getByRole('separator', { name: 'Resize stdout and stderr lanes' })
     ).toBeInTheDocument();
+  });
+
+  it('stops resizing when the window loses focus', () => {
+    render(
+      <LanesView
+        entries={[entry('stdout', 'building'), entry('stderr', 'warning')]}
+        autoScroll={false}
+      />
+    );
+
+    const separator = screen.getByRole('separator', {
+      name: 'Resize stdout and stderr lanes',
+    });
+    const scrollParent = separator.parentElement?.parentElement as HTMLDivElement;
+    scrollParent.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        width: 100,
+      }) as DOMRect;
+
+    fireEvent.pointerDown(separator, { clientX: 50 });
+    act(() => {
+      document.dispatchEvent(new MouseEvent('pointermove', { clientX: 80 }));
+    });
+    expect(separator).toHaveStyle({ left: '80%' });
+
+    fireEvent.blur(window);
+    act(() => {
+      document.dispatchEvent(new MouseEvent('pointermove', { clientX: 20 }));
+    });
+    expect(separator).toHaveStyle({ left: '80%' });
+  });
+
+  it('resizes from the keyboard', () => {
+    render(
+      <LanesView
+        entries={[entry('stdout', 'building'), entry('stderr', 'warning')]}
+        autoScroll={false}
+      />
+    );
+
+    const separator = screen.getByRole('separator', {
+      name: 'Resize stdout and stderr lanes',
+    });
+
+    fireEvent.keyDown(separator, { key: 'ArrowRight' });
+    expect(separator).toHaveStyle({ left: '51%' });
+    expect(separator).toHaveAttribute('aria-valuenow', '51');
+
+    fireEvent.keyDown(separator, { key: 'End' });
+    expect(separator).toHaveStyle({ left: '80%' });
+    expect(separator).toHaveAttribute('aria-valuenow', '80');
   });
 });

--- a/frontend/src/__tests__/components/RunOutput/LanesView.test.tsx
+++ b/frontend/src/__tests__/components/RunOutput/LanesView.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { LanesView, clampSplit } from '../../../components/RunOutput/LanesView';
+import type { OutputEntry } from '../../../types/runOutput';
+
+// LanesView renders OutputLine, which imports the generated Wails bindings via
+// editorNavigation; mock it so the suite doesn't load untransformed ESM.
+jest.mock('../../../utils/editorNavigation', () => ({
+  navigateToEditorLocation: jest.fn(),
+}));
+
+const entry = (stream: 'stdout' | 'stderr', text: string): OutputEntry => ({
+  stream,
+  text,
+  timestamp: 0,
+});
+
+describe('clampSplit', () => {
+  it('keeps a usable split in range', () => {
+    expect(clampSplit(0.5)).toBe(0.5);
+    expect(clampSplit(0.05)).toBe(0.2); // below min
+    expect(clampSplit(0.95)).toBe(0.8); // above max
+    expect(clampSplit(NaN)).toBe(0.5); // bad persisted value falls back
+  });
+});
+
+describe('LanesView', () => {
+  it('renders both lane headers and a resize separator', () => {
+    render(
+      <LanesView
+        entries={[entry('stdout', 'building'), entry('stderr', 'warning')]}
+        autoScroll={false}
+      />
+    );
+
+    expect(screen.getByText('stdout')).toBeInTheDocument();
+    expect(screen.getByText('stderr')).toBeInTheDocument();
+    expect(
+      screen.getByRole('separator', { name: 'Resize stdout and stderr lanes' })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/RunOutput/LanesView.tsx
+++ b/frontend/src/components/RunOutput/LanesView.tsx
@@ -5,6 +5,7 @@ import {
   useState,
   useCallback,
   type CSSProperties,
+  type KeyboardEvent,
   type PointerEvent,
 } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
@@ -58,6 +59,7 @@ export function LanesView({ entries, autoScroll, workingDir, workspacePath }: La
   const parentRef = useRef<HTMLDivElement>(null);
   const [split, setSplit] = useState<number>(loadSplit);
   const splitRef = useRef(split);
+  const dragCleanupRef = useRef<(() => void) | null>(null);
   splitRef.current = split;
 
   const rows = useMemo(() => {
@@ -82,24 +84,58 @@ export function LanesView({ entries, autoScroll, workingDir, workspacePath }: La
     }
   }, [rows.length, autoScroll, virtualizer]);
 
+  useEffect(() => () => dragCleanupRef.current?.(), []);
+
+  const commitSplit = useCallback((value: number) => {
+    const next = clampSplit(value);
+    splitRef.current = next;
+    setSplit(next);
+    writeSplit(next);
+  }, []);
+
   const onDividerDown = useCallback((e: PointerEvent<HTMLDivElement>) => {
     e.preventDefault();
     const el = parentRef.current;
     if (!el) return;
+    dragCleanupRef.current?.();
     const rect = el.getBoundingClientRect();
     let latest = splitRef.current;
     const move = (ev: globalThis.PointerEvent) => {
       latest = clampSplit((ev.clientX - rect.left) / rect.width);
       setSplit(latest);
     };
-    const up = () => {
+    const stop = () => {
+      if (dragCleanupRef.current !== stop) return;
+      dragCleanupRef.current = null;
       document.removeEventListener('pointermove', move);
-      document.removeEventListener('pointerup', up);
+      document.removeEventListener('pointerup', stop);
+      document.removeEventListener('pointercancel', stop);
+      window.removeEventListener('blur', stop);
       writeSplit(latest);
     };
+    dragCleanupRef.current = stop;
     document.addEventListener('pointermove', move);
-    document.addEventListener('pointerup', up);
+    document.addEventListener('pointerup', stop);
+    document.addEventListener('pointercancel', stop);
+    window.addEventListener('blur', stop);
   }, []);
+
+  const onDividerKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      const step = e.shiftKey ? 0.05 : 0.01;
+      let next: number | null = null;
+
+      if (e.key === 'ArrowLeft') next = splitRef.current - step;
+      if (e.key === 'ArrowRight') next = splitRef.current + step;
+      if (e.key === 'Home') next = MIN_SPLIT;
+      if (e.key === 'End') next = MAX_SPLIT;
+      if (next == null) return;
+
+      e.preventDefault();
+      commitSplit(next);
+    },
+    [commitSplit]
+  );
 
   if (entries.length === 0) {
     return (
@@ -128,9 +164,14 @@ export function LanesView({ entries, autoScroll, workingDir, workspacePath }: La
           className={styles.laneDivider}
           style={{ left: `${split * 100}%` }}
           onPointerDown={onDividerDown}
+          onKeyDown={onDividerKeyDown}
           role="separator"
+          tabIndex={0}
           aria-orientation="vertical"
           aria-label="Resize stdout and stderr lanes"
+          aria-valuemin={MIN_SPLIT * 100}
+          aria-valuemax={MAX_SPLIT * 100}
+          aria-valuenow={Math.round(split * 100)}
         />
       </div>
       <div className={styles.laneRows} style={{ height: `${virtualizer.getTotalSize()}px` }}>

--- a/frontend/src/components/RunOutput/LanesView.tsx
+++ b/frontend/src/components/RunOutput/LanesView.tsx
@@ -1,4 +1,12 @@
-import { useRef, useEffect, useMemo } from 'react';
+import {
+  useRef,
+  useEffect,
+  useMemo,
+  useState,
+  useCallback,
+  type CSSProperties,
+  type PointerEvent,
+} from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { OutputEntry } from '../../types/runOutput';
 import { OutputLine } from './OutputLine';
@@ -16,8 +24,41 @@ interface LaneRow {
   stderr: string | null;
 }
 
+// Column split is the fraction of width given to the stdout lane. Clamped so
+// neither lane collapses below a usable minimum. Persisted globally (one split
+// for all profiles) — mirrors the localStorage idiom in ideStore.
+const LANE_SPLIT_KEY = 'firn.lanesSplit';
+const MIN_SPLIT = 0.2;
+const MAX_SPLIT = 0.8;
+const DEFAULT_SPLIT = 0.5;
+
+export function clampSplit(n: number): number {
+  if (!Number.isFinite(n)) return DEFAULT_SPLIT;
+  return Math.min(MAX_SPLIT, Math.max(MIN_SPLIT, n));
+}
+
+function loadSplit(): number {
+  try {
+    const raw = typeof localStorage !== 'undefined' ? localStorage.getItem(LANE_SPLIT_KEY) : null;
+    return raw == null ? DEFAULT_SPLIT : clampSplit(parseFloat(raw));
+  } catch {
+    return DEFAULT_SPLIT;
+  }
+}
+
+function writeSplit(v: number): void {
+  try {
+    if (typeof localStorage !== 'undefined') localStorage.setItem(LANE_SPLIT_KEY, String(v));
+  } catch {
+    // localStorage may be unavailable (private mode / WebView quirks); split still applies in-session.
+  }
+}
+
 export function LanesView({ entries, autoScroll, workingDir, workspacePath }: LanesViewProps) {
   const parentRef = useRef<HTMLDivElement>(null);
+  const [split, setSplit] = useState<number>(loadSplit);
+  const splitRef = useRef(split);
+  splitRef.current = split;
 
   const rows = useMemo(() => {
     return entries.map(
@@ -41,6 +82,25 @@ export function LanesView({ entries, autoScroll, workingDir, workspacePath }: La
     }
   }, [rows.length, autoScroll, virtualizer]);
 
+  const onDividerDown = useCallback((e: PointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const el = parentRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    let latest = splitRef.current;
+    const move = (ev: globalThis.PointerEvent) => {
+      latest = clampSplit((ev.clientX - rect.left) / rect.width);
+      setSplit(latest);
+    };
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      writeSplit(latest);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  }, []);
+
   if (entries.length === 0) {
     return (
       <div className={styles.emptyState}>
@@ -50,7 +110,11 @@ export function LanesView({ entries, autoScroll, workingDir, workspacePath }: La
   }
 
   return (
-    <div ref={parentRef} className={styles.outputContent}>
+    <div
+      ref={parentRef}
+      className={`${styles.outputContent} ${styles.lanesScroll}`}
+      style={{ ['--lane-split']: `${split * 100}%` } as CSSProperties}
+    >
       <div className={styles.laneHeaders}>
         <div className={`${styles.laneHeader} ${styles.stdoutHeader}`}>
           <span className={styles.laneDot} />
@@ -60,8 +124,16 @@ export function LanesView({ entries, autoScroll, workingDir, workspacePath }: La
           <span className={styles.laneDot} />
           stderr
         </div>
+        <div
+          className={styles.laneDivider}
+          style={{ left: `${split * 100}%` }}
+          onPointerDown={onDividerDown}
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize stdout and stderr lanes"
+        />
       </div>
-      <div style={{ height: `${virtualizer.getTotalSize()}px`, position: 'relative' }}>
+      <div className={styles.laneRows} style={{ height: `${virtualizer.getTotalSize()}px` }}>
         {virtualizer.getVirtualItems().map((virtualRow) => {
           const row = rows[virtualRow.index];
           return (

--- a/frontend/src/components/RunOutput/RunOutput.module.css
+++ b/frontend/src/components/RunOutput/RunOutput.module.css
@@ -246,16 +246,26 @@
   overflow: hidden;
 }
 
+/* Lanes own their own padding via cells, so the scroll parent has none — this
+   removes the 8px top gap where rows would otherwise show above the sticky
+   header (#107). */
+.lanesScroll {
+  padding: 0;
+}
+
 .laneHeaders {
-  display: flex;
+  display: grid;
+  grid-template-columns: var(--lane-split, 50%) 1fr;
   position: sticky;
   top: 0;
-  z-index: 2;
+  z-index: 3;
   background: #040406;
+  /* Promote to its own compositor layer so momentum-scrolled rows (each a GPU
+     layer via translateY) can't paint over the sticky header in WebView. */
+  will-change: transform;
 }
 
 .laneHeader {
-  flex: 1;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -289,12 +299,47 @@
   flex-shrink: 0;
 }
 
+/* Draggable column boundary. Lives in the sticky header (always visible) and is
+   positioned at the split fraction; the visual line continues down the body via
+   the .laneLine.stderr border-left. */
+.laneDivider {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 9px;
+  transform: translateX(-50%);
+  cursor: col-resize;
+  z-index: 1;
+}
+
+.laneDivider::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 1px;
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
+.laneDivider:hover::before {
+  background: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+/* Isolated stacking context so the absolutely-positioned, transformed virtual
+   rows are contained strictly below the sticky header (#107). */
+.laneRows {
+  position: relative;
+  z-index: 0;
+  isolation: isolate;
+}
+
 .laneRow {
-  display: flex;
+  display: grid;
+  grid-template-columns: var(--lane-split, 50%) 1fr;
 }
 
 .laneLine {
-  flex: 1;
   min-height: 20px;
   min-width: 0;
   white-space: pre-wrap;


### PR DESCRIPTION
Closes #107. Polishes the LANES tab of the run-profile Output view (`RunOutput/LanesView.tsx`, `RunOutput.module.css`). UI-only, frontend.

## Three defects

1. **stdout/stderr not resizable** — lanes were a hard 50/50 `flex: 1`. Now a CSS-grid `--lane-split` variable, set once on the scroll parent and consumed by both the sticky header and every virtual row, driven by a draggable divider in the header. Clamped to 20-80% per lane; the split persists to `localStorage` (`firn.lanesSplit`), mirroring the syntax-theme persistence idiom in `ideStore`.

2. **Stray-colour final "R" in the STDERR header** — not a font bug. It was stderr content compositing over the sticky header at that x-position. Resolved by the #3 stacking fix.

3. **Output bleeds over the headers on scroll** — virtualized rows each sit on their own GPU layer (`transform: translateY`) and could paint over the sticky header during momentum scroll. Fixed by: promoting the header to its own compositor layer (`will-change: transform`) at a raised z-index, isolating the rows container in its own stacking context (`isolation: isolate`), and removing the 8px top padding gap (lanes own per-cell padding) that let rows show above `top: 0`.

## Tests

Adds `LanesView.test.tsx`: `clampSplit` clamp/NaN-fallback, plus header + resize-separator render. The pre-push hook (jest + `go test ./...` + `golangci-lint run`) gated this push and passed.

## Follow-up

#137 (separate) tracks reworking the lanes into independent per-column scroll with an optional sync toggle, so a one-sided run (e.g. all-stderr `npm test`) no longer masks the quieter stream. Kept out of this PR — it replaces the scroll model this PR polishes.

Generated with [Claude Code](https://claude.com/claude-code)
