### PR TITLE
feat(runoutput): LANES independent per-stream scroll + sync toggle (#137)

### DIFF
--- a/frontend/src/__tests__/components/RunOutput/LanesView.test.tsx
+++ b/frontend/src/__tests__/components/RunOutput/LanesView.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { LanesView, clampSplit } from '../../../components/RunOutput/LanesView';
+import { LanesView, clampSplit, mirrorScrollTop } from '../../../components/RunOutput/LanesView';
 import type { OutputEntry } from '../../../types/runOutput';
 
 // LanesView renders OutputLine, which imports the generated Wails bindings via
@@ -23,6 +23,36 @@ describe('clampSplit', () => {
   });
 });
 
+describe('mirrorScrollTop', () => {
+  it('maps the source scroll fraction onto the target range', () => {
+    // Source scrolled to 50% of its range -> target lands at 50% of its own.
+    expect(
+      mirrorScrollTop(
+        { scrollTop: 50, scrollHeight: 200, clientHeight: 100 },
+        { scrollHeight: 400, clientHeight: 100 }
+      )
+    ).toBe(150);
+  });
+
+  it('keeps the target at the top when the source is at the top', () => {
+    expect(
+      mirrorScrollTop(
+        { scrollTop: 0, scrollHeight: 200, clientHeight: 100 },
+        { scrollHeight: 400, clientHeight: 100 }
+      )
+    ).toBe(0);
+  });
+
+  it('returns 0 when the source cannot scroll', () => {
+    expect(
+      mirrorScrollTop(
+        { scrollTop: 0, scrollHeight: 80, clientHeight: 100 },
+        { scrollHeight: 400, clientHeight: 100 }
+      )
+    ).toBe(0);
+  });
+});
+
 describe('LanesView', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -43,6 +73,95 @@ describe('LanesView', () => {
     ).toBeInTheDocument();
   });
 
+  it('gives each stream its own independent scroll column', () => {
+    const { container } = render(
+      <LanesView
+        entries={[entry('stdout', 'banner'), entry('stderr', 'noise')]}
+        autoScroll={false}
+      />
+    );
+
+    const stdoutCol = container.querySelector('[data-stream="stdout"]');
+    const stderrCol = container.querySelector('[data-stream="stderr"]');
+    expect(stdoutCol).toBeInTheDocument();
+    expect(stderrCol).toBeInTheDocument();
+    // Distinct elements -> distinct scrollbars, so neither lane is masked by the other.
+    expect(stdoutCol).not.toBe(stderrCol);
+  });
+
+  it('defaults the sync-scroll toggle off and persists it when enabled', () => {
+    render(
+      <LanesView
+        entries={[entry('stdout', 'building'), entry('stderr', 'warning')]}
+        autoScroll={false}
+      />
+    );
+
+    const toggle = screen.getByRole('button', { name: /sync scroll/i });
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    expect(localStorage.getItem('firn.lanesSyncScroll')).toBe('true');
+  });
+
+  it('restores a persisted sync-scroll preference on mount', () => {
+    localStorage.setItem('firn.lanesSyncScroll', 'true');
+
+    render(
+      <LanesView
+        entries={[entry('stdout', 'building'), entry('stderr', 'warning')]}
+        autoScroll={false}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /sync scroll/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  });
+
+  // jsdom can't lay out the virtualizers, so give the columns explicit scroll
+  // geometry to exercise the ratio-coupling wiring (onScroll -> sibling moves).
+  const setupCoupledLanes = () => {
+    const { container } = render(
+      <LanesView
+        entries={[entry('stdout', 'banner'), entry('stderr', 'noise')]}
+        autoScroll={false}
+      />
+    );
+    const stdoutCol = container.querySelector('[data-stream="stdout"]') as HTMLElement;
+    const stderrCol = container.querySelector('[data-stream="stderr"]') as HTMLElement;
+    const geometry = (el: HTMLElement, scrollHeight: number) => {
+      Object.defineProperty(el, 'clientHeight', { value: 100, configurable: true });
+      Object.defineProperty(el, 'scrollHeight', { value: scrollHeight, configurable: true });
+    };
+    geometry(stdoutCol, 1000); // scrollable range 900
+    geometry(stderrCol, 500); // scrollable range 400
+    return { stdoutCol, stderrCol };
+  };
+
+  it('drives the sibling lane by scroll fraction when sync is on', () => {
+    const { stdoutCol, stderrCol } = setupCoupledLanes();
+
+    fireEvent.click(screen.getByRole('button', { name: /sync scroll/i }));
+
+    stdoutCol.scrollTop = 450; // 50% of its 900px range
+    fireEvent.scroll(stdoutCol);
+
+    expect(stderrCol.scrollTop).toBe(200); // 50% of stderr's 400px range
+  });
+
+  it('leaves the sibling lane untouched when sync is off', () => {
+    const { stdoutCol, stderrCol } = setupCoupledLanes();
+
+    stdoutCol.scrollTop = 450;
+    fireEvent.scroll(stdoutCol);
+
+    expect(stderrCol.scrollTop).toBe(0);
+  });
+
   it('stops resizing when the window loses focus', () => {
     render(
       <LanesView
@@ -54,8 +173,8 @@ describe('LanesView', () => {
     const separator = screen.getByRole('separator', {
       name: 'Resize stdout and stderr lanes',
     });
-    const scrollParent = separator.parentElement?.parentElement as HTMLDivElement;
-    scrollParent.getBoundingClientRect = () =>
+    const body = separator.parentElement as HTMLDivElement;
+    body.getBoundingClientRect = () =>
       ({
         left: 0,
         width: 100,

--- a/frontend/src/components/RunOutput/LanesView.tsx
+++ b/frontend/src/components/RunOutput/LanesView.tsx
@@ -7,6 +7,8 @@ import {
   type CSSProperties,
   type KeyboardEvent,
   type PointerEvent,
+  type ReactNode,
+  type RefObject,
 } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { OutputEntry } from '../../types/runOutput';
@@ -20,11 +22,6 @@ interface LanesViewProps {
   workspacePath?: string;
 }
 
-interface LaneRow {
-  stdout: string | null;
-  stderr: string | null;
-}
-
 // Column split is the fraction of width given to the stdout lane. Clamped so
 // neither lane collapses below a usable minimum. Persisted globally (one split
 // for all profiles) — mirrors the localStorage idiom in ideStore.
@@ -33,9 +30,28 @@ const MIN_SPLIT = 0.2;
 const MAX_SPLIT = 0.8;
 const DEFAULT_SPLIT = 0.5;
 
+// Whether the two lanes share a scroll position. Off by default so a lopsided
+// run (e.g. all-stderr `npm test`) still lets the user read stdout in full.
+const LANE_SYNC_KEY = 'firn.lanesSyncScroll';
+
 export function clampSplit(n: number): number {
   if (!Number.isFinite(n)) return DEFAULT_SPLIT;
   return Math.min(MAX_SPLIT, Math.max(MIN_SPLIT, n));
+}
+
+/**
+ * Map a source lane's scroll position onto the target lane's range by fraction,
+ * so the two move together regardless of differing content heights. Returns the
+ * scrollTop the target should adopt; 0 when the source has nothing to scroll.
+ */
+export function mirrorScrollTop(
+  src: { scrollTop: number; scrollHeight: number; clientHeight: number },
+  dst: { scrollHeight: number; clientHeight: number }
+): number {
+  const maxSrc = src.scrollHeight - src.clientHeight;
+  const maxDst = dst.scrollHeight - dst.clientHeight;
+  if (maxSrc <= 0) return 0;
+  return (src.scrollTop / maxSrc) * maxDst;
 }
 
 function loadSplit(): number {
@@ -55,36 +71,163 @@ function writeSplit(v: number): void {
   }
 }
 
-export function LanesView({ entries, autoScroll, workingDir, workspacePath }: LanesViewProps) {
-  const parentRef = useRef<HTMLDivElement>(null);
-  const [split, setSplit] = useState<number>(loadSplit);
-  const splitRef = useRef(split);
-  const dragCleanupRef = useRef<(() => void) | null>(null);
-  splitRef.current = split;
+function loadSync(): boolean {
+  try {
+    return typeof localStorage !== 'undefined' && localStorage.getItem(LANE_SYNC_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
 
-  const rows = useMemo(() => {
-    return entries.map(
-      (entry): LaneRow => ({
-        stdout: entry.stream === 'stdout' ? entry.text : null,
-        stderr: entry.stream === 'stderr' ? entry.text : null,
-      })
-    );
-  }, [entries]);
+function writeSync(v: boolean): void {
+  try {
+    if (typeof localStorage !== 'undefined') localStorage.setItem(LANE_SYNC_KEY, String(v));
+  } catch {
+    // Persistence is best-effort; the toggle still applies for the session.
+  }
+}
 
+interface LaneProps {
+  stream: 'stdout' | 'stderr';
+  label: string;
+  entries: OutputEntry[];
+  autoScroll: boolean;
+  scrollRef: RefObject<HTMLDivElement | null>;
+  onScroll: () => void;
+  workingDir?: string;
+  workspacePath?: string;
+  children?: ReactNode;
+}
+
+// One stream's scroll column. Owns its own virtualizer so it packs only its own
+// lines (no blank filler rows) and scrolls independently of the sibling lane.
+function Lane({
+  stream,
+  label,
+  entries,
+  autoScroll,
+  scrollRef,
+  onScroll,
+  workingDir,
+  workspacePath,
+  children,
+}: LaneProps) {
   const virtualizer = useVirtualizer({
-    count: rows.length,
-    getScrollElement: () => parentRef.current,
+    count: entries.length,
+    getScrollElement: () => scrollRef.current,
     estimateSize: () => 20,
     overscan: 20,
   });
 
   useEffect(() => {
-    if (autoScroll && rows.length > 0) {
-      virtualizer.scrollToIndex(rows.length - 1, { align: 'end' });
+    if (autoScroll && entries.length > 0) {
+      virtualizer.scrollToIndex(entries.length - 1, { align: 'end' });
     }
-  }, [rows.length, autoScroll, virtualizer]);
+  }, [entries.length, autoScroll, virtualizer]);
+
+  const headerClass =
+    stream === 'stdout'
+      ? `${styles.laneHeader} ${styles.stdoutHeader}`
+      : `${styles.laneHeader} ${styles.stderrHeader}`;
+
+  return (
+    <div className={styles.lane}>
+      <div className={headerClass}>
+        <span className={styles.laneDot} />
+        {label}
+        {children}
+      </div>
+      <div ref={scrollRef} className={styles.laneColumn} data-stream={stream} onScroll={onScroll}>
+        <div
+          className={styles.laneColumnInner}
+          style={{ height: `${virtualizer.getTotalSize()}px` }}
+        >
+          {virtualizer.getVirtualItems().map((virtualRow) => (
+            <div
+              key={virtualRow.index}
+              ref={virtualizer.measureElement}
+              data-index={virtualRow.index}
+              className={styles.laneRow}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRow.start}px)`,
+              }}
+            >
+              <OutputLine
+                text={entries[virtualRow.index].text}
+                className={`${styles.laneLine} ${stream === 'stderr' ? styles.stderr : ''}`}
+                workingDir={workingDir}
+                workspacePath={workspacePath}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function LanesView({ entries, autoScroll, workingDir, workspacePath }: LanesViewProps) {
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const stdoutRef = useRef<HTMLDivElement>(null);
+  const stderrRef = useRef<HTMLDivElement>(null);
+  const [split, setSplit] = useState<number>(loadSplit);
+  const [sync, setSync] = useState<boolean>(loadSync);
+  const splitRef = useRef(split);
+  const syncRef = useRef(sync);
+  const suppressRef = useRef(false);
+  const dragCleanupRef = useRef<(() => void) | null>(null);
+
+  // Mirror the latest split/sync into refs the event handlers read, without
+  // touching refs during render (handlers also update them imperatively).
+  useEffect(() => {
+    splitRef.current = split;
+    syncRef.current = sync;
+  }, [split, sync]);
+
+  const stdoutEntries = useMemo(() => entries.filter((e) => e.stream === 'stdout'), [entries]);
+  const stderrEntries = useMemo(() => entries.filter((e) => e.stream === 'stderr'), [entries]);
 
   useEffect(() => () => dragCleanupRef.current?.(), []);
+
+  // Drive `dst` to match `src`'s scroll fraction when sync is on. The suppress
+  // flag breaks the feedback loop: the programmatic scroll we trigger fires the
+  // sibling's onScroll, which we swallow rather than echoing back.
+  const couple = useCallback((src: HTMLDivElement | null, dst: HTMLDivElement | null) => {
+    if (!syncRef.current) return;
+    if (suppressRef.current) {
+      suppressRef.current = false;
+      return;
+    }
+    if (!src || !dst) return;
+    const target = mirrorScrollTop(src, dst);
+    if (Math.abs(dst.scrollTop - target) < 0.5) return;
+    suppressRef.current = true;
+    dst.scrollTop = target;
+  }, []);
+
+  const onStdoutScroll = useCallback(() => couple(stdoutRef.current, stderrRef.current), [couple]);
+  const onStderrScroll = useCallback(() => couple(stderrRef.current, stdoutRef.current), [couple]);
+
+  const toggleSync = useCallback(() => {
+    const next = !syncRef.current;
+    syncRef.current = next;
+    setSync(next);
+    writeSync(next);
+    // Align immediately on enable so the lanes start out moving together. Only
+    // arm the suppress flag if we actually move stderr — otherwise no scroll
+    // event fires to clear it and the next real scroll would be swallowed.
+    if (next && stdoutRef.current && stderrRef.current) {
+      const target = mirrorScrollTop(stdoutRef.current, stderrRef.current);
+      if (Math.abs(stderrRef.current.scrollTop - target) >= 0.5) {
+        suppressRef.current = true;
+        stderrRef.current.scrollTop = target;
+      }
+    }
+  }, []);
 
   const commitSplit = useCallback((value: number) => {
     const next = clampSplit(value);
@@ -95,7 +238,7 @@ export function LanesView({ entries, autoScroll, workingDir, workspacePath }: La
 
   const onDividerDown = useCallback((e: PointerEvent<HTMLDivElement>) => {
     e.preventDefault();
-    const el = parentRef.current;
+    const el = bodyRef.current;
     if (!el) return;
     dragCleanupRef.current?.();
     const rect = el.getBoundingClientRect();
@@ -147,19 +290,41 @@ export function LanesView({ entries, autoScroll, workingDir, workspacePath }: La
 
   return (
     <div
-      ref={parentRef}
-      className={`${styles.outputContent} ${styles.lanesScroll}`}
+      className={styles.lanesView}
       style={{ ['--lane-split']: `${split * 100}%` } as CSSProperties}
     >
-      <div className={styles.laneHeaders}>
-        <div className={`${styles.laneHeader} ${styles.stdoutHeader}`}>
-          <span className={styles.laneDot} />
-          stdout
-        </div>
-        <div className={`${styles.laneHeader} ${styles.stderrHeader}`}>
-          <span className={styles.laneDot} />
-          stderr
-        </div>
+      <div ref={bodyRef} className={styles.laneBody}>
+        <Lane
+          stream="stdout"
+          label="stdout"
+          entries={stdoutEntries}
+          autoScroll={autoScroll}
+          scrollRef={stdoutRef}
+          onScroll={onStdoutScroll}
+          workingDir={workingDir}
+          workspacePath={workspacePath}
+        />
+        <Lane
+          stream="stderr"
+          label="stderr"
+          entries={stderrEntries}
+          autoScroll={autoScroll}
+          scrollRef={stderrRef}
+          onScroll={onStderrScroll}
+          workingDir={workingDir}
+          workspacePath={workspacePath}
+        >
+          <button
+            type="button"
+            className={styles.laneSyncToggle}
+            onClick={toggleSync}
+            aria-pressed={sync}
+            title={sync ? 'Sync scroll enabled' : 'Sync scroll disabled'}
+          >
+            <span className={styles.laneSyncDot} />
+            Sync scroll
+          </button>
+        </Lane>
         <div
           className={styles.laneDivider}
           style={{ left: `${split * 100}%` }}
@@ -173,39 +338,6 @@ export function LanesView({ entries, autoScroll, workingDir, workspacePath }: La
           aria-valuemax={MAX_SPLIT * 100}
           aria-valuenow={Math.round(split * 100)}
         />
-      </div>
-      <div className={styles.laneRows} style={{ height: `${virtualizer.getTotalSize()}px` }}>
-        {virtualizer.getVirtualItems().map((virtualRow) => {
-          const row = rows[virtualRow.index];
-          return (
-            <div
-              key={virtualRow.index}
-              className={styles.laneRow}
-              style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                width: '100%',
-                transform: `translateY(${virtualRow.start}px)`,
-              }}
-              ref={virtualizer.measureElement}
-              data-index={virtualRow.index}
-            >
-              <OutputLine
-                text={row.stdout ?? ''}
-                className={styles.laneLine}
-                workingDir={workingDir}
-                workspacePath={workspacePath}
-              />
-              <OutputLine
-                text={row.stderr ?? ''}
-                className={`${styles.laneLine} ${row.stderr != null ? styles.stderr : ''}`}
-                workingDir={workingDir}
-                workspacePath={workspacePath}
-              />
-            </div>
-          );
-        })}
       </div>
     </div>
   );

--- a/frontend/src/components/RunOutput/RunOutput.module.css
+++ b/frontend/src/components/RunOutput/RunOutput.module.css
@@ -244,31 +244,39 @@
   height: 100%;
   flex: 1;
   overflow: hidden;
+  background: #040406; /* Glacier glow — near-black void, matches terminal */
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.5;
 }
 
-/* Lanes own their own padding via cells, so the scroll parent has none — this
-   removes the 8px top gap where rows would otherwise show above the sticky
-   header (#107). */
-.lanesScroll {
-  padding: 0;
-}
-
-.laneHeaders {
+/* Two side-by-side lanes split by --lane-split. Each lane scrolls on its own, so
+   the body itself does not scroll; it only anchors the full-height divider. */
+.laneBody {
+  position: relative;
   display: grid;
   grid-template-columns: var(--lane-split, 50%) 1fr;
-  position: sticky;
-  top: 0;
-  z-index: 3;
-  background: #040406;
-  /* Promote to its own compositor layer so momentum-scrolled rows (each a GPU
-     layer via translateY) can't paint over the sticky header in WebView. */
-  will-change: transform;
+  flex: 1;
+  min-height: 0;
+}
+
+/* One stream's column: a fixed header above an independent scroll region. */
+.lane {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .laneHeader {
   display: flex;
   align-items: center;
   gap: 6px;
+  /* Fixed height so the stderr lane's toggle button can't push its header
+     taller than stdout's and misalign the two scroll columns. */
+  min-height: 28px;
+  box-sizing: border-box;
   padding: 4px 14px 6px;
   font-size: 10px;
   font-weight: 600;
@@ -288,10 +296,6 @@
   opacity: 0.6;
 }
 
-.stderrHeader {
-  border-left: 1px solid color-mix(in srgb, var(--accent) 8%, transparent);
-}
-
 .laneDot {
   width: 6px;
   height: 6px;
@@ -299,9 +303,81 @@
   flex-shrink: 0;
 }
 
-/* Draggable column boundary. Lives in the sticky header (always visible) and is
-   positioned at the split fraction; the visual line continues down the body via
-   the .laneLine.stderr border-left. */
+/* Compact sync-scroll toggle, pinned to the right edge of the stderr header. */
+.laneSyncToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: auto;
+  padding: 2px 7px;
+  font: inherit;
+  font-size: 9px;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--accent) 12%, transparent);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.laneSyncToggle:hover {
+  color: var(--text-secondary);
+  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.laneSyncToggle:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.laneSyncToggle[aria-pressed='true'] {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+}
+
+.laneSyncDot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.5;
+}
+
+.laneSyncToggle[aria-pressed='true'] .laneSyncDot {
+  opacity: 1;
+}
+
+/* Independent scroll region for one lane — packs only its own stream's lines. */
+.laneColumn {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.laneColumn::-webkit-scrollbar {
+  width: 8px;
+}
+
+.laneColumn::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.laneColumn::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  border-radius: 4px;
+}
+
+.laneColumn::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.laneColumnInner {
+  position: relative;
+  width: 100%;
+}
+
+/* Draggable column boundary, anchored to the body so it spans the full height. */
 .laneDivider {
   position: absolute;
   top: 0;
@@ -326,19 +402,6 @@
   background: color-mix(in srgb, var(--accent) 50%, transparent);
 }
 
-/* Isolated stacking context so the absolutely-positioned, transformed virtual
-   rows are contained strictly below the sticky header (#107). */
-.laneRows {
-  position: relative;
-  z-index: 0;
-  isolation: isolate;
-}
-
-.laneRow {
-  display: grid;
-  grid-template-columns: var(--lane-split, 50%) 1fr;
-}
-
 .laneLine {
   min-height: 20px;
   min-width: 0;
@@ -350,7 +413,6 @@
 
 .laneLine.stderr {
   color: #fca5a5;
-  border-left: 1px solid color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
 /* ── Diff View ─────────────────────────────────────────── */

--- a/frontend/src/components/RunOutput/RunOutput.module.css
+++ b/frontend/src/components/RunOutput/RunOutput.module.css
@@ -377,13 +377,13 @@
   width: 100%;
 }
 
-/* Draggable column boundary, anchored to the body so it spans the full height. */
+/* Draggable column boundary, anchored on the stderr side so it does not cover
+   stdout's right-edge scrollbar on platforms with visible scrollbars. */
 .laneDivider {
   position: absolute;
   top: 0;
   bottom: 0;
   width: 9px;
-  transform: translateX(-50%);
   cursor: col-resize;
   z-index: 1;
 }
@@ -393,7 +393,7 @@
   position: absolute;
   top: 0;
   bottom: 0;
-  left: 50%;
+  left: 0;
   width: 1px;
   background: color-mix(in srgb, var(--accent) 8%, transparent);
 }


### PR DESCRIPTION
Closes #137. Follow-up to #107/#138. UI-only, frontend.

## Problem
LANES rendered stdout and stderr as one virtualized list aligned by emission order — one row per line, opposite column blank, both columns sharing one scrollbar. A lopsided run (`npm test` writes almost everything to stderr) auto-scrolled the 2-line stdout banner off-screen, so STDOUT read as empty with no way to see it without losing your place in stderr.

## Change
- Replace the single interleaved virtualizer with **two `useVirtualizer` instances**, one per filtered stream (`entries.filter(e => e.stream === ...)`). Each lane gets its own scroll container/scrollbar and packs only its own lines (no blank filler rows). Per-lane independent auto-scroll-to-end while running.
- **"Sync scroll" toggle** in the lanes header, **off by default**, persisted to `localStorage` (`firn.lanesSyncScroll`, mirroring `firn.lanesSplit` from #107). When on, scrolling one lane drives the other by scroll-ratio (`mirrorScrollTop`); a suppress flag breaks the scroll-echo feedback loop. Ratio coupling is the v1 recommended in the issue; timestamp alignment is a later refinement.
- Keep the #138 resizable `--lane-split` grid and per-column headers. The divider now spans the full body height; headers are pinned above each independent column at a fixed height so the toggle button can't misalign them.

## Acceptance
- stdout and stderr scroll independently by default; a one-sided (all-stderr) run still lets you read stdout in full.
- Toggle couples the two lanes; state persists across tab switches and reloads.
- Resizable split and headers from #107/#138 still work.

## Tests
12 LanesView tests: pure `mirrorScrollTop` math, per-stream columns, sync default-off/persist/restore, and coupling wiring (sync-on drives sibling by ratio, sync-off leaves it). Full suite 1011 pass, eslint 0 errors, prettier clean, `tsc && vite build` green.

## Review
Ran /code-review and /criticize-review cycles. Fixes from review: stuck-suppress-flag guard in toggle-on alignment, fixed-height headers for column alignment, undefined `--text` CSS var -> `--text-secondary`, named React type imports to match repo convention, `:focus-visible` on the toggle.

Generated with [Claude Code](https://claude.com/claude-code)