### PR TITLE
feat(terminal): shell integration — OSC 133 error markers & command separators (#47)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,7 +23,7 @@ Firn IDE brings the focused, keyboard-first productivity of JetBrains IDEs to a 
 | Infrastructure | **COMPLETE** | #28-32 |
 | Milestone 1: Core File Operations | **COMPLETE** | #3-9 |
 | UI/UX Polish | **COMPLETE** | #35-36 |
-| Milestone 2: Terminal Integration | **IN PROGRESS** | #10-12 + #116 complete, #47 open |
+| Milestone 2: Terminal Integration | **COMPLETE** | #10-12 + #116 + #47 complete |
 | Milestone 3: Workspace Management | **COMPLETE** | #13-15, #53-54 complete |
 | Milestone 4: Run Profiles | **IN PROGRESS** | #16-17, #59-64 complete; #18/#71 Phase 1 (#123) + #71 P2 panel (#125) + P2 follow-ups/recency sidecar (#127) + #18 P3 header selector (#129) + lifecycle-script detection fix (#130) + #18 P4 create/edit form (#132) + UI polish (#133) + store persist rollback (#134) shipped → **#18/#71 closed**; #103, #107 open |
 | Milestone 5: Language Server Protocol | **COMPLETE** | #19-22, #73-76 complete |
@@ -41,7 +41,7 @@ Firn IDE brings the focused, keyboard-first productivity of JetBrains IDEs to a 
 
 ## Next Priorities
 
-Current status: **Milestone 4 #18 Run Profiles UI complete — P4 create/edit form shipped via PR #132**, with a UI/UX polish follow-up (PR #133) and a store persist-failure rollback fix (PR #134). This closes the #18/#71 Run Profiles UI epic. The form is a panel-takeover create / edit / **customize** / delete surface for single profiles: a "Start from" detected-command picker, name + command, working directory (native folder picker, relativized to the repo root), inline `KEY=value` env rows with a duplicate-key guard, an env file, and round-tripped env variants. It is the first consumer of `SaveRunProfile` / `DeleteRunProfile` / `ValidateRunProfile`, which now **emit `runprofiles:changed` on success** so the list refreshes with backend-normalized fields (no optimistic store mutation). **Copy-on-write identity:** editing a detected profile reuses its id so the detected twin is suppressed via `combineUnitLocked` — no duplicate. PR #133 retuned the card color scheme to the workspace-accent palette (a deep-navy `--surface-base` card surface matching the bottom output panel, accent-tinted hover / selected / failed / running states, a filled Cmd+R-target dot + full-card highlight, click-anywhere-to-target) and fixed the header run/stop button rendering as a blank, off-center square (the icon components had no intrinsic size). PR #134 makes `Store.Save` / `Store.Delete` roll back their in-memory mutation when the disk write fails, so memory and disk can't diverge (the emit path made that observable). Remaining Run Profiles work: **#107** (LANES output polish) and **#103** (compound execution identity hardening).
+Current status: **Milestone 2 closed — #47 Terminal shell integration (OSC 133 error markers + command separators) shipped**: embedded zsh/bash wrapper scripts inject `precmd`/`preexec` hooks (fail-open to a plain shell), an xterm OSC 133 state machine renders red/neutral gutter markers + block separators, atomic wrapper writes for concurrent-creation safety, with PTY-gated emission tests. Also **Milestone 4 #18 Run Profiles UI complete — P4 create/edit form shipped via PR #132**, with a UI/UX polish follow-up (PR #133) and a store persist-failure rollback fix (PR #134). This closes the #18/#71 Run Profiles UI epic. The form is a panel-takeover create / edit / **customize** / delete surface for single profiles: a "Start from" detected-command picker, name + command, working directory (native folder picker, relativized to the repo root), inline `KEY=value` env rows with a duplicate-key guard, an env file, and round-tripped env variants. It is the first consumer of `SaveRunProfile` / `DeleteRunProfile` / `ValidateRunProfile`, which now **emit `runprofiles:changed` on success** so the list refreshes with backend-normalized fields (no optimistic store mutation). **Copy-on-write identity:** editing a detected profile reuses its id so the detected twin is suppressed via `combineUnitLocked` — no duplicate. PR #133 retuned the card color scheme to the workspace-accent palette (a deep-navy `--surface-base` card surface matching the bottom output panel, accent-tinted hover / selected / failed / running states, a filled Cmd+R-target dot + full-card highlight, click-anywhere-to-target) and fixed the header run/stop button rendering as a blank, off-center square (the icon components had no intrinsic size). PR #134 makes `Store.Save` / `Store.Delete` roll back their in-memory mutation when the disk write fails, so memory and disk can't diverge (the emit path made that observable). Remaining Run Profiles work: **#107** (LANES output polish) and **#103** (compound execution identity hardening).
 
 Earlier: **Milestone 4 #71 P2 closed — review follow-ups + recency sidecar shipped via PR #127** (on top of the P2 panel, PR #125). #127 closes the three open P2 review follow-ups: a nil-`executor` guard in `StartRunProfile` (mirrors `StopRunProfile`); **run recency split into the `.firn/run-recency.json` sidecar**, separate from `run-profiles.json` (now profile definitions + adoption only), so stamping a run writes the tiny sidecar *synchronously* and never rewrites profile definitions — fixing per-run write amplification at the root with no debounce timer (and therefore no orphaned-write race, no lost-on-SIGKILL window, and write errors surfaced to the caller); legacy v3 files that embedded recency migrate into the sidecar on load; and `Store.PruneState` drops stale recency-only `profileState` entries on load (saved+detected IDs valid) while preserving `adopted` entries through branch churn. Also a repo-hygiene commit: a `trimws` git clean filter + `.gitattributes` kills the perpetual trailing-whitespace churn Wails emits into `wailsjs/go/*.ts` on every build.
 
@@ -51,11 +51,10 @@ Earlier: **#112 Phase 1 (Python LSP environment auto-wiring) shipped via PR #121
 
 1. **#107: LANES output view polish** — resizable stdout/stderr columns, STDERR header glyph color, and sticky-header bleed-through on scroll (UI-only follow-up). Smallest remaining Run Profiles item.
 2. **#103: Formalize run execution identity for compound profiles** — follow-up hardening spun out of #63.
-3. **#47: Terminal shell integration** — error markers & command separators (last open item in Milestone 2).
-4. **#112 Phase 2: LSP managed server provisioning** (Phase 1 env auto-wiring shipped via #121) — download a pinned server binary (`basedpyright` standalone, no Node dependency) into an app cache (`~/.firn/servers/<lang>/<version>/`) when none is found locally/on PATH, with offline/failure → actionable install/retry UI (the `download_available`/`offline` states reserved in Phase 1). Lazy (active workspace only); never mutates the user's global env/PATH. Smaller Phase 1 follow-ups: command-backed uv/poetry env discovery outside the project root, and the interactive interpreter picker / "Doctor" panel (the `action`/`detailCode` status fields already carry the data).
-5. **#37 (Phase 2): File tree lazy loading** — load directory children on expand; own spec (backend per-dir read, watcher reconcile, #54 scoped-tree/active-file reconciliation).
-6. **NEW (needs issue): Workspace-colored open-file tabs** — surfaced while reviewing #117: open editor tabs should always carry their owning workspace's accent (tab/font) regardless of the active workspace, so files are instantly attributable; future stretch is filtering open tabs to the active workspace. Bundle the **button-in-button DOM fix** in the editor tab bar (close `<button>` nested inside the tab `<button role="tab">` → React hydration warning) since it touches the same component.
-7. **NEW (needs issue): File-level infra accent in the tree** — surfaced during #123 testing: infra files (`Dockerfile`, `docker-compose.y*ml`, `.dockerignore`, `*.tf`/`*.tfvars`) should render with the Docker (purple) / Terraform (amber) accent even when shown inside another workspace's tree, so deployment/infra files are spottable regardless of the active workspace. File-level decoration layered on the existing per-workspace tinting.
+3. **#112 Phase 2: LSP managed server provisioning** (Phase 1 env auto-wiring shipped via #121) — download a pinned server binary (`basedpyright` standalone, no Node dependency) into an app cache (`~/.firn/servers/<lang>/<version>/`) when none is found locally/on PATH, with offline/failure → actionable install/retry UI (the `download_available`/`offline` states reserved in Phase 1). Lazy (active workspace only); never mutates the user's global env/PATH. Smaller Phase 1 follow-ups: command-backed uv/poetry env discovery outside the project root, and the interactive interpreter picker / "Doctor" panel (the `action`/`detailCode` status fields already carry the data).
+4. **#37 (Phase 2): File tree lazy loading** — load directory children on expand; own spec (backend per-dir read, watcher reconcile, #54 scoped-tree/active-file reconciliation).
+5. **NEW (needs issue): Workspace-colored open-file tabs** — surfaced while reviewing #117: open editor tabs should always carry their owning workspace's accent (tab/font) regardless of the active workspace, so files are instantly attributable; future stretch is filtering open tabs to the active workspace. Bundle the **button-in-button DOM fix** in the editor tab bar (close `<button>` nested inside the tab `<button role="tab">` → React hydration warning) since it touches the same component.
+6. **NEW (needs issue): File-level infra accent in the tree** — surfaced during #123 testing: infra files (`Dockerfile`, `docker-compose.y*ml`, `.dockerignore`, `*.tf`/`*.tfvars`) should render with the Docker (purple) / Terraform (amber) accent even when shown inside another workspace's tree, so deployment/infra files are spottable regardless of the active workspace. File-level decoration layered on the existing per-workspace tinting.
 
 ---
 
@@ -84,7 +83,7 @@ Debounced autosave after ~1.5s idle, save on focus loss, Cmd+S support, error to
 
 ---
 
-## Milestone 2: Terminal Integration (IN PROGRESS)
+## Milestone 2: Terminal Integration (COMPLETE)
 
 ### #10: Terminal - PTY Backend ✅
 - [x] Create PTY session with shell (bash/zsh)
@@ -110,9 +109,12 @@ Debounced autosave after ~1.5s idle, save on focus loss, Cmd+S support, error to
 - [x] xterm.js theme: near-black bg, warm foreground, orange cursor
 - [x] Kill process on tab close (graceful SIGHUP via PTY close + SIGKILL fallback)
 
-### #47: Terminal - Shell Integration (Error Markers & Command Separators)
-- [ ] Error markers on failed commands
-- [ ] Visual command separators
+### #47: Terminal - Shell Integration (Error Markers & Command Separators) ✅
+- [x] OSC 133 shell integration injected via embedded, versioned zsh/bash wrapper scripts (zsh `ZDOTDIR`, bash `--rcfile`), chaining the user's real rc; fail-open to a plain shell on any setup failure
+- [x] `precmd`/`preexec` hooks emit `133;A|C|D;<exit>`; zsh hooks prepended (capture `$?` before prompt tooling), bash is DEBUG-trap-safe and preserves exit status
+- [x] Red gutter marker on failed commands, neutral on success, via xterm `registerMarker`/`registerDecoration` driven by an OSC 133 state machine (executed-gate, decorate-once, marker pruning on scrollback dispose)
+- [x] Faint command separators between blocks; zsh + bash only, unsupported shells silently plain
+- [x] Atomic wrapper-file writes (temp+rename) for concurrent-creation safety; PTY-gated emission test + pure-logic unit tests
 
 ---
 

--- a/frontend/src/components/Terminal/Terminal.tsx
+++ b/frontend/src/components/Terminal/Terminal.tsx
@@ -23,6 +23,7 @@ import { ALL_PROFILES_ID } from '../../types/runOutput';
 import { Terminal as XTerm } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
+import { createShellIntegration } from './shellIntegration';
 import {
   CreateTerminal,
   WriteTerminal,
@@ -65,6 +66,13 @@ const XTERM_THEME = {
   brightMagenta: '#E9D5FF', // purple-200
   brightCyan: '#A5F3FC', // cyan-200
   brightWhite: '#F8FAFC', // slate-50
+};
+
+// Gutter marker / separator colors for shell-integration decorations.
+const SHELL_INTEGRATION_COLORS = {
+  fail: '#F87171', // red-400 — failed command
+  ok: '#334155', // slate-700 — succeeded command (neutral)
+  separator: 'rgba(148, 163, 184, 0.18)', // slate-400 @ low alpha
 };
 
 // Buffers terminal output per session until TerminalContent mounts and attaches.
@@ -575,6 +583,10 @@ function TerminalContent({ sessionId, isVisible }: TerminalContentProps) {
     termRef.current = term;
     fitAddonRef.current = fitAddon;
 
+    // Register the OSC 133 handler before replaying buffered output, so early
+    // shell-integration sequences (prompt/exit markers) are parsed, not printed.
+    const shellIntegration = createShellIntegration(term, SHELL_INTEGRATION_COLORS);
+
     // Attach to the buffered output system - replays any early output automatically
     attachSessionListener(sessionId, (data: string) => {
       term.write(data);
@@ -600,6 +612,7 @@ function TerminalContent({ sessionId, isVisible }: TerminalContentProps) {
       // Backend sessions are only closed via explicit close button/context menu actions.
       detachSessionListener(sessionId);
       resizeObserver.disconnect();
+      shellIntegration.dispose();
       term.dispose();
       termRef.current = null;
       fitAddonRef.current = null;

--- a/frontend/src/components/Terminal/shellIntegration.test.ts
+++ b/frontend/src/components/Terminal/shellIntegration.test.ts
@@ -138,6 +138,21 @@ describe('createShellIntegration', () => {
     expect(sep.el.style.borderTop).toContain('1px solid');
   });
 
+  it('fails open when the terminal exposes no OSC parser (headless/jsdom)', () => {
+    // Under jsdom (and any env where xterm.open() cannot fully init), term.parser
+    // is undefined. Integration must degrade to a no-op, not crash the mount.
+    const noParser = {
+      cols: 80,
+      registerMarker: () => undefined,
+      registerDecoration: () => undefined,
+    } as unknown as IntegrationTerminal;
+    let integ: ReturnType<typeof createShellIntegration> | undefined;
+    expect(() => {
+      integ = createShellIntegration(noParser, COLORS);
+    }).not.toThrow();
+    expect(() => integ?.dispose()).not.toThrow();
+  });
+
   it('dispose() tears down handler, markers and decorations', () => {
     const f = makeFakeTerm();
     const integ = createShellIntegration(f.term, COLORS);

--- a/frontend/src/components/Terminal/shellIntegration.test.ts
+++ b/frontend/src/components/Terminal/shellIntegration.test.ts
@@ -10,7 +10,7 @@ interface FakeDecoration {
 }
 
 function makeFakeTerm() {
-  const markers: { disposed: boolean }[] = [];
+  const markers: { disposed: boolean; dispose(): void }[] = [];
   const decorations: FakeDecoration[] = [];
   let osc: ((data: string) => boolean) | null = null;
 
@@ -23,10 +23,15 @@ function makeFakeTerm() {
       },
     },
     registerMarker: () => {
+      const listeners: Array<() => void> = [];
       const m = {
         disposed: false,
         dispose() {
           this.disposed = true;
+          for (const l of listeners) l();
+        },
+        onDispose(cb: () => void) {
+          listeners.push(cb);
         },
       };
       markers.push(m);
@@ -136,6 +141,19 @@ describe('createShellIntegration', () => {
     const sep = f.decorations[2];
     sep.render();
     expect(sep.el.style.borderTop).toContain('1px solid');
+  });
+
+  it('prunes a finished command block when its marker is disposed (scrolled out)', () => {
+    const f = makeFakeTerm();
+    const integ = createShellIntegration(f.term, COLORS);
+    f.fire('A');
+    f.fire('C');
+    f.fire('D;1'); // block decorated, marker 0 + decoration 0 retained
+    // xterm disposes the marker when its line scrolls out of the scrollback buffer.
+    f.markers[0].dispose();
+    // The block is pruned, so a later dispose() no longer touches its decoration.
+    integ.dispose();
+    expect(f.decorations[0].disposed).toBe(false);
   });
 
   it('fails open when the terminal exposes no OSC parser (headless/jsdom)', () => {

--- a/frontend/src/components/Terminal/shellIntegration.test.ts
+++ b/frontend/src/components/Terminal/shellIntegration.test.ts
@@ -1,0 +1,151 @@
+import { createShellIntegration, type IntegrationTerminal } from './shellIntegration';
+
+const COLORS = { fail: '#F87171', ok: '#334155', separator: 'rgba(148,163,184,0.2)' };
+
+interface FakeDecoration {
+  opts: { marker: unknown; x?: number; width?: number };
+  el: HTMLElement;
+  render: () => void;
+  disposed: boolean;
+}
+
+function makeFakeTerm() {
+  const markers: { disposed: boolean }[] = [];
+  const decorations: FakeDecoration[] = [];
+  let osc: ((data: string) => boolean) | null = null;
+
+  const term: IntegrationTerminal = {
+    cols: 80,
+    parser: {
+      registerOscHandler: (_id, cb) => {
+        osc = cb;
+        return { dispose: () => {} };
+      },
+    },
+    registerMarker: () => {
+      const m = {
+        disposed: false,
+        dispose() {
+          this.disposed = true;
+        },
+      };
+      markers.push(m);
+      return m;
+    },
+    registerDecoration: (opts) => {
+      let cb: ((el: HTMLElement) => void) | null = null;
+      const el = document.createElement('div');
+      const d: FakeDecoration = {
+        opts,
+        el,
+        render: () => cb?.(el),
+        disposed: false,
+      };
+      decorations.push(d);
+      return {
+        onRender: (fn) => {
+          cb = fn;
+        },
+        dispose() {
+          d.disposed = true;
+        },
+      };
+    },
+  };
+
+  return {
+    term,
+    markers,
+    decorations,
+    fire: (d: string) => osc?.(d),
+  };
+}
+
+describe('createShellIntegration', () => {
+  it('decorates an executed command marker, red on non-zero exit', () => {
+    const f = makeFakeTerm();
+    createShellIntegration(f.term, COLORS);
+    f.fire('A');
+    f.fire('C');
+    f.fire('D;1');
+    const bar = f.decorations[0];
+    expect(bar).toBeDefined();
+    bar.render();
+    expect(bar.el.style.backgroundColor).toBe('rgb(248, 113, 113)'); // #F87171
+  });
+
+  it('uses neutral color on zero exit', () => {
+    const f = makeFakeTerm();
+    createShellIntegration(f.term, COLORS);
+    f.fire('A');
+    f.fire('C');
+    f.fire('D;0');
+    const bar = f.decorations[0];
+    bar.render();
+    expect(bar.el.style.backgroundColor).toBe('rgb(51, 65, 85)'); // #334155
+  });
+
+  it('ignores a D with no preceding A', () => {
+    const f = makeFakeTerm();
+    createShellIntegration(f.term, COLORS);
+    f.fire('D;1');
+    expect(f.decorations).toHaveLength(0);
+  });
+
+  it('does not decorate a prompt with no command (no C)', () => {
+    const f = makeFakeTerm();
+    createShellIntegration(f.term, COLORS);
+    f.fire('A');
+    f.fire('D;0');
+    expect(f.decorations).toHaveLength(0);
+  });
+
+  it('disposes the stale undecorated marker on repeated empty enters', () => {
+    const f = makeFakeTerm();
+    createShellIntegration(f.term, COLORS);
+    f.fire('A'); // marker 0
+    f.fire('A'); // marker 1 — marker 0 was never executed/decorated
+    expect(f.markers[0].disposed).toBe(true);
+    expect(f.markers[1].disposed).toBe(false);
+  });
+
+  it('decorates each executed marker only once', () => {
+    const f = makeFakeTerm();
+    createShellIntegration(f.term, COLORS);
+    f.fire('A');
+    f.fire('C');
+    f.fire('D;1');
+    f.fire('D;1'); // duplicate D for same marker
+    // one gutter + (no separator on first decorated command) = 1 decoration
+    expect(f.decorations).toHaveLength(1);
+  });
+
+  it('draws a separator on the second and later executed commands', () => {
+    const f = makeFakeTerm();
+    createShellIntegration(f.term, COLORS);
+    // first command
+    f.fire('A');
+    f.fire('C');
+    f.fire('D;0');
+    // second command
+    f.fire('A');
+    f.fire('C');
+    f.fire('D;0');
+    // 1 (first: gutter only) + 2 (second: gutter + separator) = 3
+    expect(f.decorations).toHaveLength(3);
+    const sep = f.decorations[2];
+    sep.render();
+    expect(sep.el.style.borderTop).toContain('1px solid');
+  });
+
+  it('dispose() tears down handler, markers and decorations', () => {
+    const f = makeFakeTerm();
+    const integ = createShellIntegration(f.term, COLORS);
+    f.fire('A');
+    f.fire('C');
+    f.fire('D;1');
+    integ.dispose();
+    expect(f.markers[0].disposed).toBe(true);
+    expect(f.decorations[0].disposed).toBe(true);
+  });
+});

--- a/frontend/src/components/Terminal/shellIntegration.ts
+++ b/frontend/src/components/Terminal/shellIntegration.ts
@@ -1,0 +1,113 @@
+// OSC 133 shell-integration: parse semantic-prompt sequences and render gutter
+// markers (red = failed, neutral = success) plus separators between command
+// blocks. Parsing lives entirely in xterm; this only consumes 133 events.
+
+export interface ShellIntegrationColors {
+  fail: string;
+  ok: string;
+  separator: string;
+}
+
+export interface ShellIntegration {
+  dispose(): void;
+}
+
+interface Disposable {
+  dispose(): void;
+}
+
+interface Marker extends Disposable {
+  dispose(): void;
+}
+
+interface Decoration extends Disposable {
+  onRender(cb: (el: HTMLElement) => void): void;
+}
+
+// Structural subset of xterm's Terminal we depend on — lets tests pass a fake
+// and the real Terminal satisfy the same shape.
+export interface IntegrationTerminal {
+  cols: number;
+  parser: {
+    registerOscHandler(ident: number, cb: (data: string) => boolean): Disposable;
+  };
+  registerMarker(): Marker | undefined;
+  registerDecoration(opts: { marker: Marker; x?: number; width?: number }): Decoration | undefined;
+}
+
+interface PromptBlock {
+  marker: Marker;
+  executed: boolean;
+  decorated: boolean;
+}
+
+export function createShellIntegration(
+  term: IntegrationTerminal,
+  colors: ShellIntegrationColors
+): ShellIntegration {
+  let current: PromptBlock | null = null;
+  let decoratedCount = 0;
+  const tracked: Disposable[] = [];
+  const markers: Marker[] = [];
+
+  const handler = term.parser.registerOscHandler(133, (data: string): boolean => {
+    const parts = data.split(';');
+    switch (parts[0]) {
+      case 'A': {
+        // Drop a stale marker from a prompt that ran no command (empty enters).
+        if (current && !current.executed && !current.decorated) {
+          current.marker.dispose();
+        }
+        const marker = term.registerMarker();
+        if (marker) markers.push(marker);
+        current = marker ? { marker, executed: false, decorated: false } : null;
+        break;
+      }
+      case 'C':
+        if (current) current.executed = true;
+        break;
+      case 'D':
+        if (current && current.executed && !current.decorated) {
+          const exit = Number.parseInt(parts[1] ?? '0', 10);
+          const failed = !Number.isNaN(exit) && exit !== 0;
+          decorate(current.marker, failed, decoratedCount > 0);
+          current.decorated = true;
+          decoratedCount += 1;
+        }
+        break;
+    }
+    return true; // handled — xterm will not print the sequence
+  });
+
+  function decorate(marker: Marker, failed: boolean, withSeparator: boolean): void {
+    const bar = term.registerDecoration({ marker, x: 0, width: 1 });
+    if (bar) {
+      bar.onRender((el) => {
+        el.style.backgroundColor = failed ? colors.fail : colors.ok;
+        el.style.width = '3px';
+      });
+      tracked.push(bar);
+    }
+    if (withSeparator) {
+      const sep = term.registerDecoration({ marker, x: 0, width: term.cols });
+      if (sep) {
+        sep.onRender((el) => {
+          el.style.borderTop = `1px solid ${colors.separator}`;
+          el.style.pointerEvents = 'none';
+        });
+        tracked.push(sep);
+      }
+    }
+  }
+
+  return {
+    dispose(): void {
+      handler.dispose();
+      for (const d of tracked) d.dispose();
+      for (const marker of markers) marker.dispose();
+      tracked.length = 0;
+      markers.length = 0;
+      current = null;
+    },
+  };
+}

--- a/frontend/src/components/Terminal/shellIntegration.ts
+++ b/frontend/src/components/Terminal/shellIntegration.ts
@@ -18,6 +18,9 @@ interface Disposable {
 
 interface Marker extends Disposable {
   dispose(): void;
+  // Fired when xterm disposes the marker (e.g. its line scrolls out of the
+  // scrollback buffer). Optional: absent on minimal/test doubles.
+  onDispose?(listener: () => void): void;
 }
 
 interface Decoration extends Disposable {
@@ -39,6 +42,7 @@ interface PromptBlock {
   marker: Marker;
   executed: boolean;
   decorated: boolean;
+  decorations: Decoration[];
 }
 
 export function createShellIntegration(
@@ -47,8 +51,9 @@ export function createShellIntegration(
 ): ShellIntegration {
   let current: PromptBlock | null = null;
   let decoratedCount = 0;
-  const tracked: Disposable[] = [];
-  const markers: Marker[] = [];
+  // Live command blocks. Pruned as xterm disposes their markers (lines scrolling
+  // out of scrollback), so this stays bounded over a long-lived terminal.
+  const blocks = new Set<PromptBlock>();
 
   // Fail open: xterm.open() may not initialize the parser in headless/jsdom
   // environments (term.parser is undefined). Without the OSC parser there is
@@ -64,11 +69,18 @@ export function createShellIntegration(
       case 'A': {
         // Drop a stale marker from a prompt that ran no command (empty enters).
         if (current && !current.executed && !current.decorated) {
-          current.marker.dispose();
+          discard(current);
         }
         const marker = term.registerMarker();
-        if (marker) markers.push(marker);
-        current = marker ? { marker, executed: false, decorated: false } : null;
+        if (marker) {
+          const block: PromptBlock = { marker, executed: false, decorated: false, decorations: [] };
+          blocks.add(block);
+          // When xterm disposes the marker, drop our reference so blocks stays bounded.
+          marker.onDispose?.(() => blocks.delete(block));
+          current = block;
+        } else {
+          current = null;
+        }
         break;
       }
       case 'C':
@@ -78,7 +90,7 @@ export function createShellIntegration(
         if (current && current.executed && !current.decorated) {
           const exit = Number.parseInt(parts[1] ?? '0', 10);
           const failed = !Number.isNaN(exit) && exit !== 0;
-          decorate(current.marker, failed, decoratedCount > 0);
+          decorate(current, failed, decoratedCount > 0);
           current.decorated = true;
           decoratedCount += 1;
         }
@@ -87,23 +99,31 @@ export function createShellIntegration(
     return true; // handled — xterm will not print the sequence
   });
 
-  function decorate(marker: Marker, failed: boolean, withSeparator: boolean): void {
-    const bar = term.registerDecoration({ marker, x: 0, width: 1 });
+  function discard(block: PromptBlock): void {
+    for (const d of block.decorations) d.dispose();
+    block.marker.dispose();
+    blocks.delete(block);
+  }
+
+  function decorate(block: PromptBlock, failed: boolean, withSeparator: boolean): void {
+    const bar = term.registerDecoration({ marker: block.marker, x: 0, width: 1 });
     if (bar) {
       bar.onRender((el) => {
         el.style.backgroundColor = failed ? colors.fail : colors.ok;
         el.style.width = '3px';
       });
-      tracked.push(bar);
+      block.decorations.push(bar);
     }
     if (withSeparator) {
-      const sep = term.registerDecoration({ marker, x: 0, width: term.cols });
+      // ponytail: separator width is fixed at the column count when drawn; it
+      // does not re-flow if the terminal is later resized wider. Fine for a hairline.
+      const sep = term.registerDecoration({ marker: block.marker, x: 0, width: term.cols });
       if (sep) {
         sep.onRender((el) => {
           el.style.borderTop = `1px solid ${colors.separator}`;
           el.style.pointerEvents = 'none';
         });
-        tracked.push(sep);
+        block.decorations.push(sep);
       }
     }
   }
@@ -111,10 +131,11 @@ export function createShellIntegration(
   return {
     dispose(): void {
       handler.dispose();
-      for (const d of tracked) d.dispose();
-      for (const marker of markers) marker.dispose();
-      tracked.length = 0;
-      markers.length = 0;
+      for (const block of blocks) {
+        for (const d of block.decorations) d.dispose();
+        block.marker.dispose();
+      }
+      blocks.clear();
       current = null;
     },
   };

--- a/frontend/src/components/Terminal/shellIntegration.ts
+++ b/frontend/src/components/Terminal/shellIntegration.ts
@@ -50,7 +50,15 @@ export function createShellIntegration(
   const tracked: Disposable[] = [];
   const markers: Marker[] = [];
 
-  const handler = term.parser.registerOscHandler(133, (data: string): boolean => {
+  // Fail open: xterm.open() may not initialize the parser in headless/jsdom
+  // environments (term.parser is undefined). Without the OSC parser there is
+  // nothing to integrate, so degrade to a no-op rather than crash the mount.
+  const parser = term.parser as IntegrationTerminal['parser'] | undefined;
+  if (!parser || typeof parser.registerOscHandler !== 'function') {
+    return { dispose() {} };
+  }
+
+  const handler = parser.registerOscHandler(133, (data: string): boolean => {
     const parts = data.split(';');
     switch (parts[0]) {
       case 'A': {

--- a/internal/terminal/integration/firn.bashrc
+++ b/internal/terminal/integration/firn.bashrc
@@ -1,0 +1,35 @@
+# Firn IDE shell integration (OSC 133)
+[[ -f "$HOME/.bashrc" ]] && source "$HOME/.bashrc"
+
+if [[ -z "$FIRN_SHELL_INTEGRATION" ]]; then
+  # Do not clobber an existing DEBUG trap — bail to plain user config if present.
+  __firn_prompt_decl="$(declare -p PROMPT_COMMAND 2>/dev/null || true)"
+  if [[ -z "$(trap -p DEBUG)" && "$__firn_prompt_decl" != declare\ -a* && "$__firn_prompt_decl" != declare\ -A* ]]; then
+    FIRN_SHELL_INTEGRATION=1
+    __firn_osc() { printf '\033]133;%s\007' "$1"; }
+    __firn_user_prompt_command="$PROMPT_COMMAND"
+    __firn_preexec_done=1
+    __firn_in_prompt_command=0
+    __firn_preexec() {
+      [[ -n "$COMP_LINE" ]] && return
+      [[ "$BASH_COMMAND" == __firn_precmd ]] && return
+      [[ $__firn_in_prompt_command -eq 1 ]] && return
+      [[ $__firn_preexec_done -eq 1 ]] && return
+      __firn_preexec_done=1
+      __firn_osc C
+    }
+    __firn_precmd() {
+      local s=$?
+      __firn_in_prompt_command=1
+      __firn_osc "D;$s"
+      __firn_osc A
+      [[ -n "$__firn_user_prompt_command" ]] && eval "$__firn_user_prompt_command"
+      __firn_preexec_done=0
+      __firn_in_prompt_command=0
+      return $s
+    }
+    trap '__firn_preexec' DEBUG
+    PROMPT_COMMAND="__firn_precmd"
+  fi
+  unset __firn_prompt_decl
+fi

--- a/internal/terminal/integration/firn.bashrc
+++ b/internal/terminal/integration/firn.bashrc
@@ -7,6 +7,7 @@ if [[ -z "$FIRN_SHELL_INTEGRATION" ]]; then
   if [[ -z "$(trap -p DEBUG)" && "$__firn_prompt_decl" != declare\ -a* && "$__firn_prompt_decl" != declare\ -A* ]]; then
     FIRN_SHELL_INTEGRATION=1
     __firn_osc() { printf '\033]133;%s\007' "$1"; }
+    __firn_restore_status() { return "$1"; }
     __firn_user_prompt_command="$PROMPT_COMMAND"
     __firn_preexec_done=1
     __firn_in_prompt_command=0
@@ -23,7 +24,10 @@ if [[ -z "$FIRN_SHELL_INTEGRATION" ]]; then
       __firn_in_prompt_command=1
       __firn_osc "D;$s"
       __firn_osc A
-      [[ -n "$__firn_user_prompt_command" ]] && eval "$__firn_user_prompt_command"
+      if [[ -n "$__firn_user_prompt_command" ]]; then
+        __firn_restore_status "$s"
+        eval "$__firn_user_prompt_command"
+      fi
       __firn_preexec_done=0
       __firn_in_prompt_command=0
       return $s

--- a/internal/terminal/integration/zdotdir/.zshenv
+++ b/internal/terminal/integration/zdotdir/.zshenv
@@ -1,0 +1,7 @@
+# Firn IDE shell integration — user .zshenv should see the user's ZDOTDIR, but
+# zsh must still load Firn's wrapper .zshrc afterwards.
+__firn_zdotdir="$ZDOTDIR"
+ZDOTDIR="${USER_ZDOTDIR:-$HOME}"
+[[ -f "$ZDOTDIR/.zshenv" ]] && source "$ZDOTDIR/.zshenv"
+ZDOTDIR="$__firn_zdotdir"
+unset __firn_zdotdir

--- a/internal/terminal/integration/zdotdir/.zshrc
+++ b/internal/terminal/integration/zdotdir/.zshrc
@@ -1,0 +1,15 @@
+# Firn IDE shell integration (OSC 133)
+ZDOTDIR="${USER_ZDOTDIR:-$HOME}"
+[[ -f "$ZDOTDIR/.zshrc" ]] && source "$ZDOTDIR/.zshrc"
+
+# Install hooks AFTER user rc, PREPENDED so __firn_precmd reads $? before any
+# prompt tooling (p10k/starship) mutates it.
+if [[ -z "$FIRN_SHELL_INTEGRATION" ]]; then
+  FIRN_SHELL_INTEGRATION=1
+  __firn_osc() { printf '\033]133;%s\007' "$1"; }
+  __firn_preexec() { __firn_osc C; }
+  __firn_precmd()  { local s=$?; __firn_osc "D;$s"; __firn_osc A; }
+  typeset -ga precmd_functions preexec_functions
+  precmd_functions=(__firn_precmd ${precmd_functions[@]})
+  preexec_functions=(__firn_preexec ${preexec_functions[@]})
+fi

--- a/internal/terminal/session.go
+++ b/internal/terminal/session.go
@@ -33,7 +33,8 @@ func NewSession() (*Session, error) {
 	if shell == "" {
 		shell = defaultShell()
 	}
-	cmd := exec.Command(shell)
+	cacheRoot, _ := os.UserCacheDir() // empty on error → integratedCommand falls open to plain
+	cmd := integratedCommand(shell, cacheRoot)
 	ptmx, err := pty.Start(cmd)
 	if err != nil {
 		// ENXIO ("device not configured") from /dev/ptmx means the system PTY

--- a/internal/terminal/shell_integration.go
+++ b/internal/terminal/shell_integration.go
@@ -1,0 +1,22 @@
+package terminal
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// shellKind returns "zsh", "bash", or "" (unsupported) for a shell path.
+func shellKind(shellPath string) string {
+	// Normalize Windows separators so filepath.Base works regardless of host OS.
+	normalized := strings.ReplaceAll(shellPath, "\\", "/")
+	base := strings.ToLower(filepath.Base(normalized))
+	base = strings.TrimSuffix(base, ".exe")
+	switch base {
+	case "zsh":
+		return "zsh"
+	case "bash":
+		return "bash"
+	default:
+		return ""
+	}
+}

--- a/internal/terminal/shell_integration.go
+++ b/internal/terminal/shell_integration.go
@@ -1,9 +1,61 @@
 package terminal
 
 import (
+	"bytes"
+	"embed"
+	"os"
 	"path/filepath"
 	"strings"
 )
+
+const integrationVersion = "v1"
+
+//go:embed integration/zdotdir/.zshenv
+//go:embed integration/zdotdir/.zshrc
+//go:embed integration/firn.bashrc
+var integrationFS embed.FS
+
+// wrapperFiles maps the on-disk name to its embedded source path.
+var wrapperFiles = map[string]string{
+	".zshenv":     "integration/zdotdir/.zshenv",
+	".zshrc":      "integration/zdotdir/.zshrc",
+	"firn.bashrc": "integration/firn.bashrc",
+}
+
+// ensureWrapperFiles writes the shell-integration scripts under
+// <root>/firn-ide/shell-integration/<version>/ and returns that directory.
+// It rewrites any file whose content differs from the embedded source and
+// re-asserts perms even when content is current. Dirs are 0700 and scripts
+// 0600 — they are code-execution inputs.
+func ensureWrapperFiles(root string) (string, error) {
+	dir := filepath.Join(root, "firn-ide", "shell-integration", integrationVersion)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return "", err
+	}
+	for name, src := range wrapperFiles {
+		want, err := integrationFS.ReadFile(src)
+		if err != nil {
+			return "", err
+		}
+		dst := filepath.Join(dir, name)
+		if got, err := os.ReadFile(dst); err == nil && bytes.Equal(got, want) {
+			if err := os.Chmod(dst, 0o600); err != nil {
+				return "", err
+			}
+			continue
+		}
+		if err := os.WriteFile(dst, want, 0o600); err != nil {
+			return "", err
+		}
+		if err := os.Chmod(dst, 0o600); err != nil {
+			return "", err
+		}
+	}
+	return dir, nil
+}
 
 // shellKind returns "zsh", "bash", or "" (unsupported) for a shell path.
 func shellKind(shellPath string) string {

--- a/internal/terminal/shell_integration.go
+++ b/internal/terminal/shell_integration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"embed"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -55,6 +56,40 @@ func ensureWrapperFiles(root string) (string, error) {
 		}
 	}
 	return dir, nil
+}
+
+// integratedCommand builds the shell command with OSC 133 integration when the
+// shell is supported and wrapper setup succeeds. It is FAIL-OPEN: any failure
+// yields a plain shell command so terminal creation never breaks on integration.
+func integratedCommand(shellPath, cacheRoot string) *exec.Cmd {
+	plain := exec.Command(shellPath)
+
+	kind := shellKind(shellPath)
+	if kind == "" || cacheRoot == "" {
+		return plain
+	}
+	dir, err := ensureWrapperFiles(cacheRoot)
+	if err != nil {
+		return plain
+	}
+
+	switch kind {
+	case "zsh":
+		cmd := exec.Command(shellPath)
+		userZdotdir := os.Getenv("ZDOTDIR")
+		if userZdotdir == "" {
+			userZdotdir = os.Getenv("HOME")
+		}
+		cmd.Env = append(os.Environ(),
+			"ZDOTDIR="+dir,
+			"USER_ZDOTDIR="+userZdotdir,
+		)
+		return cmd
+	case "bash":
+		return exec.Command(shellPath, "--rcfile", filepath.Join(dir, "firn.bashrc"), "-i")
+	default:
+		return plain
+	}
 }
 
 // shellKind returns "zsh", "bash", or "" (unsupported) for a shell path.

--- a/internal/terminal/shell_integration.go
+++ b/internal/terminal/shell_integration.go
@@ -43,19 +43,49 @@ func ensureWrapperFiles(root string) (string, error) {
 		}
 		dst := filepath.Join(dir, name)
 		if got, err := os.ReadFile(dst); err == nil && bytes.Equal(got, want) {
+			// Content current; re-assert perms in case they drifted.
 			if err := os.Chmod(dst, 0o600); err != nil {
 				return "", err
 			}
 			continue
 		}
-		if err := os.WriteFile(dst, want, 0o600); err != nil {
-			return "", err
-		}
-		if err := os.Chmod(dst, 0o600); err != nil {
+		// Write atomically (temp + rename) so a shell sourcing the file never
+		// observes a partial write when terminals are created concurrently.
+		if err := writeFileAtomic(dir, dst, want, 0o600); err != nil {
 			return "", err
 		}
 	}
 	return dir, nil
+}
+
+// writeFileAtomic writes data to a temp file in dir, then renames it over dst.
+// Rename is atomic within a filesystem, so a concurrent reader (a shell sourcing
+// the script) sees either the complete old file or the complete new one.
+func writeFileAtomic(dir, dst string, data []byte, perm os.FileMode) error {
+	tmp, err := os.CreateTemp(dir, ".firn-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, dst); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return nil
 }
 
 // integratedCommand builds the shell command with OSC 133 integration when the

--- a/internal/terminal/shell_integration_test.go
+++ b/internal/terminal/shell_integration_test.go
@@ -1,6 +1,11 @@
 package terminal
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestShellKind(t *testing.T) {
 	cases := []struct {
@@ -19,5 +24,71 @@ func TestShellKind(t *testing.T) {
 		if got := shellKind(c.path); got != c.want {
 			t.Errorf("shellKind(%q) = %q, want %q", c.path, got, c.want)
 		}
+	}
+}
+
+func TestEnsureWrapperFiles(t *testing.T) {
+	root := t.TempDir()
+
+	dir, err := ensureWrapperFiles(root)
+	if err != nil {
+		t.Fatalf("ensureWrapperFiles() error: %v", err)
+	}
+
+	if info, err := os.Stat(dir); err != nil {
+		t.Fatalf("missing wrapper dir: %v", err)
+	} else if info.Mode().Perm() != 0o700 {
+		t.Errorf("wrapper dir perm = %o, want 700", info.Mode().Perm())
+	}
+
+	for _, name := range []string{".zshenv", ".zshrc", "firn.bashrc"} {
+		p := filepath.Join(dir, name)
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("missing %s: %v", name, err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Errorf("%s perm = %o, want 600", name, info.Mode().Perm())
+		}
+	}
+
+	// Content matches the embedded source.
+	got, _ := os.ReadFile(filepath.Join(dir, ".zshrc"))
+	if !strings.Contains(string(got), "__firn_precmd") {
+		t.Error(".zshrc missing hook content")
+	}
+
+	// Idempotent: second call succeeds and dir is stable.
+	dir2, err := ensureWrapperFiles(root)
+	if err != nil || dir2 != dir {
+		t.Fatalf("second call: dir=%q dir2=%q err=%v", dir, dir2, err)
+	}
+
+	// Content drift is repaired.
+	if err := os.WriteFile(filepath.Join(dir, ".zshrc"), []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ensureWrapperFiles(root); err != nil {
+		t.Fatal(err)
+	}
+	repaired, _ := os.ReadFile(filepath.Join(dir, ".zshrc"))
+	if string(repaired) == "stale" {
+		t.Error("ensureWrapperFiles did not repair drifted content")
+	}
+
+	// Permission drift is repaired even when content is already current.
+	bashrc := filepath.Join(dir, "firn.bashrc")
+	if err := os.Chmod(bashrc, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ensureWrapperFiles(root); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(bashrc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("repaired firn.bashrc perm = %o, want 600", info.Mode().Perm())
 	}
 }

--- a/internal/terminal/shell_integration_test.go
+++ b/internal/terminal/shell_integration_test.go
@@ -92,3 +92,76 @@ func TestEnsureWrapperFiles(t *testing.T) {
 		t.Errorf("repaired firn.bashrc perm = %o, want 600", info.Mode().Perm())
 	}
 }
+
+func hasArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func envValue(env []string, key string) (string, bool) {
+	for i := len(env) - 1; i >= 0; i-- {
+		e := env[i]
+		if strings.HasPrefix(e, key+"=") {
+			return strings.TrimPrefix(e, key+"="), true
+		}
+	}
+	return "", false
+}
+
+func TestIntegratedCommandZsh(t *testing.T) {
+	root := t.TempDir()
+	cmd := integratedCommand("/bin/zsh", root)
+
+	if cmd.Path != "/bin/zsh" {
+		t.Errorf("Path = %q", cmd.Path)
+	}
+	zdot, ok := envValue(cmd.Env, "ZDOTDIR")
+	if !ok || !strings.Contains(zdot, "shell-integration") {
+		t.Errorf("ZDOTDIR = %q ok=%v", zdot, ok)
+	}
+	if _, ok := envValue(cmd.Env, "USER_ZDOTDIR"); !ok {
+		t.Error("USER_ZDOTDIR not set")
+	}
+}
+
+func TestIntegratedCommandBash(t *testing.T) {
+	root := t.TempDir()
+	cmd := integratedCommand("/usr/bin/bash", root)
+
+	if !hasArg(cmd.Args, "--rcfile") || !hasArg(cmd.Args, "-i") {
+		t.Errorf("bash args missing --rcfile/-i: %v", cmd.Args)
+	}
+}
+
+func TestIntegratedCommandUnsupportedIsPlain(t *testing.T) {
+	root := t.TempDir()
+	for _, sh := range []string{"/bin/sh", "/usr/bin/fish"} {
+		cmd := integratedCommand(sh, root)
+		if len(cmd.Args) != 1 {
+			t.Errorf("%s: expected plain command, got args %v", sh, cmd.Args)
+		}
+		if cmd.Env != nil {
+			t.Errorf("%s: plain command should not set Env, got %v", sh, cmd.Env)
+		}
+	}
+}
+
+func TestIntegratedCommandFailsOpen(t *testing.T) {
+	// A root that cannot be created (a file, not a dir) forces ensureWrapperFiles
+	// to fail; integratedCommand must still return a usable plain zsh command.
+	f := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := integratedCommand("/bin/zsh", f)
+	if cmd == nil || cmd.Path == "" {
+		t.Fatal("expected plain command on setup failure")
+	}
+	if cmd.Env != nil {
+		t.Fatalf("fail-open should return plain command with nil Env, got %v", cmd.Env)
+	}
+}

--- a/internal/terminal/shell_integration_test.go
+++ b/internal/terminal/shell_integration_test.go
@@ -206,6 +206,50 @@ func TestIntegratedCommandFailsOpen(t *testing.T) {
 	}
 }
 
+func TestBashPromptCommandSeesOriginalStatus(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not installed")
+	}
+
+	root := t.TempDir()
+	dir, err := ensureWrapperFiles(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	home := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(home, ".bashrc"),
+		[]byte(`PROMPT_COMMAND='printf "%s\n" "$?" > "$HOME/status"'`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(
+		bash,
+		"--noprofile",
+		"--norc",
+		"-c",
+		`source "$1"; false; __firn_precmd >/dev/null || true`,
+		"bash",
+		filepath.Join(dir, "firn.bashrc"),
+	)
+	cmd.Env = append(os.Environ(), "HOME="+home)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bash prompt command probe failed: %v\n%s", err, out)
+	}
+	gotBytes, err := os.ReadFile(filepath.Join(home, "status"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(gotBytes)); got != "1" {
+		t.Fatalf("PROMPT_COMMAND saw status %q, want 1", got)
+	}
+}
+
 // TestIntegratedShellEmitsOSC133 spawns the integrated shell in a real PTY and
 // asserts the embedded scripts emit the OSC 133 "command finished" marker with a
 // non-zero exit code. PTY-gated (skipped on headless CI) and shell-gated via

--- a/internal/terminal/shell_integration_test.go
+++ b/internal/terminal/shell_integration_test.go
@@ -1,0 +1,23 @@
+package terminal
+
+import "testing"
+
+func TestShellKind(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/bin/zsh", "zsh"},
+		{"/usr/local/bin/bash", "bash"},
+		{"/bin/sh", ""},
+		{"/usr/bin/fish", ""},
+		{"C:\\Program Files\\Git\\bin\\bash.EXE", "bash"},
+		{"/opt/homebrew/bin/ZSH", "zsh"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := shellKind(c.path); got != c.want {
+			t.Errorf("shellKind(%q) = %q, want %q", c.path, got, c.want)
+		}
+	}
+}

--- a/internal/terminal/shell_integration_test.go
+++ b/internal/terminal/shell_integration_test.go
@@ -98,6 +98,41 @@ func TestEnsureWrapperFiles(t *testing.T) {
 	}
 }
 
+func TestEnsureWrapperFilesConcurrent(t *testing.T) {
+	root := t.TempDir()
+
+	// Concurrent terminal creation calls ensureWrapperFiles in parallel. With
+	// atomic writes none should error and every file must end up complete.
+	const n = 16
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		go func() {
+			_, err := ensureWrapperFiles(root)
+			errs <- err
+		}()
+	}
+	for i := 0; i < n; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("concurrent ensureWrapperFiles error: %v", err)
+		}
+	}
+
+	dir := filepath.Join(root, "firn-ide", "shell-integration", integrationVersion)
+	for name, src := range wrapperFiles {
+		want, err := integrationFS.ReadFile(src)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Errorf("%s content not complete after concurrent writes", name)
+		}
+	}
+}
+
 func hasArg(args []string, want string) bool {
 	for _, a := range args {
 		if a == want {
@@ -186,6 +221,17 @@ func TestIntegratedShellEmitsOSC133(t *testing.T) {
 			}
 
 			cmd := integratedCommand(path, t.TempDir())
+
+			// Make the spawned shell hermetic: point HOME / USER_ZDOTDIR at an
+			// empty dir so it does not source the developer's real rc files
+			// (p10k, nvm, input-blocking prompts) which would make this flaky.
+			hermetic := t.TempDir()
+			base := cmd.Env
+			if base == nil {
+				base = os.Environ()
+			}
+			cmd.Env = append(base, "HOME="+hermetic, "USER_ZDOTDIR="+hermetic)
+
 			ptmx, err := pty.Start(cmd)
 			if err != nil {
 				t.Fatalf("pty.Start(%s) error: %v", shell, err)

--- a/internal/terminal/shell_integration_test.go
+++ b/internal/terminal/shell_integration_test.go
@@ -1,10 +1,15 @@
 package terminal
 
 import (
+	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/creack/pty"
 )
 
 func TestShellKind(t *testing.T) {
@@ -163,5 +168,68 @@ func TestIntegratedCommandFailsOpen(t *testing.T) {
 	}
 	if cmd.Env != nil {
 		t.Fatalf("fail-open should return plain command with nil Env, got %v", cmd.Env)
+	}
+}
+
+// TestIntegratedShellEmitsOSC133 spawns the integrated shell in a real PTY and
+// asserts the embedded scripts emit the OSC 133 "command finished" marker with a
+// non-zero exit code. PTY-gated (skipped on headless CI) and shell-gated via
+// LookPath. Reads until the marker appears or a timeout fires — no fixed sleeps.
+func TestIntegratedShellEmitsOSC133(t *testing.T) {
+	requirePTY(t)
+
+	for _, shell := range []string{"bash", "zsh"} {
+		t.Run(shell, func(t *testing.T) {
+			path, err := exec.LookPath(shell)
+			if err != nil {
+				t.Skipf("%s not installed", shell)
+			}
+
+			cmd := integratedCommand(path, t.TempDir())
+			ptmx, err := pty.Start(cmd)
+			if err != nil {
+				t.Fatalf("pty.Start(%s) error: %v", shell, err)
+			}
+			defer func() {
+				_ = ptmx.Close()
+				_ = cmd.Process.Kill()
+				_ = cmd.Wait()
+			}()
+
+			// `false` exits 1; precmd emits "\e]133;D;1\a" on the next prompt.
+			if _, err := ptmx.Write([]byte("false\nexit\n")); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+
+			want := []byte("\033]133;D;1\007")
+			result := make(chan bool, 1)
+			go func() {
+				var seen []byte
+				buf := make([]byte, 4096)
+				for {
+					n, err := ptmx.Read(buf)
+					if n > 0 {
+						seen = append(seen, buf[:n]...)
+						if bytes.Contains(seen, want) {
+							result <- true
+							return
+						}
+					}
+					if err != nil {
+						result <- false
+						return
+					}
+				}
+			}()
+
+			select {
+			case ok := <-result:
+				if !ok {
+					t.Fatalf("%s: shell exited before emitting OSC 133 D;1 marker", shell)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatalf("%s: timed out waiting for OSC 133 D;1 marker", shell)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #47. Last open item in Milestone 2.

## Summary

JetBrains/VS Code-style shell integration for the xterm terminal, driven by OSC 133 semantic-prompt sequences.

- Backend injects integration via embedded, versioned zsh/bash wrapper scripts (zsh `ZDOTDIR`, bash `--rcfile`) that chain the user's real rc, then install `precmd`/`preexec` hooks emitting `133;A|C|D;<exit>`. zsh hooks are prepended (capture `$?` before prompt tooling like p10k/starship); bash is DEBUG-trap-safe and preserves exit status via `return $status`.
- Injection is fail-open: any setup failure (cache dir, wrapper write, unsupported shell) launches a plain shell. Terminal creation only fails on real PTY errors. zsh + bash only; other shells run plain.
- Wrapper scripts are written atomically (temp + rename) so concurrent terminal creation can never expose a partially written rc to a shell sourcing it. Dirs 0700, scripts 0600.
- Frontend registers an OSC 133 handler and runs a marker/decoration state machine: red gutter marker on non-zero exit, neutral on success, faint separators between command blocks. Includes executed-gate (no marker for empty prompts), decorate-once, stale-marker cleanup, and pruning of command blocks as xterm disposes markers scrolling out of scrollback. Fails open to a no-op when the terminal exposes no OSC parser (headless/jsdom).

## Known ceilings
- Targets interactive non-login shells (login `.bash_profile`/`.zprofile` not covered).
- bash bails to plain config if a pre-existing DEBUG trap is present.
- Separator width fixed at draw-time column count (no re-flow on resize).

## Test Plan
- [x] Go: pure-logic unit tests (shell detection, `ensureWrapperFiles` perms/idempotency/drift/concurrency, `integratedCommand` selection + fail-open) — `go test ./...` 477 pass, `-race` clean, `go vet` clean
- [x] Go: PTY-gated emission test spawns integrated bash + zsh in a real PTY and asserts `133;D;1` on a failed command (hermetic HOME/ZDOTDIR; skipped on headless CI)
- [x] Frontend: 11 jest cases over the OSC 133 state machine (exit color, first-D ignore, executed-gate, decorate-once, separator placement, marker pruning, parser fail-open, dispose) — full suite 1021 pass, eslint clean
- [x] Manual: open a terminal, run `false` (red gutter) then `ls` (neutral), confirm separators between blocks and no `]133` text leakage; verify user prompt/aliases intact