### PR TITLE
LSP Phase 2: managed language-server provisioning + interpreter wiring (#112)

### DIFF
--- a/app.go
+++ b/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"firn/internal/filesystem"
 	"firn/internal/lsp"
+	"firn/internal/lsp/provision"
 	"firn/internal/runprofile"
 	"firn/internal/search"
 	"firn/internal/terminal"
@@ -11,7 +12,9 @@ import (
 	"firn/internal/workspace"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	stdruntime "runtime"
 	"sync"
 	"time"
 
@@ -87,6 +90,33 @@ func (a *App) startup(ctx context.Context) {
 	a.lspManager = lsp.NewManager(func(event string, data ...any) {
 		runtime.EventsEmit(a.ctx, event, data...)
 	})
+	a.wireLSPProvisioners()
+}
+
+// wireLSPProvisioners builds and registers the managed-server provisioners on
+// the LSP manager. Currently only the Python (basedpyright) provisioner is
+// managed. When the home directory is unavailable the provisioner is skipped
+// gracefully — managed installs simply won't be offered, while interpreter/env
+// wiring still works.
+func (a *App) wireLSPProvisioners() {
+	if a.lspManager == nil {
+		return
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return
+	}
+	cacheRoot := filepath.Join(home, ".firn", "servers")
+	pyProv := provision.NewPythonProvisioner(cacheRoot, stdruntime.GOOS, stdruntime.GOARCH, provision.PythonDeps{
+		LookPath: exec.LookPath,
+		RunUV: func(ctx context.Context, uv string, args, env []string) error {
+			cmd := exec.CommandContext(ctx, uv, args...)
+			cmd.Env = env
+			return cmd.Run()
+		},
+		// Fetch nil -> defaultFetch (real download+verify+unzip).
+	})
+	a.lspManager.SetProvisioners(map[string]provision.Provisioner{"python": pyProv})
 }
 
 // beforeClose is called by Wails before the application window closes.
@@ -732,6 +762,74 @@ func (a *App) SetLSPWorkspaceRoot(workspacePath string) {
 	}
 	a.lspManager.ShutdownAll(lspWorkspaceSwitchTimeout)
 	a.lspManager.SetWorkspaceRoot(workspacePath)
+
+	// Seed any persisted interpreter override so it applies before the first
+	// file opens. Best-effort: a load error or absent state just means no
+	// override to seed.
+	if st, err := a.workspaceStore.Load(workspacePath); err == nil && st != nil && st.LSP.InterpreterOverride != "" {
+		a.lspManager.SeedInterpreterOverride(workspacePath, st.LSP.InterpreterOverride)
+	}
+}
+
+// --- LSP Phase 2 bindings (managed provisioning + interpreter override) ---
+
+// LSPDoctor returns interpreter candidates + current override for a workspace.
+// This is exposed to the frontend via Wails bindings.
+func (a *App) LSPDoctor(workspacePath string) (lsp.DoctorReport, error) {
+	if a.lspManager == nil {
+		return lsp.DoctorReport{}, fmt.Errorf("LSP not initialized")
+	}
+	return a.lspManager.Doctor(workspacePath), nil
+}
+
+// LSPSetInterpreter validates + persists a manual interpreter override for the
+// workspace and re-wires/restarts the affected server.
+// This is exposed to the frontend via Wails bindings.
+func (a *App) LSPSetInterpreter(workspacePath, interpreterPath string) error {
+	if a.lspManager == nil {
+		return fmt.Errorf("LSP not initialized")
+	}
+	// Validate + apply in the manager first (it stat-checks the path and restarts).
+	if err := a.lspManager.SetInterpreterOverride(workspacePath, interpreterPath); err != nil {
+		return err
+	}
+	// Persist only after a successful apply.
+	return a.persistLSPInterpreter(workspacePath, interpreterPath)
+}
+
+// LSPClearInterpreter removes the override and re-detects.
+// This is exposed to the frontend via Wails bindings.
+func (a *App) LSPClearInterpreter(workspacePath string) error {
+	if a.lspManager == nil {
+		return fmt.Errorf("LSP not initialized")
+	}
+	if err := a.lspManager.ClearInterpreterOverride(workspacePath); err != nil {
+		return err
+	}
+	return a.persistLSPInterpreter(workspacePath, "") // empty clears it
+}
+
+// LSPRetryProvision re-attempts a managed server install for a family.
+// This is exposed to the frontend via Wails bindings.
+func (a *App) LSPRetryProvision(family string) error {
+	if a.lspManager == nil {
+		return fmt.Errorf("LSP not initialized")
+	}
+	return a.lspManager.RetryProvision(family)
+}
+
+// persistLSPInterpreter writes the interpreter override into the workspace's
+// persisted state (~/.firn/workspaces). interpreterPath=="" clears it.
+func (a *App) persistLSPInterpreter(workspacePath, interpreterPath string) error {
+	st, err := a.workspaceStore.Load(workspacePath)
+	if err != nil {
+		return err
+	}
+	if st == nil {
+		st = &workspace.State{WorkspacePath: workspacePath}
+	}
+	st.LSP.InterpreterOverride = interpreterPath
+	return a.workspaceStore.Save(*st)
 }
 
 // --- Search bindings ---

--- a/frontend/src/__tests__/components/Editor/CodeMirrorEditor.test.tsx
+++ b/frontend/src/__tests__/components/Editor/CodeMirrorEditor.test.tsx
@@ -105,6 +105,13 @@ jest.mock('../../../components/Editor/codemirror', () => {
   };
 });
 
+jest.mock('../../../../wailsjs/go/main/App', () => ({
+  LSPRetryProvision: jest.fn().mockResolvedValue(undefined),
+  LSPSetInterpreter: jest.fn().mockResolvedValue(undefined),
+  LSPClearInterpreter: jest.fn().mockResolvedValue(undefined),
+  LSPDoctor: jest.fn().mockResolvedValue({ family: 'python', candidates: [] }),
+}));
+
 import { CodeMirrorEditor } from '../../../components/Editor/CodeMirrorEditor';
 import { applyEditorTheme } from '../../../components/Editor/codemirror';
 import { useIDEStore } from '../../../stores/ideStore';

--- a/frontend/src/__tests__/components/Editor/LSPSetupCard.test.tsx
+++ b/frontend/src/__tests__/components/Editor/LSPSetupCard.test.tsx
@@ -1,11 +1,29 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { LSPSetupCard } from '../../../components/Editor/LSPSetupCard';
 import { describeSetup } from '../../../components/Editor/lspSetupNotice';
 import type { LSPServerStatus } from '../../../stores/lspStore';
 
+const mockRetry = jest.fn().mockResolvedValue(undefined);
+const mockSetInterpreter = jest.fn().mockResolvedValue(undefined);
+const mockClearInterpreter = jest.fn().mockResolvedValue(undefined);
+const mockDoctor = jest.fn().mockResolvedValue({ family: 'python', candidates: ['/cand'] });
+
+jest.mock('../../../../wailsjs/go/main/App', () => ({
+  LSPRetryProvision: (...args: unknown[]) => mockRetry(...args),
+  LSPSetInterpreter: (...args: unknown[]) => mockSetInterpreter(...args),
+  LSPClearInterpreter: (...args: unknown[]) => mockClearInterpreter(...args),
+  LSPDoctor: (...args: unknown[]) => mockDoctor(...args),
+}));
+
 function status(overrides: Partial<LSPServerStatus>): LSPServerStatus {
   return { family: 'python', workspace: '/proj', state: 'ready', ...overrides };
 }
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDoctor.mockResolvedValue({ family: 'python', candidates: ['/cand'] });
+});
 
 describe('describeSetup', () => {
   it('returns null when ready', () => {
@@ -27,17 +45,84 @@ describe('describeSetup', () => {
     const notice = describeSetup(status({ setupState: 'missing_server' }));
     expect(notice!.tone).toBe('error');
   });
+
+  it('shows a 0% download hint when provisionPct is zero', () => {
+    const notice = describeSetup(status({ setupState: 'provisioning', provisionPct: 0 }));
+    expect(notice!.hint).toContain('(0%)');
+  });
+
+  it('uses ASCII ellipsis in the provisioning message', () => {
+    const notice = describeSetup(status({ setupState: 'provisioning' }));
+    expect(notice!.message).toContain('...');
+    expect(notice!.message).not.toContain('…');
+  });
 });
 
 describe('LSPSetupCard', () => {
   it('renders nothing when ready', () => {
-    const { container } = render(<LSPSetupCard status={status({ setupState: 'ready' })} />);
+    const { container } = render(
+      <LSPSetupCard status={status({ setupState: 'ready' })} workspacePath="/proj" />
+    );
     expect(container).toBeEmptyDOMElement();
   });
 
   it('renders the message and hint for missing_interpreter', () => {
-    render(<LSPSetupCard status={status({ setupState: 'missing_interpreter' })} />);
+    render(
+      <LSPSetupCard status={status({ setupState: 'missing_interpreter' })} workspacePath="/proj" />
+    );
     expect(screen.getByRole('status')).toBeInTheDocument();
     expect(screen.getByText(/no python interpreter/i)).toBeInTheDocument();
+  });
+
+  it('offline status renders Retry wired to LSPRetryProvision', async () => {
+    const user = userEvent.setup();
+    render(
+      <LSPSetupCard
+        status={status({ setupState: 'offline', action: 'retry' })}
+        workspacePath="/proj"
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+    expect(mockRetry).toHaveBeenCalledWith('python');
+  });
+
+  it('provisioning shows progress and no Retry button', () => {
+    render(
+      <LSPSetupCard
+        status={status({ setupState: 'provisioning', provisionPct: 25 })}
+        workspacePath="/proj"
+      />
+    );
+    expect(screen.getByText(/25%/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /retry/i })).toBeNull();
+  });
+
+  it('select_interpreter populates candidates from LSPDoctor and sets on choose', async () => {
+    const user = userEvent.setup();
+    render(
+      <LSPSetupCard
+        status={status({ setupState: 'missing_interpreter', action: 'select_interpreter' })}
+        workspacePath="/proj"
+      />
+    );
+    const option = await screen.findByRole('option', { name: '/cand' });
+    expect(option).toBeInTheDocument();
+    await user.selectOptions(
+      screen.getByRole('combobox', { name: /select interpreter/i }),
+      '/cand'
+    );
+    expect(mockSetInterpreter).toHaveBeenCalledWith('/proj', '/cand');
+  });
+
+  it('renders Reset to auto when an interpreter override is active', async () => {
+    const user = userEvent.setup();
+    render(
+      <LSPSetupCard
+        status={status({ setupState: 'config_degraded', configSource: 'override' })}
+        workspacePath="/proj"
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /reset to auto/i }));
+    expect(mockClearInterpreter).toHaveBeenCalledWith('/proj');
   });
 });

--- a/frontend/src/__tests__/components/Editor/lspSetupNotice.test.ts
+++ b/frontend/src/__tests__/components/Editor/lspSetupNotice.test.ts
@@ -1,0 +1,29 @@
+import { describeSetup } from '../../../components/Editor/lspSetupNotice';
+import type { LSPServerStatus } from '../../../stores/lspStore';
+
+function status(overrides: Partial<LSPServerStatus>): LSPServerStatus {
+  return { family: 'python', workspace: '/proj', state: 'ready', ...overrides };
+}
+
+describe('describeSetup phase 2 states', () => {
+  it('provisioning -> info tone with percent', () => {
+    const n = describeSetup(status({ setupState: 'provisioning', provisionPct: 40 }));
+    expect(n?.tone).toBe('info');
+    expect(n?.message.toLowerCase()).toContain('setting up');
+    expect(n?.hint).toContain('40%');
+  });
+  it('provisioning without percent -> generic downloading hint', () => {
+    const n = describeSetup(status({ setupState: 'provisioning' }));
+    expect(n?.tone).toBe('info');
+    expect(n?.hint.toLowerCase()).toContain('downloading');
+  });
+  it('offline -> error tone with retry hint', () => {
+    const n = describeSetup(status({ setupState: 'offline', action: 'retry' }));
+    expect(n?.tone).toBe('error');
+    expect(n?.hint.toLowerCase()).toContain('retry');
+  });
+  it('provision_failed -> error tone', () => {
+    const n = describeSetup(status({ setupState: 'provision_failed', action: 'retry' }));
+    expect(n?.tone).toBe('error');
+  });
+});

--- a/frontend/src/__tests__/stores/lspStore.test.ts
+++ b/frontend/src/__tests__/stores/lspStore.test.ts
@@ -293,6 +293,43 @@ describe('lspStore', () => {
       clearAllStatuses();
       expect(useLSPStore.getState().serverStatuses.size).toBe(0);
     });
+
+    it('stores a provisioning status with provisionPct', () => {
+      useLSPStore.getState().setServerStatus({
+        family: 'python',
+        workspace: '/project',
+        state: 'starting',
+        setupState: 'provisioning',
+        provisionPct: 60,
+      });
+
+      const status = useLSPStore.getState().serverStatuses.get('/project::python');
+      expect(status?.setupState).toBe('provisioning');
+      expect(status?.provisionPct).toBe(60);
+    });
+
+    it('stores offline + provision_failed setup states', () => {
+      const { setServerStatus } = useLSPStore.getState();
+      setServerStatus({
+        family: 'python',
+        workspace: '/offline',
+        state: 'error',
+        setupState: 'offline',
+        action: 'retry',
+      });
+      setServerStatus({
+        family: 'python',
+        workspace: '/failed',
+        state: 'error',
+        setupState: 'provision_failed',
+        action: 'retry',
+      });
+
+      const statuses = useLSPStore.getState().serverStatuses;
+      expect(statuses.get('/offline::python')?.setupState).toBe('offline');
+      expect(statuses.get('/offline::python')?.action).toBe('retry');
+      expect(statuses.get('/failed::python')?.setupState).toBe('provision_failed');
+    });
   });
 
   describe('workspace cleanup', () => {

--- a/frontend/src/components/Editor/CodeMirrorEditor.tsx
+++ b/frontend/src/components/Editor/CodeMirrorEditor.tsx
@@ -350,7 +350,7 @@ export const CodeMirrorEditor = memo(function CodeMirrorEditor({
 
   return (
     <div className={styles.editorRoot}>
-      <LSPSetupCard status={setupStatus} />
+      <LSPSetupCard status={setupStatus} workspacePath={setupStatus?.workspace ?? ''} />
       <div ref={containerRef} className={styles.container} data-testid="codemirror-editor" />
     </div>
   );

--- a/frontend/src/components/Editor/LSPSetupCard.module.css
+++ b/frontend/src/components/Editor/LSPSetupCard.module.css
@@ -17,6 +17,17 @@
   border-left: 3px solid var(--status-warning);
 }
 
+.info {
+  border-left: 3px solid var(--accent-blue);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+}
+
 .message {
   color: var(--text-primary, #e6e6e6);
   font-weight: 500;

--- a/frontend/src/components/Editor/LSPSetupCard.tsx
+++ b/frontend/src/components/Editor/LSPSetupCard.tsx
@@ -1,14 +1,82 @@
+import { useEffect, useState } from 'react';
 import type { LSPServerStatus } from '../../stores/lspStore';
 import { describeSetup } from './lspSetupNotice';
+import {
+  LSPRetryProvision,
+  LSPSetInterpreter,
+  LSPClearInterpreter,
+  LSPDoctor,
+} from '../../../wailsjs/go/main/App';
 import styles from './LSPSetupCard.module.css';
 
-export function LSPSetupCard({ status }: { status: LSPServerStatus | undefined }) {
+export function LSPSetupCard({
+  status,
+  workspacePath,
+}: {
+  status: LSPServerStatus | undefined;
+  workspacePath: string;
+}) {
   const notice = describeSetup(status);
+  const [candidates, setCandidates] = useState<string[]>([]);
+  const action = status?.action;
+  const wantsPicker = action === 'select_interpreter' || action === 'create_venv';
+
+  useEffect(() => {
+    let cancelled = false;
+    if (wantsPicker && workspacePath) {
+      LSPDoctor(workspacePath)
+        .then((r) => {
+          if (!cancelled) setCandidates(r?.candidates ?? []);
+        })
+        .catch(() => {
+          if (!cancelled) setCandidates([]);
+        });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [wantsPicker, workspacePath]);
+
   if (!notice) return null;
+
+  const showActions = action === 'retry' || wantsPicker || status?.configSource === 'override';
+
   return (
     <div role="status" aria-live="polite" className={`${styles.card} ${styles[notice.tone]}`}>
       <span className={styles.message}>{notice.message}</span>
       <span className={styles.hint}>{notice.hint}</span>
+      {showActions && (
+        <div className={styles.actions}>
+          {action === 'retry' && status && (
+            <button type="button" onClick={() => LSPRetryProvision(status.family)}>
+              Retry
+            </button>
+          )}
+          {wantsPicker && (
+            <select
+              aria-label="Select interpreter"
+              defaultValue=""
+              onChange={(e) => {
+                if (e.target.value) LSPSetInterpreter(workspacePath, e.target.value);
+              }}
+            >
+              <option value="" disabled>
+                Select interpreter...
+              </option>
+              {candidates.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+          )}
+          {status?.configSource === 'override' && (
+            <button type="button" onClick={() => LSPClearInterpreter(workspacePath)}>
+              Reset to auto
+            </button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/Editor/lspSetupNotice.ts
+++ b/frontend/src/components/Editor/lspSetupNotice.ts
@@ -9,8 +9,8 @@ export interface LSPSetupNotice {
 /**
  * Maps a server's typed setup status onto a user-facing message + next-step
  * hint. Returns null when there is nothing actionable to show (server ready,
- * or no setup state reported). Phase 1 surfaces guidance text only; the
- * interactive interpreter picker is a follow-up.
+ * or no setup state reported). The interactive affordances (interpreter
+ * picker, retry) live in LSPSetupCard.
  */
 export function describeSetup(status: LSPServerStatus | undefined): LSPSetupNotice | null {
   if (!status?.setupState || status.setupState === 'ready') return null;

--- a/frontend/src/components/Editor/lspSetupNotice.ts
+++ b/frontend/src/components/Editor/lspSetupNotice.ts
@@ -48,10 +48,11 @@ export function describeSetup(status: LSPServerStatus | undefined): LSPSetupNoti
       };
     case 'provisioning':
       return {
-        message: 'Setting up language server…',
-        hint: status.provisionPct
-          ? `Downloading (${status.provisionPct}%).`
-          : 'Downloading the language server.',
+        message: 'Setting up language server...',
+        hint:
+          status.provisionPct != null
+            ? `Downloading (${status.provisionPct}%).`
+            : 'Downloading the language server.',
         tone: 'info',
       };
     case 'offline':

--- a/frontend/src/components/Editor/lspSetupNotice.ts
+++ b/frontend/src/components/Editor/lspSetupNotice.ts
@@ -3,7 +3,7 @@ import type { LSPServerStatus } from '../../stores/lspStore';
 export interface LSPSetupNotice {
   message: string;
   hint: string;
-  tone: 'error' | 'warning';
+  tone: 'error' | 'warning' | 'info';
 }
 
 /**
@@ -44,6 +44,26 @@ export function describeSetup(status: LSPServerStatus | undefined): LSPSetupNoti
       return {
         message: 'The language server failed to start.',
         hint: 'Reopen the file to retry.',
+        tone: 'error',
+      };
+    case 'provisioning':
+      return {
+        message: 'Setting up language server…',
+        hint: status.provisionPct
+          ? `Downloading (${status.provisionPct}%).`
+          : 'Downloading the language server.',
+        tone: 'info',
+      };
+    case 'offline':
+      return {
+        message: 'Could not download the language server (offline).',
+        hint: 'Check your connection, then Retry.',
+        tone: 'error',
+      };
+    case 'provision_failed':
+      return {
+        message: 'Language server setup failed.',
+        hint: 'Retry, or install basedpyright/pyright manually.',
         tone: 'error',
       };
     default:

--- a/frontend/src/stores/lspStore.ts
+++ b/frontend/src/stores/lspStore.ts
@@ -50,7 +50,10 @@ export type LSPSetupState =
   | 'missing_interpreter'
   | 'misconfigured_env'
   | 'config_degraded'
-  | 'retryable';
+  | 'retryable'
+  | 'provisioning'
+  | 'offline'
+  | 'provision_failed';
 
 export type LSPSetupAction = 'create_venv' | 'select_interpreter' | 'retry';
 
@@ -62,6 +65,7 @@ export interface LSPServerStatus {
   error?: string;
   completionTriggerCharacters?: string[];
   setupState?: LSPSetupState;
+  provisionPct?: number;
   interpreterPath?: string;
   projectRoot?: string;
   configSource?: string;

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -37,6 +37,8 @@ export function GetWorkspaceInfo():Promise<main.WorkspaceInfo>;
 
 export function IsWatching():Promise<boolean>;
 
+export function LSPClearInterpreter(arg1:string):Promise<void>;
+
 export function LSPComplete(arg1:string,arg2:number,arg3:number,arg4:string):Promise<lsp.CompletionList>;
 
 export function LSPDefinition(arg1:string,arg2:number,arg3:number):Promise<Array<lsp.Location>>;
@@ -49,9 +51,15 @@ export function LSPDidOpen(arg1:string,arg2:string,arg3:number,arg4:string):Prom
 
 export function LSPDidSave(arg1:string):Promise<void>;
 
+export function LSPDoctor(arg1:string):Promise<lsp.DoctorReport>;
+
 export function LSPHover(arg1:string,arg2:number,arg3:number):Promise<lsp.Hover>;
 
 export function LSPResolveCompletionItem(arg1:string,arg2:lsp.CompletionItem):Promise<lsp.CompletionItem>;
+
+export function LSPRetryProvision(arg1:string):Promise<void>;
+
+export function LSPSetInterpreter(arg1:string,arg2:string):Promise<void>;
 
 export function ListRecentWorkspaces():Promise<Array<workspace.Summary>>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -62,6 +62,10 @@ export function IsWatching() {
   return window['go']['main']['App']['IsWatching']();
 }
 
+export function LSPClearInterpreter(arg1) {
+  return window['go']['main']['App']['LSPClearInterpreter'](arg1);
+}
+
 export function LSPComplete(arg1, arg2, arg3, arg4) {
   return window['go']['main']['App']['LSPComplete'](arg1, arg2, arg3, arg4);
 }
@@ -86,12 +90,24 @@ export function LSPDidSave(arg1) {
   return window['go']['main']['App']['LSPDidSave'](arg1);
 }
 
+export function LSPDoctor(arg1) {
+  return window['go']['main']['App']['LSPDoctor'](arg1);
+}
+
 export function LSPHover(arg1, arg2, arg3) {
   return window['go']['main']['App']['LSPHover'](arg1, arg2, arg3);
 }
 
 export function LSPResolveCompletionItem(arg1, arg2) {
   return window['go']['main']['App']['LSPResolveCompletionItem'](arg1, arg2);
+}
+
+export function LSPRetryProvision(arg1) {
+  return window['go']['main']['App']['LSPRetryProvision'](arg1);
+}
+
+export function LSPSetInterpreter(arg1, arg2) {
+  return window['go']['main']['App']['LSPSetInterpreter'](arg1, arg2);
 }
 
 export function ListRecentWorkspaces() {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -243,6 +243,26 @@ export namespace lsp {
 		    return a;
 		}
 	}
+	export class DoctorReport {
+	    family: string;
+	    interpreterPath?: string;
+	    interpreterSource?: string;
+	    override?: string;
+	    candidates: string[];
+
+	    static createFrom(source: any = {}) {
+	        return new DoctorReport(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.family = source["family"];
+	        this.interpreterPath = source["interpreterPath"];
+	        this.interpreterSource = source["interpreterSource"];
+	        this.override = source["override"];
+	        this.candidates = source["candidates"];
+	    }
+	}
 	export class Hover {
 	    contents: number[];
 	    range?: Range;
@@ -324,6 +344,7 @@ export namespace lsp {
 	    pythonVersion?: string;
 	    action?: string;
 	    detailCode?: string;
+	    provisionPct?: number;
 
 	    static createFrom(source: any = {}) {
 	        return new ServerStatus(source);
@@ -345,6 +366,7 @@ export namespace lsp {
 	        this.pythonVersion = source["pythonVersion"];
 	        this.action = source["action"];
 	        this.detailCode = source["detailCode"];
+	        this.provisionPct = source["provisionPct"];
 	    }
 	}
 	export class TextDocumentContentChangeEvent {
@@ -876,6 +898,20 @@ export namespace workspace {
 		}
 	}
 
+	export class LSPState {
+	    interpreterOverride?: string;
+	    serverPathOverride?: Record<string, string>;
+
+	    static createFrom(source: any = {}) {
+	        return new LSPState(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.interpreterOverride = source["interpreterOverride"];
+	        this.serverPathOverride = source["serverPathOverride"];
+	    }
+	}
 	export class PanelSizes {
 	    left: number;
 	    right: number;
@@ -939,6 +975,7 @@ export namespace workspace {
 	    activeSidebar: string;
 	    hiddenProfileIds?: string[];
 	    activeWorkspaceId?: string;
+	    lsp?: LSPState;
 
 	    static createFrom(source: any = {}) {
 	        return new State(source);
@@ -955,6 +992,7 @@ export namespace workspace {
 	        this.activeSidebar = source["activeSidebar"];
 	        this.hiddenProfileIds = source["hiddenProfileIds"];
 	        this.activeWorkspaceId = source["activeWorkspaceId"];
+	        this.lsp = this.convertValues(source["lsp"], LSPState);
 	    }
 
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/lsp/config_provider.go
+++ b/internal/lsp/config_provider.go
@@ -1,8 +1,11 @@
 package lsp
 
 import (
+	"context"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"firn/internal/lsp/pythonenv"
 )
@@ -21,17 +24,59 @@ type WorkspaceConfigProvider interface {
 type envConfigProvider struct {
 	detectPython func(projectRoot string, deps pythonenv.Deps) pythonenv.Env
 	pythonDeps   pythonenv.Deps
+	overrideFor  func(projectRoot string) string                                      // per-workspace manual interpreter; "" if none
+	discover     func(ctx context.Context, projectRoot string) (string, string, bool) // uv/poetry overlay
 }
 
 func newEnvConfigProvider() *envConfigProvider {
 	return &envConfigProvider{
 		detectPython: pythonenv.Detect,
 		pythonDeps:   pythonenv.OSDeps(),
+		overrideFor:  func(string) string { return "" },
+		discover: func(ctx context.Context, root string) (string, string, bool) {
+			return pythonenv.DiscoverInterpreter(ctx, root, osRunner)
+		},
 	}
 }
 
+// SetInterpreterOverrideFunc lets the manager supply the per-workspace override
+// lookup (reads workspace.State.LSP.InterpreterOverride). Manual override is the
+// highest-precedence interpreter source.
+func (p *envConfigProvider) SetInterpreterOverrideFunc(fn func(projectRoot string) string) {
+	if fn != nil {
+		p.overrideFor = fn
+	}
+}
+
+// osRunner runs a command and returns trimmed stdout. Used by the default discover.
+func osRunner(ctx context.Context, name string, args ...string) (string, error) {
+	out, err := exec.CommandContext(ctx, name, args...).Output()
+	return strings.TrimSpace(string(out)), err
+}
+
+// PythonEnv resolves the workspace interpreter with three precedence layers:
+// (1) a manual per-workspace override always wins; (2) pure Detect; (3) when
+// Detect is low-confidence, a uv/poetry discovery overlay (gated on markers by
+// DiscoverInterpreter, so marker-free workspaces never shell out).
 func (p *envConfigProvider) PythonEnv(projectRoot string) pythonenv.Env {
-	return p.detectPython(projectRoot, p.pythonDeps)
+	if p.overrideFor != nil {
+		if ov := p.overrideFor(projectRoot); ov != "" {
+			return pythonenv.Env{InterpreterPath: ov, Source: "override", Confidence: "high"}
+		}
+	}
+	env := p.detectPython(projectRoot, p.pythonDeps)
+	if env.InterpreterPath == "" || env.Confidence == "low" || env.Source == "system" || env.Source == "none" {
+		if p.discover != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if interp, source, ok := p.discover(ctx, projectRoot); ok {
+				env.InterpreterPath = interp
+				env.Source = source
+				env.Confidence = "high"
+			}
+		}
+	}
+	return env
 }
 
 // pythonEnvReader is satisfied by envConfigProvider and any other provider that

--- a/internal/lsp/config_provider_test.go
+++ b/internal/lsp/config_provider_test.go
@@ -1,6 +1,8 @@
 package lsp
 
 import (
+	"context"
+	"path/filepath"
 	"testing"
 
 	"firn/internal/lsp/pythonenv"
@@ -109,6 +111,52 @@ func TestEnvConfigProvider_EmptyPythonEnvReturnsNil(t *testing.T) {
 	}
 	if results[0] != nil || results[1] != nil {
 		t.Fatalf("results = %v, want [nil nil] for empty env", results)
+	}
+}
+
+func TestPythonEnv_overrideWins(t *testing.T) {
+	p := newEnvConfigProvider()
+	p.overrideFor = func(string) string { return "/manual/python" }
+	// detectPython/discover must NOT override the manual choice; stub them to prove it.
+	p.detectPython = func(string, pythonenv.Deps) pythonenv.Env {
+		return pythonenv.Env{InterpreterPath: "/auto", Source: "system"}
+	}
+	p.discover = func(context.Context, string) (string, string, bool) { return "/discovered", "uv", true }
+	env := p.PythonEnv("/whatever")
+	if env.InterpreterPath != "/manual/python" || env.Source != "override" {
+		t.Fatalf("env = %+v, want override interpreter", env)
+	}
+}
+
+func TestPythonEnv_discoveryUpgradesLowConfidence(t *testing.T) {
+	root := t.TempDir()
+	interp := filepath.Join(root, ".venv", "bin", "python")
+	p := newEnvConfigProvider()
+	p.overrideFor = func(string) string { return "" }
+	p.detectPython = func(string, pythonenv.Deps) pythonenv.Env {
+		return pythonenv.Env{Source: "system", Confidence: "low", InterpreterPath: "/usr/bin/python3"}
+	}
+	p.discover = func(_ context.Context, r string) (string, string, bool) { return interp, "uv", true }
+	env := p.PythonEnv(root)
+	if env.InterpreterPath != interp || env.Source != "uv" || env.Confidence != "high" {
+		t.Fatalf("env = %+v, want uv-discovered high-confidence", env)
+	}
+}
+
+func TestPythonEnv_highConfidenceSkipsDiscovery(t *testing.T) {
+	called := false
+	p := newEnvConfigProvider()
+	p.overrideFor = func(string) string { return "" }
+	p.detectPython = func(string, pythonenv.Deps) pythonenv.Env {
+		return pythonenv.Env{Source: ".venv", Confidence: "high", InterpreterPath: "/proj/.venv/bin/python"}
+	}
+	p.discover = func(context.Context, string) (string, string, bool) { called = true; return "", "", false }
+	env := p.PythonEnv("/proj")
+	if called {
+		t.Error("discovery must not run when Detect is high-confidence")
+	}
+	if env.InterpreterPath != "/proj/.venv/bin/python" {
+		t.Errorf("env = %+v", env)
 	}
 }
 

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"firn/internal/lsp/provision"
 )
 
 // errNoWorkspaceRoot signals that an LSP method was called before
@@ -36,7 +38,7 @@ type ServerStatus struct {
 	State                       string   `json:"state"` // "starting", "ready", "stopping", "stopped", "error"
 	Error                       string   `json:"error,omitempty"`
 	CompletionTriggerCharacters []string `json:"completionTriggerCharacters,omitempty"`
-	SetupState                  string   `json:"setupState,omitempty"` // ready|missing_server|missing_interpreter|misconfigured_env|config_degraded|retryable
+	SetupState                  string   `json:"setupState,omitempty"` // ready|missing_server|missing_interpreter|misconfigured_env|config_degraded|retryable|provisioning|offline|provision_failed
 	InterpreterPath             string   `json:"interpreterPath,omitempty"`
 	ProjectRoot                 string   `json:"projectRoot,omitempty"`
 	ConfigSource                string   `json:"configSource,omitempty"`
@@ -44,6 +46,7 @@ type ServerStatus struct {
 	PythonVersion               string   `json:"pythonVersion,omitempty"`
 	Action                      string   `json:"action,omitempty"` // create_venv|select_interpreter|retry|""
 	DetailCode                  string   `json:"detailCode,omitempty"`
+	ProvisionPct                int      `json:"provisionPct,omitempty"` // 0-100 during managed install
 }
 
 // EventEmitter is the callback signature for emitting events to the frontend.
@@ -76,6 +79,22 @@ type Manager struct {
 	// stopped is set by ShutdownAll to prevent crash-recovery restarts
 	// from resurrecting servers after intentional teardown.
 	stopped bool
+
+	// provisioners maps a language family to its managed provisioner. Populated
+	// by SetProvisioners and shared with the registry so a resolver miss can be
+	// classified as provisionable.
+	provisioners map[string]provision.Provisioner
+
+	// provisionMu guards provisioning. It is intentionally separate from mu so
+	// an in-flight install never blocks document routing on the hot path.
+	provisionMu sync.Mutex
+	// provisioning tracks families with an install in flight (single-flight).
+	provisioning map[string]bool
+
+	// ctx is the manager's lifetime context, cancelled by ShutdownAll so
+	// background installs stop when the workspace is torn down.
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 // serverKey identifies a unique server instance by language family and workspace.
@@ -102,13 +121,24 @@ type serverEntry struct {
 
 // NewManager creates a new LSP manager with the given event emitter.
 func NewManager(emitter EventEmitter) *Manager {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &Manager{
 		registry:       NewRegistry(),
 		emitter:        emitter,
 		configProvider: newEnvConfigProvider(),
 		servers:        make(map[serverKey]*serverEntry),
 		docKeys:        make(map[string]serverKey),
+		provisioning:   make(map[string]bool),
+		ctx:            ctx,
+		cancel:         cancel,
 	}
+}
+
+// SetProvisioners injects managed provisioners and forwards them to the registry
+// so a resolver miss can be classified as provisionable.
+func (m *Manager) SetProvisioners(p map[string]provision.Provisioner) {
+	m.provisioners = p
+	m.registry.SetProvisioners(p)
 }
 
 // SetWorkspaceRoot updates the active workspace root path.
@@ -129,6 +159,13 @@ func (m *Manager) SetWorkspaceRoot(root string) {
 	defer m.mu.Unlock()
 	m.workspaceRoot = cleaned
 	m.stopped = false
+	// Refresh the lifetime context: a workspace switch cancels installs scoped
+	// to the previous root and gives the new root a live context to provision
+	// under (also revives the manager after a ShutdownAll teardown).
+	if m.cancel != nil {
+		m.cancel()
+	}
+	m.ctx, m.cancel = context.WithCancel(context.Background())
 }
 
 // WorkspaceRoot returns the current workspace root path.
@@ -170,6 +207,12 @@ func (m *Manager) DidOpen(ctx context.Context, path, languageID string, version 
 	entry, err := m.ensureServer(ctx, family, workspace)
 	if err != nil {
 		return err
+	}
+	if entry == nil {
+		// A managed install is in flight (provisionable miss). DidOpen is
+		// non-blocking: the document re-opens via restartFamily once the cache
+		// is populated. The frontend re-sends content on the ready status.
+		return nil
 	}
 
 	m.mu.Lock()
@@ -393,11 +436,17 @@ func (m *Manager) GetStatus() []ServerStatus {
 func (m *Manager) ShutdownAll(timeout time.Duration) {
 	m.mu.Lock()
 	m.stopped = true
+	cancel := m.cancel
 	keys := make([]serverKey, 0, len(m.servers))
 	for key := range m.servers {
 		keys = append(keys, key)
 	}
 	m.mu.Unlock()
+
+	// Cancel the lifetime context so any in-flight managed install stops.
+	if cancel != nil {
+		cancel()
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -429,11 +478,120 @@ func (m *Manager) ensureServer(ctx context.Context, family, workspace string) (*
 	// Resolve server config
 	config, err := m.registry.ServerConfigFor(family, workspace)
 	if err != nil {
+		// A managed provisioner can serve this family: kick off an async install
+		// rather than hard-failing the file open. The server starts once the
+		// cache is populated (see restartFamily).
+		var miss *ServerMissError
+		if errors.As(err, &miss) && miss.Provisionable && m.provisioners[family] != nil {
+			m.beginProvision(family, workspace)
+			return nil, nil
+		}
 		m.emitStatus(family, workspace, "error", err.Error(), defaultServerCommand(family))
 		return nil, err
 	}
 
 	return m.startServer(ctx, key, config)
+}
+
+// provisionCtx returns the manager's lifetime context, falling back to a
+// background context when the manager was built via a struct literal (some
+// tests) rather than NewManager. The install goroutine derives cancellation
+// from this so workspace teardown (ShutdownAll) stops in-flight installs.
+func (m *Manager) provisionCtx() context.Context {
+	if m.ctx != nil {
+		return m.ctx
+	}
+	return context.Background()
+}
+
+// beginProvision installs a family's managed server in the background, emitting
+// status transitions. Single-flight per family: a second open of the same
+// family while an install is in flight is a no-op.
+func (m *Manager) beginProvision(family, projectRoot string) {
+	prov := m.provisioners[family]
+	if prov == nil {
+		return
+	}
+
+	m.provisionMu.Lock()
+	if m.provisioning == nil {
+		m.provisioning = map[string]bool{}
+	}
+	if m.provisioning[family] {
+		m.provisionMu.Unlock()
+		return
+	}
+	m.provisioning[family] = true
+	m.provisionMu.Unlock()
+
+	m.emitProvisionStatus(family, projectRoot, "provisioning", "", "", 0)
+
+	go func() {
+		res := prov.Install(m.provisionCtx(), func(p provision.Progress) {
+			m.emitProvisionStatus(family, projectRoot, "provisioning", "", "", p.Pct)
+		})
+
+		m.provisionMu.Lock()
+		m.provisioning[family] = false
+		m.provisionMu.Unlock()
+
+		switch res.State {
+		case provision.StateAvailable:
+			// Cache is populated — re-run the normal start path.
+			m.restartFamily(family, projectRoot)
+		case provision.StateOffline:
+			m.emitProvisionStatus(family, projectRoot, "offline", "retry", "download_offline", 0)
+		case provision.StateChecksumFailed:
+			m.emitProvisionStatus(family, projectRoot, "provision_failed", "retry", "checksum_mismatch", 0)
+		default:
+			m.emitProvisionStatus(family, projectRoot, "provision_failed", "retry", "provision_error", 0)
+		}
+	}()
+}
+
+// RetryProvision re-attempts a managed install (frontend Retry action). It uses
+// the manager's current workspace root as the project root.
+func (m *Manager) RetryProvision(family string) error {
+	if _, ok := m.provisioners[family]; !ok {
+		return fmt.Errorf("no managed provisioner for %q", family)
+	}
+	m.beginProvision(family, m.WorkspaceRoot())
+	return nil
+}
+
+// restartFamily re-runs the normal start path for a family after a successful
+// provision. It reuses ensureServer so the server is launched and a ready
+// status emitted exactly as a first open would. Errors are logged; the start
+// path already emits an error status on failure.
+func (m *Manager) restartFamily(family, projectRoot string) {
+	if _, err := m.ensureServer(m.provisionCtx(), family, projectRoot); err != nil {
+		log.Printf("lsp: post-provision start failed family=%s root=%q: %v", family, projectRoot, err)
+	}
+}
+
+// emitProvisionStatus emits an lsp:status event describing a managed-install
+// transition. It mirrors emitStatus's contract (called without m.mu held) but
+// carries the typed setup fields the provisioning cards need. The LSP State is
+// "starting" while provisioning and "error" once an install fails so existing
+// frontend state machines treat it sensibly.
+func (m *Manager) emitProvisionStatus(family, projectRoot, setupState, action, detailCode string, pct int) {
+	if m.emitter == nil {
+		return
+	}
+	state := "starting"
+	if setupState == "offline" || setupState == "provision_failed" {
+		state = "error"
+	}
+	m.emitter("lsp:status", ServerStatus{
+		Family:       family,
+		Workspace:    projectRoot,
+		State:        state,
+		ProjectRoot:  projectRoot,
+		SetupState:   setupState,
+		Action:       action,
+		DetailCode:   detailCode,
+		ProvisionPct: pct,
+	})
 }
 
 // startServer launches a new language server process and initializes it.

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -95,6 +95,11 @@ type Manager struct {
 	// provisioning tracks families with an install in flight (single-flight).
 	provisioning map[string]bool
 
+	// pendingProvisionDocs tracks documents opened while a managed server is
+	// installing. Once the server starts, these URIs are sent via lsp:reconnect
+	// so the frontend replays didOpen with current buffer content.
+	pendingProvisionDocs map[serverKey]map[string]bool
+
 	// ctx is the manager's lifetime context, cancelled by ShutdownAll so
 	// background installs stop when the workspace is torn down.
 	ctx    context.Context
@@ -139,6 +144,7 @@ func NewManager(emitter EventEmitter) *Manager {
 		servers:              make(map[serverKey]*serverEntry),
 		docKeys:              make(map[string]serverKey),
 		provisioning:         make(map[string]bool),
+		pendingProvisionDocs: make(map[serverKey]map[string]bool),
 		ctx:                  ctx,
 		cancel:               cancel,
 		interpreterOverrides: make(map[string]string),
@@ -222,16 +228,23 @@ func (m *Manager) DidOpen(ctx context.Context, path, languageID string, version 
 		return nil
 	}
 
+	key := serverKey{family: family, workspace: workspace}
+	if !m.serverRunning(key) {
+		m.trackPendingProvisionDoc(key, uri)
+	}
+
 	entry, err := m.ensureServer(ctx, family, workspace)
 	if err != nil {
+		m.untrackPendingProvisionDoc(uri)
 		return err
 	}
 	if entry == nil {
 		// A managed install is in flight (provisionable miss). DidOpen is
-		// non-blocking: the document re-opens via restartFamily once the cache
-		// is populated. The frontend re-sends content on the ready status.
+		// non-blocking: restartFamily emits lsp:reconnect once the cache is
+		// populated, and the frontend re-sends current content.
 		return nil
 	}
+	m.untrackPendingProvisionDoc(uri)
 
 	m.mu.Lock()
 	ds, exists := entry.openDocs[uri]
@@ -305,6 +318,9 @@ func (m *Manager) DidClose(ctx context.Context, path string) error {
 	uri, err := FileToURI(path)
 	if err != nil {
 		return fmt.Errorf("invalid path %q: %w", path, err)
+	}
+	if m.untrackPendingProvisionDoc(uri) {
+		return nil
 	}
 
 	m.mu.Lock()
@@ -455,6 +471,7 @@ func (m *Manager) ShutdownAll(timeout time.Duration) {
 	m.mu.Lock()
 	m.stopped = true
 	cancel := m.cancel
+	m.pendingProvisionDocs = nil
 	keys := make([]serverKey, 0, len(m.servers))
 	for key := range m.servers {
 		keys = append(keys, key)
@@ -591,8 +608,13 @@ func (m *Manager) RetryProvision(family string) error {
 // status emitted exactly as a first open would. Errors are logged; the start
 // path already emits an error status on failure.
 func (m *Manager) restartFamily(family, projectRoot string) {
-	if _, err := m.ensureServer(m.provisionCtx(), family, projectRoot); err != nil {
+	entry, err := m.ensureServer(m.provisionCtx(), family, projectRoot)
+	if err != nil {
 		log.Printf("lsp: post-provision start failed family=%s root=%q: %v", family, projectRoot, err)
+		return
+	}
+	if entry != nil {
+		m.emitPendingProvisionReconnect(serverKey{family: family, workspace: projectRoot})
 	}
 }
 
@@ -740,6 +762,65 @@ func (m *Manager) emitProvisionStatus(family, projectRoot, setupState, action, d
 		DetailCode:   detailCode,
 		ProvisionPct: pct,
 	})
+}
+
+func (m *Manager) serverRunning(key serverKey) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.servers[key]
+	return ok
+}
+
+func (m *Manager) trackPendingProvisionDoc(key serverKey, uri string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.pendingProvisionDocs == nil {
+		m.pendingProvisionDocs = make(map[serverKey]map[string]bool)
+	}
+	docs := m.pendingProvisionDocs[key]
+	if docs == nil {
+		docs = make(map[string]bool)
+		m.pendingProvisionDocs[key] = docs
+	}
+	docs[uri] = true
+}
+
+func (m *Manager) untrackPendingProvisionDoc(uri string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for key, docs := range m.pendingProvisionDocs {
+		if docs[uri] {
+			delete(docs, uri)
+			if len(docs) == 0 {
+				delete(m.pendingProvisionDocs, key)
+			}
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Manager) emitPendingProvisionReconnect(key serverKey) {
+	m.mu.Lock()
+	docsByURI := m.pendingProvisionDocs[key]
+	if len(docsByURI) == 0 {
+		m.mu.Unlock()
+		return
+	}
+	documents := make([]string, 0, len(docsByURI))
+	for uri := range docsByURI {
+		documents = append(documents, uri)
+	}
+	delete(m.pendingProvisionDocs, key)
+	m.mu.Unlock()
+
+	if m.emitter != nil {
+		m.emitter("lsp:reconnect", map[string]any{
+			"family":    key.family,
+			"workspace": key.workspace,
+			"documents": documents,
+		})
+	}
 }
 
 // startServer launches a new language server process and initializes it.

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -82,7 +82,8 @@ type Manager struct {
 
 	// provisioners maps a language family to its managed provisioner. Populated
 	// by SetProvisioners and shared with the registry so a resolver miss can be
-	// classified as provisionable.
+	// classified as provisionable. Set once via SetProvisioners before the first
+	// DidOpen and not mutated after; reads are unsynchronized on that basis.
 	provisioners map[string]provision.Provisioner
 
 	// provisionMu guards provisioning. It is intentionally separate from mu so
@@ -497,7 +498,13 @@ func (m *Manager) ensureServer(ctx context.Context, family, workspace string) (*
 // background context when the manager was built via a struct literal (some
 // tests) rather than NewManager. The install goroutine derives cancellation
 // from this so workspace teardown (ShutdownAll) stops in-flight installs.
+//
+// m.ctx is rewritten under m.mu by SetWorkspaceRoot, so the read is locked.
+// Both call sites evaluate this as a plain argument before any further lock is
+// taken, so there is no nested-lock path.
 func (m *Manager) provisionCtx() context.Context {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.ctx != nil {
 		return m.ctx
 	}
@@ -543,6 +550,9 @@ func (m *Manager) beginProvision(family, projectRoot string) {
 			m.emitProvisionStatus(family, projectRoot, "offline", "retry", "download_offline", 0)
 		case provision.StateChecksumFailed:
 			m.emitProvisionStatus(family, projectRoot, "provision_failed", "retry", "checksum_mismatch", 0)
+		case provision.StateUnsupported:
+			// No retry: an unsupported platform fails identically every time.
+			m.emitProvisionStatus(family, projectRoot, "provision_failed", "", "unsupported_platform", 0)
 		default:
 			m.emitProvisionStatus(family, projectRoot, "provision_failed", "retry", "provision_error", 0)
 		}

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -6,12 +6,15 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
 	"firn/internal/lsp/provision"
+	"firn/internal/lsp/pythonenv"
 )
 
 // errNoWorkspaceRoot signals that an LSP method was called before
@@ -96,6 +99,12 @@ type Manager struct {
 	// background installs stop when the workspace is torn down.
 	ctx    context.Context
 	cancel context.CancelFunc
+
+	// interpreterOverrides maps a workspace/project root -> manual interpreter
+	// path. In-memory only; Task 12b persists/seeds it from workspace state.
+	// Wired into the envConfigProvider override hook via overrideForRoot.
+	overrideMu           sync.RWMutex
+	interpreterOverrides map[string]string
 }
 
 // serverKey identifies a unique server instance by language family and workspace.
@@ -123,16 +132,24 @@ type serverEntry struct {
 // NewManager creates a new LSP manager with the given event emitter.
 func NewManager(emitter EventEmitter) *Manager {
 	ctx, cancel := context.WithCancel(context.Background())
-	return &Manager{
-		registry:       NewRegistry(),
-		emitter:        emitter,
-		configProvider: newEnvConfigProvider(),
-		servers:        make(map[serverKey]*serverEntry),
-		docKeys:        make(map[string]serverKey),
-		provisioning:   make(map[string]bool),
-		ctx:            ctx,
-		cancel:         cancel,
+	m := &Manager{
+		registry:             NewRegistry(),
+		emitter:              emitter,
+		configProvider:       newEnvConfigProvider(),
+		servers:              make(map[serverKey]*serverEntry),
+		docKeys:              make(map[string]serverKey),
+		provisioning:         make(map[string]bool),
+		ctx:                  ctx,
+		cancel:               cancel,
+		interpreterOverrides: make(map[string]string),
 	}
+	// Wire the manual interpreter override into env resolution. The
+	// configProvider field is the interface type; the override hook lives only
+	// on the concrete provider, so assert before wiring.
+	if ep, ok := m.configProvider.(*envConfigProvider); ok {
+		ep.SetInterpreterOverrideFunc(m.overrideForRoot)
+	}
+	return m
 }
 
 // SetProvisioners injects managed provisioners and forwards them to the registry
@@ -577,6 +594,127 @@ func (m *Manager) restartFamily(family, projectRoot string) {
 	if _, err := m.ensureServer(m.provisionCtx(), family, projectRoot); err != nil {
 		log.Printf("lsp: post-provision start failed family=%s root=%q: %v", family, projectRoot, err)
 	}
+}
+
+// restartRunningFamily restarts a server only if one is currently running for
+// the given family/root. Used after an interpreter-override change so the new
+// interpreter takes effect. When no server is running it is a safe no-op — a
+// future DidOpen starts the server with the override already applied.
+func (m *Manager) restartRunningFamily(family, projectRoot string) {
+	key := serverKey{family: family, workspace: projectRoot}
+	m.mu.Lock()
+	_, running := m.servers[key]
+	m.mu.Unlock()
+	if !running {
+		return
+	}
+	shutCtx, cancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
+	m.shutdownServer(shutCtx, key)
+	cancel()
+	m.restartFamily(family, projectRoot)
+}
+
+// overrideForRoot is the lookup wired into envConfigProvider.SetInterpreterOverrideFunc.
+func (m *Manager) overrideForRoot(projectRoot string) string {
+	m.overrideMu.RLock()
+	defer m.overrideMu.RUnlock()
+	return m.interpreterOverrides[projectRoot]
+}
+
+// SeedInterpreterOverride sets an override WITHOUT restarting servers (used at
+// workspace load to apply a persisted choice before the first DidOpen).
+func (m *Manager) SeedInterpreterOverride(projectRoot, interpreterPath string) {
+	m.overrideMu.Lock()
+	if interpreterPath == "" {
+		delete(m.interpreterOverrides, projectRoot)
+	} else {
+		m.interpreterOverrides[projectRoot] = interpreterPath
+	}
+	m.overrideMu.Unlock()
+}
+
+// SetInterpreterOverride validates the path, stores the override, and restarts
+// the python server for that root so the new interpreter takes effect.
+// Returns an error if interpreterPath does not exist / is a directory.
+func (m *Manager) SetInterpreterOverride(projectRoot, interpreterPath string) error {
+	// Override paths bypass the discovery layer's stat validation, so validate
+	// here: the env layer trusts whatever this map returns.
+	if interpreterPath == "" {
+		return fmt.Errorf("interpreter not found: %q", interpreterPath)
+	}
+	if info, err := os.Stat(interpreterPath); err != nil || info.IsDir() {
+		return fmt.Errorf("interpreter not found: %q", interpreterPath)
+	}
+
+	m.overrideMu.Lock()
+	m.interpreterOverrides[projectRoot] = interpreterPath
+	m.overrideMu.Unlock()
+
+	m.restartRunningFamily("python", projectRoot)
+	return nil
+}
+
+// ClearInterpreterOverride removes the override and restarts python for that root.
+func (m *Manager) ClearInterpreterOverride(projectRoot string) error {
+	m.overrideMu.Lock()
+	delete(m.interpreterOverrides, projectRoot)
+	m.overrideMu.Unlock()
+
+	m.restartRunningFamily("python", projectRoot)
+	return nil
+}
+
+// DoctorReport summarizes python LSP setup for a workspace so the UI can render
+// actionable choices from one call.
+type DoctorReport struct {
+	Family            string   `json:"family"`
+	InterpreterPath   string   `json:"interpreterPath,omitempty"`
+	InterpreterSource string   `json:"interpreterSource,omitempty"`
+	Override          string   `json:"override,omitempty"`
+	Candidates        []string `json:"candidates"`
+}
+
+// Doctor returns the resolved interpreter + override + candidate interpreters
+// for the given workspace root (python family).
+func (m *Manager) Doctor(projectRoot string) DoctorReport {
+	env := pythonEnvFromProvider(m.configProvider, projectRoot)
+	override := m.overrideForRoot(projectRoot)
+
+	rep := DoctorReport{
+		Family:            "python",
+		InterpreterPath:   env.InterpreterPath,
+		InterpreterSource: env.Source,
+		Override:          override,
+	}
+
+	// Build a deduped candidate list, dropping empties. Best-effort: discovery
+	// and LookPath errors are ignored.
+	seen := map[string]bool{}
+	add := func(p string) {
+		if p == "" || seen[p] {
+			return
+		}
+		seen[p] = true
+		rep.Candidates = append(rep.Candidates, p)
+	}
+
+	add(env.InterpreterPath)
+	add(override)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	if interp, _, ok := pythonenv.DiscoverInterpreter(ctx, projectRoot, osRunner); ok {
+		add(interp)
+	}
+	cancel()
+
+	if p, err := exec.LookPath("python3"); err == nil {
+		add(p)
+	}
+	if p, err := exec.LookPath("python"); err == nil {
+		add(p)
+	}
+
+	return rep
 }
 
 // emitProvisionStatus emits an lsp:status event describing a managed-install

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"firn/internal/lsp/provision"
 	"firn/internal/lsp/pythonenv"
 )
 
@@ -1851,5 +1852,185 @@ func TestGetStatus_PythonReadyEnriched(t *testing.T) {
 	}
 	if got.ConfigSource != "detected" {
 		t.Errorf("ConfigSource = %q, want detected", got.ConfigSource)
+	}
+}
+
+// --- Managed provisioning orchestration (#112) ---
+
+// scriptedProv is a test Provisioner whose Resolve flips to StateAvailable only
+// after Install runs, and whose Install returns a scripted Resolution. When the
+// install resolves to StateAvailable, Path/Args point at the mock LSP server so
+// restartFamily can actually launch it.
+type scriptedProv struct {
+	family     string
+	installRes provision.Resolution
+	mu         sync.Mutex
+	installed  bool
+	calls      int
+}
+
+func (p *scriptedProv) Family() string { return p.family }
+
+func (p *scriptedProv) Resolve() provision.Resolution {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.installed && p.installRes.State == provision.StateAvailable {
+		return p.installRes
+	}
+	return provision.Resolution{State: provision.StateMissing}
+}
+
+func (p *scriptedProv) Install(ctx context.Context, progress func(provision.Progress)) provision.Resolution {
+	if progress != nil {
+		progress(provision.Progress{Phase: "download", Pct: 50})
+	}
+	p.mu.Lock()
+	p.calls++
+	p.installed = true
+	res := p.installRes
+	p.mu.Unlock()
+	return res
+}
+
+func (p *scriptedProv) installCalls() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+// mockServerResolution returns a StateAvailable Resolution whose launch command
+// is the current test binary re-invoked as the mock LSP server.
+func mockServerResolution() provision.Resolution {
+	return provision.Resolution{
+		State: provision.StateAvailable,
+		Path:  os.Args[0],
+		Args:  []string{"-test.run=^TestMockServerProcess$"},
+	}
+}
+
+// newProvisionManager builds a Manager whose registry resolves the python family
+// only via the supplied managed provisioner (no host binary), with the workspace
+// root set to a temp dir.
+func newProvisionManager(t *testing.T, prov provision.Provisioner) (*Manager, *eventCollector, string) {
+	t.Helper()
+	// Defeat any host pyright/basedpyright so the python resolver falls through
+	// to managedOrMiss deterministically.
+	t.Setenv("PATH", "")
+	t.Setenv("VIRTUAL_ENV", "")
+
+	workspace := t.TempDir()
+	collector := &eventCollector{}
+	mgr := NewManager(collector.emit)
+	mgr.SetProvisioners(map[string]provision.Provisioner{"python": prov})
+	mgr.SetWorkspaceRoot(workspace)
+	t.Cleanup(func() { mgr.ShutdownAll(5 * time.Second) })
+	return mgr, collector, workspace
+}
+
+// latestPythonStatus returns the most recent lsp:status ServerStatus for the
+// python family, or false if none was emitted.
+func latestPythonStatus(ec *eventCollector) (ServerStatus, bool) {
+	var found ServerStatus
+	var ok bool
+	for _, e := range ec.eventsByName("lsp:status") {
+		if len(e.data) == 0 {
+			continue
+		}
+		s, isStatus := e.data[0].(ServerStatus)
+		if isStatus && s.Family == "python" {
+			found = s
+			ok = true
+		}
+	}
+	return found, ok
+}
+
+func TestManager_provisionsOnMiss(t *testing.T) {
+	if os.Getenv("FIRN_MOCK_LSP") == "1" {
+		t.Skip("running as mock server")
+	}
+	t.Setenv("FIRN_MOCK_LSP", "1")
+
+	prov := &scriptedProv{family: "python", installRes: mockServerResolution()}
+	mgr, collector, workspace := newProvisionManager(t, prov)
+
+	pyFile := filepath.Join(workspace, "main.py")
+	if err := mgr.DidOpen(context.Background(), pyFile, "python", 1, "x = 1"); err != nil {
+		t.Fatalf("DidOpen must be non-blocking on a provisionable miss, got: %v", err)
+	}
+
+	// A provisioning status must be emitted promptly.
+	waitFor(t, 2*time.Second, "provisioning status", func() bool {
+		for _, e := range collector.eventsByName("lsp:status") {
+			if len(e.data) == 0 {
+				continue
+			}
+			if s, ok := e.data[0].(ServerStatus); ok && s.Family == "python" && s.SetupState == "provisioning" {
+				return true
+			}
+		}
+		return false
+	})
+
+	// After install completes, restartFamily starts the mock server -> ready.
+	waitFor(t, 5*time.Second, "python server ready", func() bool {
+		mgr.mu.Lock()
+		defer mgr.mu.Unlock()
+		entry, ok := mgr.servers[serverKey{family: "python", workspace: workspace}]
+		return ok && entry.client.State() == ClientStateReady
+	})
+
+	if got := prov.installCalls(); got != 1 {
+		t.Errorf("Install called %d times, want 1 (single-flight)", got)
+	}
+}
+
+func TestManager_provisionOfflineSurfacesCard(t *testing.T) {
+	prov := &scriptedProv{
+		family:     "python",
+		installRes: provision.Resolution{State: provision.StateOffline, Err: errors.New("network down")},
+	}
+	mgr, collector, workspace := newProvisionManager(t, prov)
+
+	if err := mgr.DidOpen(context.Background(), filepath.Join(workspace, "main.py"), "python", 1, "x = 1"); err != nil {
+		t.Fatalf("DidOpen non-blocking, got: %v", err)
+	}
+
+	waitFor(t, 2*time.Second, "offline status", func() bool {
+		s, ok := latestPythonStatus(collector)
+		return ok && s.SetupState == "offline"
+	})
+
+	s, _ := latestPythonStatus(collector)
+	if s.Action != "retry" {
+		t.Errorf("Action = %q, want retry", s.Action)
+	}
+	if s.DetailCode != "download_offline" {
+		t.Errorf("DetailCode = %q, want download_offline", s.DetailCode)
+	}
+}
+
+func TestManager_provisionChecksumFailed(t *testing.T) {
+	prov := &scriptedProv{
+		family:     "python",
+		installRes: provision.Resolution{State: provision.StateChecksumFailed, Err: errors.New("hash mismatch")},
+	}
+	mgr, collector, workspace := newProvisionManager(t, prov)
+
+	if err := mgr.DidOpen(context.Background(), filepath.Join(workspace, "main.py"), "python", 1, "x = 1"); err != nil {
+		t.Fatalf("DidOpen non-blocking, got: %v", err)
+	}
+
+	waitFor(t, 2*time.Second, "provision_failed status", func() bool {
+		s, ok := latestPythonStatus(collector)
+		return ok && s.SetupState == "provision_failed"
+	})
+
+	s, _ := latestPythonStatus(collector)
+	if s.Action != "retry" {
+		t.Errorf("Action = %q, want retry", s.Action)
+	}
+	if s.DetailCode != "checksum_mismatch" {
+		t.Errorf("DetailCode = %q, want checksum_mismatch", s.DetailCode)
 	}
 }

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -1958,6 +1958,13 @@ func TestManager_provisionsOnMiss(t *testing.T) {
 	if err := mgr.DidOpen(context.Background(), pyFile, "python", 1, "x = 1"); err != nil {
 		t.Fatalf("DidOpen must be non-blocking on a provisionable miss, got: %v", err)
 	}
+	if err := mgr.DidChange(pyFile, 2, []TextDocumentContentChangeEvent{{Text: "x = 2"}}); err != nil {
+		t.Fatalf("DidChange during provisioning must be a no-op, got: %v", err)
+	}
+	uri, err := FileToURI(pyFile)
+	if err != nil {
+		t.Fatalf("FileToURI: %v", err)
+	}
 
 	// A provisioning status must be emitted promptly.
 	waitFor(t, 2*time.Second, "provisioning status", func() bool {
@@ -1978,6 +1985,27 @@ func TestManager_provisionsOnMiss(t *testing.T) {
 		defer mgr.mu.Unlock()
 		entry, ok := mgr.servers[serverKey{family: "python", workspace: workspace}]
 		return ok && entry.client.State() == ClientStateReady
+	})
+	waitFor(t, 2*time.Second, "provision reconnect event", func() bool {
+		for _, e := range collector.eventsByName("lsp:reconnect") {
+			if len(e.data) == 0 {
+				continue
+			}
+			payload, ok := e.data[0].(map[string]any)
+			if !ok || payload["family"] != "python" || payload["workspace"] != workspace {
+				continue
+			}
+			documents, ok := payload["documents"].([]string)
+			if !ok {
+				continue
+			}
+			for _, got := range documents {
+				if got == uri {
+					return true
+				}
+			}
+		}
+		return false
 	})
 
 	if got := prov.installCalls(); got != 1 {

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -2034,3 +2034,88 @@ func TestManager_provisionChecksumFailed(t *testing.T) {
 		t.Errorf("DetailCode = %q, want checksum_mismatch", s.DetailCode)
 	}
 }
+
+func TestSetInterpreterOverride_rejectsMissingPath(t *testing.T) {
+	m := NewManager(nil)
+	err := m.SetInterpreterOverride(t.TempDir(), filepath.Join(t.TempDir(), "nope", "python"))
+	if err == nil {
+		t.Fatal("expected error for non-existent interpreter")
+	}
+}
+
+func TestSetInterpreterOverride_rejectsDirectory(t *testing.T) {
+	m := NewManager(nil)
+	root := t.TempDir()
+	if err := m.SetInterpreterOverride(root, root); err == nil {
+		t.Fatal("expected error when interpreter path is a directory")
+	}
+}
+
+func TestSetAndClearInterpreterOverride_roundTrip(t *testing.T) {
+	m := NewManager(nil)
+	root := t.TempDir()
+	interp := filepath.Join(root, "python")
+	if err := os.WriteFile(interp, []byte("#!py"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.SetInterpreterOverride(root, interp); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if got := m.overrideForRoot(root); got != interp {
+		t.Errorf("override = %q, want %q", got, interp)
+	}
+	if err := m.ClearInterpreterOverride(root); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if got := m.overrideForRoot(root); got != "" {
+		t.Errorf("override after clear = %q, want empty", got)
+	}
+}
+
+func TestSeedInterpreterOverride_setsWithoutRestart(t *testing.T) {
+	m := NewManager(nil)
+	root := t.TempDir()
+	m.SeedInterpreterOverride(root, "/some/interp")
+	if got := m.overrideForRoot(root); got != "/some/interp" {
+		t.Errorf("seeded override = %q, want /some/interp", got)
+	}
+}
+
+func TestOverrideFeedsConfigProvider(t *testing.T) {
+	m := NewManager(nil)
+	root := t.TempDir()
+	interp := filepath.Join(root, "python")
+	if err := os.WriteFile(interp, []byte("#!py"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.SetInterpreterOverride(root, interp); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	env := pythonEnvFromProvider(m.configProvider, root)
+	if env.InterpreterPath != interp || env.Source != "override" {
+		t.Errorf("provider env = %+v, want interpreter %q source override", env, interp)
+	}
+}
+
+func TestDoctor_reportsOverrideAndCandidates(t *testing.T) {
+	m := NewManager(nil)
+	root := t.TempDir()
+	interp := filepath.Join(root, "python")
+	if err := os.WriteFile(interp, []byte("#!py"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_ = m.SetInterpreterOverride(root, interp)
+	rep := m.Doctor(root)
+	if rep.Family != "python" || rep.Override != interp {
+		t.Fatalf("report = %+v", rep)
+	}
+	found := false
+	for _, c := range rep.Candidates {
+		if c == interp {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("candidates %v missing override %q", rep.Candidates, interp)
+	}
+}

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -181,8 +181,17 @@ func TestRegistry_GoServerConfigReportsMissingGopls(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when gopls is not found")
 	}
-	if !contains(err.Error(), "go install golang.org/x/tools/gopls@latest") {
-		t.Errorf("error should include install instructions, got: %s", err.Error())
+	// Typed miss: go has no managed provisioner, so it is unprovisionable and
+	// the gopls install guidance must be preserved as the hint.
+	var miss *ServerMissError
+	if !errors.As(err, &miss) {
+		t.Fatalf("err = %v, want *ServerMissError", err)
+	}
+	if miss.Provisionable {
+		t.Error("go has no managed provisioner; expected Provisionable=false")
+	}
+	if !contains(miss.Hint, "go install golang.org/x/tools/gopls@latest") {
+		t.Errorf("hint should include install instructions, got: %s", miss.Hint)
 	}
 }
 
@@ -305,8 +314,17 @@ func TestRegistry_PythonServerConfigReportsMissingPyright(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when pyright-langserver is not found")
 	}
-	if !contains(err.Error(), "npm install -g pyright") {
-		t.Errorf("error should include install instructions, got: %s", err.Error())
+	// Typed miss with actionable hint. No managed provisioner is wired on a bare
+	// registry, so this resolves as unprovisionable.
+	var miss *ServerMissError
+	if !errors.As(err, &miss) {
+		t.Fatalf("err = %v, want *ServerMissError", err)
+	}
+	if miss.Provisionable {
+		t.Error("no provisioner wired; expected Provisionable=false")
+	}
+	if !contains(miss.Hint, "basedpyright/pyright") {
+		t.Errorf("hint should include install guidance, got: %s", miss.Hint)
 	}
 }
 

--- a/internal/lsp/provision/archive.go
+++ b/internal/lsp/provision/archive.go
@@ -30,6 +30,10 @@ func UnzipWheel(src, destDir string) error {
 			}
 			continue
 		}
+		if f.Mode()&os.ModeSymlink != 0 {
+			// ponytail: trusted vendor wheels carry no symlinks; skip rather than materialize them.
+			continue
+		}
 		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 			return err
 		}

--- a/internal/lsp/provision/archive.go
+++ b/internal/lsp/provision/archive.go
@@ -16,7 +16,7 @@ func UnzipWheel(src, destDir string) error {
 	if err != nil {
 		return err
 	}
-	defer zr.Close()
+	defer func() { _ = zr.Close() }()
 
 	cleanDest := filepath.Clean(destDir)
 	for _, f := range zr.File {
@@ -49,7 +49,7 @@ func extractZipFile(f *zip.File, target string) error {
 	if err != nil {
 		return err
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 	mode := f.Mode()
 	if mode == 0 {
 		mode = 0o644
@@ -58,7 +58,10 @@ func extractZipFile(f *zip.File, target string) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
-	_, err = io.Copy(out, rc)
-	return err
+	if _, err := io.Copy(out, rc); err != nil {
+		_ = out.Close()
+		return err
+	}
+	// Check Close: a flush error here means a corrupt extracted binary.
+	return out.Close()
 }

--- a/internal/lsp/provision/archive.go
+++ b/internal/lsp/provision/archive.go
@@ -1,0 +1,60 @@
+package provision
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// UnzipWheel extracts a wheel (a zip) into destDir, preserving the executable
+// bit. It rejects entries that would escape destDir (zip-slip).
+func UnzipWheel(src, destDir string) error {
+	zr, err := zip.OpenReader(src)
+	if err != nil {
+		return err
+	}
+	defer zr.Close()
+
+	cleanDest := filepath.Clean(destDir)
+	for _, f := range zr.File {
+		target := filepath.Join(cleanDest, f.Name)
+		if target != cleanDest && !strings.HasPrefix(target, cleanDest+string(os.PathSeparator)) {
+			return fmt.Errorf("unsafe path in archive: %q", f.Name)
+		}
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		if err := extractZipFile(f, target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func extractZipFile(f *zip.File, target string) error {
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+	mode := f.Mode()
+	if mode == 0 {
+		mode = 0o644
+	}
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, rc)
+	return err
+}

--- a/internal/lsp/provision/archive_test.go
+++ b/internal/lsp/provision/archive_test.go
@@ -14,14 +14,14 @@ func makeZip(t *testing.T, files map[string]string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	zw := zip.NewWriter(f)
 	for name, body := range files {
 		w, err := zw.Create(name)
 		if err != nil {
 			t.Fatal(err)
 		}
-		w.Write([]byte(body))
+		_, _ = w.Write([]byte(body))
 	}
 	if err := zw.Close(); err != nil {
 		t.Fatal(err)
@@ -64,11 +64,11 @@ func TestUnzipWheel_preservesExecBit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	w.Write([]byte("#!node"))
+	_, _ = w.Write([]byte("#!node"))
 	if err := zw.Close(); err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
+	_ = f.Close()
 
 	dest := t.TempDir()
 	if err := UnzipWheel(p, dest); err != nil {

--- a/internal/lsp/provision/archive_test.go
+++ b/internal/lsp/provision/archive_test.go
@@ -1,0 +1,52 @@
+package provision
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func makeZip(t *testing.T, files map[string]string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "a.whl")
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	zw := zip.NewWriter(f)
+	for name, body := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		w.Write([]byte(body))
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestUnzipWheel_ok(t *testing.T) {
+	src := makeZip(t, map[string]string{
+		"basedpyright/langserver.index.js": "console.log('ls')",
+		"basedpyright/dist/x.js":           "x",
+	})
+	dest := t.TempDir()
+	if err := UnzipWheel(src, dest); err != nil {
+		t.Fatalf("UnzipWheel: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "basedpyright", "langserver.index.js"))
+	if err != nil || string(got) != "console.log('ls')" {
+		t.Errorf("extracted file wrong: %q err=%v", got, err)
+	}
+}
+
+func TestUnzipWheel_zipSlipRejected(t *testing.T) {
+	src := makeZip(t, map[string]string{"../escape.txt": "evil"})
+	if err := UnzipWheel(src, t.TempDir()); err == nil {
+		t.Fatal("expected zip-slip rejection")
+	}
+}

--- a/internal/lsp/provision/archive_test.go
+++ b/internal/lsp/provision/archive_test.go
@@ -50,3 +50,35 @@ func TestUnzipWheel_zipSlipRejected(t *testing.T) {
 		t.Fatal("expected zip-slip rejection")
 	}
 }
+
+func TestUnzipWheel_preservesExecBit(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "exe.whl")
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zw := zip.NewWriter(f)
+	hdr := &zip.FileHeader{Name: "nodejs_wheel/node"}
+	hdr.SetMode(0o755)
+	w, err := zw.CreateHeader(hdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Write([]byte("#!node"))
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	dest := t.TempDir()
+	if err := UnzipWheel(p, dest); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(filepath.Join(dest, "nodejs_wheel", "node"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("exec bit not preserved: mode = %v", info.Mode())
+	}
+}

--- a/internal/lsp/provision/catalog.go
+++ b/internal/lsp/provision/catalog.go
@@ -1,0 +1,59 @@
+package provision
+
+// ArtifactType describes how a family's server is packaged.
+type ArtifactType string
+
+const (
+	// ArtifactWheelNode: a py3-none-any server wheel + a platform nodejs-wheel-binaries wheel.
+	ArtifactWheelNode ArtifactType = "wheel-node"
+)
+
+// Artifact is one pinned downloadable. Pinned URL/SHA256/Version are
+// configuration constants, not placeholder data.
+type Artifact struct {
+	Kind    string // "server-wheel" | "node-wheel"
+	Package string // e.g. "basedpyright" / "nodejs-wheel-binaries"
+	Version string // exact, no floating ranges
+	URL     string // HTTPS files.pythonhosted.org URL
+	SHA256  string // hex digest; mismatch is a hard stop
+	GOOS    string // "" = any platform (universal wheel)
+	GOARCH  string
+}
+
+// CatalogEntry pins one family's managed install.
+type CatalogEntry struct {
+	Family       string
+	Version      string
+	ArtifactType ArtifactType
+	Artifacts    []Artifact
+}
+
+var catalog = map[string]CatalogEntry{
+	"python": pythonCatalogEntry,
+}
+
+// PlatformArtifacts returns the catalog entry and the exact artifact set to
+// fetch for family on goos/goarch. ok is false when the family or platform is
+// unsupported (no universal server wheel + matching platform node wheel).
+func PlatformArtifacts(family, goos, goarch string) (CatalogEntry, []Artifact, bool) {
+	entry, found := catalog[family]
+	if !found {
+		return CatalogEntry{}, nil, false
+	}
+	var out []Artifact
+	var haveServer, haveNode bool
+	for _, a := range entry.Artifacts {
+		switch {
+		case a.GOOS == "" && a.GOARCH == "": // universal
+			out = append(out, a)
+			haveServer = haveServer || a.Kind == "server-wheel"
+		case a.GOOS == goos && a.GOARCH == goarch:
+			out = append(out, a)
+			haveNode = haveNode || a.Kind == "node-wheel"
+		}
+	}
+	if !haveServer || !haveNode {
+		return entry, nil, false
+	}
+	return entry, out, true
+}

--- a/internal/lsp/provision/catalog_python.go
+++ b/internal/lsp/provision/catalog_python.go
@@ -1,0 +1,39 @@
+package provision
+
+// pythonCatalogEntry pins basedpyright (universal py3-none-any wheel) plus the
+// nodejs-wheel-binaries platform wheel per supported OS/arch. Linux uses the
+// glibc (manylinux) wheels; musl/Alpine falls through to the uv fast-path or a
+// guidance card.
+// ponytail: glibc-only linux node wheels; add musllinux entries if Alpine demand appears.
+var pythonCatalogEntry = CatalogEntry{
+	Family:       "python",
+	Version:      "1.39.9",
+	ArtifactType: ArtifactWheelNode,
+	Artifacts: []Artifact{
+		{
+			Kind:    "server-wheel",
+			Package: "basedpyright",
+			Version: "1.39.9",
+			URL:     "https://files.pythonhosted.org/packages/2a/d4/e1fa108710d0498a18c77b1e13897f31eab47c69aa8cfe2d2a4df746541e/basedpyright-1.39.9-py3-none-any.whl",
+			SHA256:  "6b0837b9eba972c71895167ab9b127e6afdbc17abc92312e3f8d15ca82a5611c",
+		},
+		{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "darwin", GOARCH: "arm64",
+			URL:    "https://files.pythonhosted.org/packages/24/6d/333e5458422f12318e3c3e6e7f194353aa68b0d633217c7e89833427ca01/nodejs_wheel_binaries-22.20.0-py2.py3-none-macosx_11_0_arm64.whl",
+			SHA256: "455add5ac4f01c9c830ab6771dbfad0fdf373f9b040d3aabe8cca9b6c56654fb"},
+		{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "darwin", GOARCH: "amd64",
+			URL:    "https://files.pythonhosted.org/packages/56/30/dcd6879d286a35b3c4c8f9e5e0e1bcf4f9e25fe35310fc77ecf97f915a23/nodejs_wheel_binaries-22.20.0-py2.py3-none-macosx_11_0_x86_64.whl",
+			SHA256: "5d8c12f97eea7028b34a84446eb5ca81829d0c428dfb4e647e09ac617f4e21fa"},
+		{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "linux", GOARCH: "arm64",
+			URL:    "https://files.pythonhosted.org/packages/58/be/c7b2e7aa3bb281d380a1c531f84d0ccfe225832dfc3bed1ca171753b9630/nodejs_wheel_binaries-22.20.0-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+			SHA256: "7a2b0989194148f66e9295d8f11bc463bde02cbe276517f4d20a310fb84780ae"},
+		{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "linux", GOARCH: "amd64",
+			URL:    "https://files.pythonhosted.org/packages/3e/c5/8befacf4190e03babbae54cb0809fb1a76e1600ec3967ab8ee9f8fc85b65/nodejs_wheel_binaries-22.20.0-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+			SHA256: "b5c500aa4dc046333ecb0a80f183e069e5c30ce637f1c1a37166b2c0b642dc21"},
+		{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "windows", GOARCH: "amd64",
+			URL:    "https://files.pythonhosted.org/packages/b4/a9/c6a480259aa0d6b270aac2c6ba73a97444b9267adde983a5b7e34f17e45a/nodejs_wheel_binaries-22.20.0-py2.py3-none-win_amd64.whl",
+			SHA256: "4bd658962f24958503541963e5a6f2cc512a8cb301e48a69dc03c879f40a28ae"},
+		{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "windows", GOARCH: "arm64",
+			URL:    "https://files.pythonhosted.org/packages/42/b1/6a4eb2c6e9efa028074b0001b61008c9d202b6b46caee9e5d1b18c088216/nodejs_wheel_binaries-22.20.0-py2.py3-none-win_arm64.whl",
+			SHA256: "1fccac931faa210d22b6962bcdbc99269d16221d831b9a118bbb80fe434a60b8"},
+	},
+}

--- a/internal/lsp/provision/catalog_test.go
+++ b/internal/lsp/provision/catalog_test.go
@@ -1,0 +1,37 @@
+package provision
+
+import "testing"
+
+func TestPlatformArtifacts_Python_supported(t *testing.T) {
+	entry, arts, ok := PlatformArtifacts("python", "darwin", "arm64")
+	if !ok {
+		t.Fatal("expected python/darwin/arm64 supported")
+	}
+	if entry.Version != "1.39.9" {
+		t.Errorf("version = %q, want 1.39.9", entry.Version)
+	}
+	var server, node int
+	for _, a := range arts {
+		switch a.Kind {
+		case "server-wheel":
+			server++
+		case "node-wheel":
+			node++
+		}
+		if a.SHA256 == "" || a.URL == "" || a.Package == "" || a.Version == "" {
+			t.Errorf("artifact missing pinned field: %+v", a)
+		}
+	}
+	if server != 1 || node != 1 {
+		t.Errorf("got server=%d node=%d, want 1/1", server, node)
+	}
+}
+
+func TestPlatformArtifacts_unsupported(t *testing.T) {
+	if _, _, ok := PlatformArtifacts("python", "plan9", "mips"); ok {
+		t.Error("expected plan9/mips unsupported")
+	}
+	if _, _, ok := PlatformArtifacts("ruby", "darwin", "arm64"); ok {
+		t.Error("expected unknown family unsupported")
+	}
+}

--- a/internal/lsp/provision/download.go
+++ b/internal/lsp/provision/download.go
@@ -1,0 +1,64 @@
+package provision
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ChecksumError marks a SHA256 verification failure so callers can map it to a
+// security stop (StateChecksumFailed) rather than a transient network failure.
+type ChecksumError struct {
+	URL  string
+	Got  string
+	Want string
+}
+
+func (e *ChecksumError) Error() string {
+	return fmt.Sprintf("checksum mismatch for %s: got %s want %s", e.URL, e.Got, e.Want)
+}
+
+// DownloadAndVerify streams url to a temp file, verifies its SHA256 against
+// wantHex (case-insensitive), and only then atomically renames it to dest. On
+// any failure the temp file is removed and dest is left untouched. Caller must
+// ensure dest's parent directory exists.
+func DownloadAndVerify(ctx context.Context, client *http.Client, url, wantHex, dest string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download %s: status %d", url, resp.StatusCode)
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(dest), ".dl-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op after successful rename
+
+	h := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(tmp, h), resp.Body); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if got := hex.EncodeToString(h.Sum(nil)); !strings.EqualFold(got, wantHex) {
+		return &ChecksumError{URL: url, Got: got, Want: wantHex}
+	}
+	return os.Rename(tmpName, dest)
+}

--- a/internal/lsp/provision/download.go
+++ b/internal/lsp/provision/download.go
@@ -37,7 +37,7 @@ func DownloadAndVerify(ctx context.Context, client *http.Client, url, wantHex, d
 	if err != nil {
 		return fmt.Errorf("download %s: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("download %s: status %d", url, resp.StatusCode)
 	}
@@ -47,11 +47,11 @@ func DownloadAndVerify(ctx context.Context, client *http.Client, url, wantHex, d
 		return err
 	}
 	tmpName := tmp.Name()
-	defer os.Remove(tmpName) // no-op after successful rename
+	defer func() { _ = os.Remove(tmpName) }() // no-op after successful rename
 
 	h := sha256.New()
 	if _, err := io.Copy(io.MultiWriter(tmp, h), resp.Body); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return err
 	}
 	if err := tmp.Close(); err != nil {

--- a/internal/lsp/provision/download_test.go
+++ b/internal/lsp/provision/download_test.go
@@ -16,7 +16,7 @@ func sha256Hex(b []byte) string { h := sha256.Sum256(b); return hex.EncodeToStri
 
 func TestDownloadAndVerify_ok(t *testing.T) {
 	body := []byte("fake-wheel-bytes")
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.Write(body) }))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write(body) }))
 	defer srv.Close()
 	dest := filepath.Join(t.TempDir(), "out.whl")
 	if err := DownloadAndVerify(context.Background(), http.DefaultClient, srv.URL, sha256Hex(body), dest); err != nil {
@@ -29,7 +29,7 @@ func TestDownloadAndVerify_ok(t *testing.T) {
 }
 
 func TestDownloadAndVerify_checksumMismatch(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.Write([]byte("tampered")) }))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { _, _ = w.Write([]byte("tampered")) }))
 	defer srv.Close()
 	dest := filepath.Join(t.TempDir(), "out.whl")
 	err := DownloadAndVerify(context.Background(), http.DefaultClient, srv.URL, sha256Hex([]byte("expected")), dest)

--- a/internal/lsp/provision/download_test.go
+++ b/internal/lsp/provision/download_test.go
@@ -1,0 +1,55 @@
+package provision
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func sha256Hex(b []byte) string { h := sha256.Sum256(b); return hex.EncodeToString(h[:]) }
+
+func TestDownloadAndVerify_ok(t *testing.T) {
+	body := []byte("fake-wheel-bytes")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.Write(body) }))
+	defer srv.Close()
+	dest := filepath.Join(t.TempDir(), "out.whl")
+	if err := DownloadAndVerify(context.Background(), http.DefaultClient, srv.URL, sha256Hex(body), dest); err != nil {
+		t.Fatalf("DownloadAndVerify: %v", err)
+	}
+	got, _ := os.ReadFile(dest)
+	if string(got) != string(body) {
+		t.Errorf("dest contents = %q", got)
+	}
+}
+
+func TestDownloadAndVerify_checksumMismatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.Write([]byte("tampered")) }))
+	defer srv.Close()
+	dest := filepath.Join(t.TempDir(), "out.whl")
+	err := DownloadAndVerify(context.Background(), http.DefaultClient, srv.URL, sha256Hex([]byte("expected")), dest)
+	if err == nil {
+		t.Fatal("expected checksum error")
+	}
+	var ce *ChecksumError
+	if !errors.As(err, &ce) {
+		t.Errorf("err = %v, want *ChecksumError", err)
+	}
+	if _, statErr := os.Stat(dest); statErr == nil {
+		t.Error("dest must not exist after checksum failure")
+	}
+}
+
+func TestDownloadAndVerify_httpError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusInternalServerError) }))
+	defer srv.Close()
+	dest := filepath.Join(t.TempDir(), "out.whl")
+	if err := DownloadAndVerify(context.Background(), http.DefaultClient, srv.URL, "abc", dest); err == nil {
+		t.Fatal("expected http error")
+	}
+}

--- a/internal/lsp/provision/fetch.go
+++ b/internal/lsp/provision/fetch.go
@@ -1,0 +1,21 @@
+package provision
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// defaultFetch downloads+verifies one artifact and unzips it into destDir.
+// Used when PythonDeps.Fetch is nil (production path).
+func defaultFetch(ctx context.Context, a Artifact, destDir string) error {
+	client := &http.Client{Timeout: 5 * time.Minute}
+	tmp := filepath.Join(destDir, ".whl-"+a.SHA256[:12])
+	if err := DownloadAndVerify(ctx, client, a.URL, a.SHA256, tmp); err != nil {
+		return err
+	}
+	defer os.Remove(tmp)
+	return UnzipWheel(tmp, destDir)
+}

--- a/internal/lsp/provision/fetch.go
+++ b/internal/lsp/provision/fetch.go
@@ -16,6 +16,6 @@ func defaultFetch(ctx context.Context, a Artifact, destDir string) error {
 	if err := DownloadAndVerify(ctx, client, a.URL, a.SHA256, tmp); err != nil {
 		return err
 	}
-	defer os.Remove(tmp)
+	defer func() { _ = os.Remove(tmp) }()
 	return UnzipWheel(tmp, destDir)
 }

--- a/internal/lsp/provision/python.go
+++ b/internal/lsp/provision/python.go
@@ -163,7 +163,7 @@ func (p *PythonProvisioner) installManual(ctx context.Context, artifacts []Artif
 	if err != nil {
 		return Resolution{State: StateOffline, Err: err}
 	}
-	defer os.RemoveAll(staging) // no-op after successful rename
+	defer func() { _ = os.RemoveAll(staging) }() // no-op after successful rename
 
 	for i, a := range artifacts {
 		if err := p.fetch(ctx, a, staging); err != nil {

--- a/internal/lsp/provision/python.go
+++ b/internal/lsp/provision/python.go
@@ -137,6 +137,10 @@ func (p *PythonProvisioner) installManual(ctx context.Context, artifacts []Artif
 		return Resolution{State: StateOffline, Err: err}
 	}
 
+	// ponytail: RemoveAll-then-Rename has a tiny non-atomic gap — a crash between
+	// the two leaves no versionDir (recoverable by re-install). versionDir is
+	// version-pinned so this normally only clears a prior partial/corrupt dir.
+	// Upgrade path: rename old aside, rename staging in, then RemoveAll the aside.
 	_ = os.RemoveAll(p.versionDir()) // clear any partial prior dir
 	if err := os.Rename(staging, p.versionDir()); err != nil {
 		return Resolution{State: StateOffline, Err: err}

--- a/internal/lsp/provision/python.go
+++ b/internal/lsp/provision/python.go
@@ -1,0 +1,208 @@
+package provision
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// PythonDeps are the injected, side-effecting operations PythonProvisioner needs.
+type PythonDeps struct {
+	// LookPath resolves an executable (used to detect "uv"). Mirrors exec.LookPath.
+	LookPath func(string) (string, error)
+	// Fetch downloads+verifies+extracts one artifact into destDir. nil => defaultFetch (real download+unzip).
+	Fetch func(ctx context.Context, a Artifact, destDir string) error
+	// RunUV runs the uv binary (Task 6). nil disables the uv fast-path.
+	RunUV func(ctx context.Context, uv string, args, env []string) error
+}
+
+// launchSpec is persisted as launch.json and is the install's commit marker.
+type launchSpec struct {
+	Path    string   `json:"path"`
+	Args    []string `json:"args"`
+	Version string   `json:"version"`
+	Abs     bool     `json:"abs"` // true: Path absolute; false: Path relative to the version dir
+}
+
+// PythonProvisioner provisions basedpyright into <cacheRoot>/python/<version>/.
+type PythonProvisioner struct {
+	cacheRoot string
+	goos      string
+	goarch    string
+	deps      PythonDeps
+	mu        sync.Mutex // single-flight: one install at a time for this family
+}
+
+func NewPythonProvisioner(cacheRoot, goos, goarch string, deps PythonDeps) *PythonProvisioner {
+	return &PythonProvisioner{cacheRoot: cacheRoot, goos: goos, goarch: goarch, deps: deps}
+}
+
+func (p *PythonProvisioner) Family() string { return "python" }
+
+func (p *PythonProvisioner) versionDir() string {
+	return filepath.Join(p.cacheRoot, "python", pythonCatalogEntry.Version)
+}
+
+// Resolve reads the committed launch.json (cache-only, no network).
+func (p *PythonProvisioner) Resolve() Resolution {
+	spec, err := readLaunchSpec(p.versionDir())
+	if err != nil {
+		return Resolution{State: StateMissing}
+	}
+	launchPath := spec.Path
+	if !spec.Abs {
+		launchPath = filepath.Join(p.versionDir(), spec.Path)
+	}
+	if _, err := os.Stat(launchPath); err != nil {
+		return Resolution{State: StateMissing}
+	}
+	return Resolution{State: StateAvailable, Path: launchPath, Args: spec.Args, Version: spec.Version}
+}
+
+func (p *PythonProvisioner) Install(ctx context.Context, progress func(Progress)) Resolution {
+	if progress == nil {
+		progress = func(Progress) {}
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if r := p.Resolve(); r.State == StateAvailable { // a concurrent installer may have finished
+		return r
+	}
+
+	_, artifacts, ok := PlatformArtifacts("python", p.goos, p.goarch)
+	if !ok {
+		if uv, uerr := p.lookUV(); uerr == nil {
+			return p.installViaUV(ctx, uv, progress)
+		}
+		return Resolution{State: StateUnsupported, Err: errors.New("no managed catalog entry for platform and uv not found")}
+	}
+	if uv, uerr := p.lookUV(); uerr == nil {
+		if r := p.installViaUV(ctx, uv, progress); r.State == StateAvailable {
+			return r
+		}
+		// fall through to manual on uv failure
+	}
+	return p.installManual(ctx, artifacts, progress)
+}
+
+func (p *PythonProvisioner) lookUV() (string, error) {
+	if p.deps.LookPath == nil || p.deps.RunUV == nil {
+		return "", errors.New("uv path disabled")
+	}
+	return p.deps.LookPath("uv")
+}
+
+// installViaUV is implemented in Task 6. Stub returns non-available so Install
+// falls through to the manual path.
+func (p *PythonProvisioner) installViaUV(ctx context.Context, uv string, progress func(Progress)) Resolution {
+	// Task 6 implements this.
+	return Resolution{State: StateOffline, Err: errors.New("uv path not yet implemented")}
+}
+
+// installManual downloads+verifies+unzips wheels into a staging dir, writes
+// launch.json (relative paths), then atomically renames staging -> versionDir.
+func (p *PythonProvisioner) installManual(ctx context.Context, artifacts []Artifact, progress func(Progress)) Resolution {
+	progress(Progress{Phase: "download", Pct: 0})
+	parent := filepath.Dir(p.versionDir())
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+	staging, err := os.MkdirTemp(parent, ".staging-*")
+	if err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+	defer os.RemoveAll(staging) // no-op after successful rename
+
+	for i, a := range artifacts {
+		if err := p.fetch(ctx, a, staging); err != nil {
+			var ce *ChecksumError
+			if errors.As(err, &ce) {
+				return Resolution{State: StateChecksumFailed, Err: err}
+			}
+			return Resolution{State: StateOffline, Err: err}
+		}
+		progress(Progress{Phase: "extract", Pct: (i + 1) * 100 / len(artifacts)})
+	}
+
+	nodeRel, jsRel, err := manualLaunchTargets(staging, p.goos)
+	if err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+	spec := launchSpec{Path: nodeRel, Args: []string{jsRel, "--stdio"}, Version: pythonCatalogEntry.Version, Abs: false}
+	if err := writeLaunchSpec(staging, spec); err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+
+	_ = os.RemoveAll(p.versionDir()) // clear any partial prior dir
+	if err := os.Rename(staging, p.versionDir()); err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+	progress(Progress{Phase: "done", Pct: 100})
+	return p.Resolve()
+}
+
+func (p *PythonProvisioner) fetch(ctx context.Context, a Artifact, destDir string) error {
+	if p.deps.Fetch != nil {
+		return p.deps.Fetch(ctx, a, destDir)
+	}
+	return defaultFetch(ctx, a, destDir)
+}
+
+// manualLaunchTargets locates the node binary and langserver entry inside an
+// extracted staging dir, returning their paths RELATIVE to staging.
+func manualLaunchTargets(staging, goos string) (nodeRel, jsRel string, err error) {
+	jsRel = filepath.Join("basedpyright", "langserver.index.js")
+	if _, statErr := os.Stat(filepath.Join(staging, jsRel)); statErr != nil {
+		return "", "", errors.New("basedpyright langserver entry not found after extract")
+	}
+	nodeName := "node"
+	if goos == "windows" {
+		nodeName = "node.exe"
+	}
+	found, ferr := findFile(staging, nodeName)
+	if ferr != nil || found == "" {
+		return "", "", errors.New("node binary not found after extract")
+	}
+	rel, relErr := filepath.Rel(staging, found)
+	if relErr != nil {
+		return "", "", relErr
+	}
+	return rel, jsRel, nil
+}
+
+func findFile(root, name string) (string, error) {
+	var hit string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && d.Name() == name {
+			hit = path
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return hit, err
+}
+
+func readLaunchSpec(dir string) (launchSpec, error) {
+	var s launchSpec
+	b, err := os.ReadFile(filepath.Join(dir, "launch.json"))
+	if err != nil {
+		return s, err
+	}
+	err = json.Unmarshal(b, &s)
+	return s, err
+}
+
+func writeLaunchSpec(dir string, s launchSpec) error {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "launch.json"), b, 0o644)
+}

--- a/internal/lsp/provision/python.go
+++ b/internal/lsp/provision/python.go
@@ -96,11 +96,59 @@ func (p *PythonProvisioner) lookUV() (string, error) {
 	return p.deps.LookPath("uv")
 }
 
-// installViaUV is implemented in Task 6. Stub returns non-available so Install
-// falls through to the manual path.
+// installViaUV installs basedpyright with uv directly into the version dir.
+// uv shims carry absolute internal paths, so we cannot stage+rename; instead we
+// clear the version dir, install, and write launch.json (absolute) as the last,
+// commit step. Any error returns a non-available Resolution so Install can fall
+// back to the manual path. Env overrides are process-scoped — the user's
+// environment and PATH are never modified.
 func (p *PythonProvisioner) installViaUV(ctx context.Context, uv string, progress func(Progress)) Resolution {
-	// Task 6 implements this.
-	return Resolution{State: StateOffline, Err: errors.New("uv path not yet implemented")}
+	progress(Progress{Phase: "download", Pct: 0})
+	vdir := p.versionDir()
+	if err := os.RemoveAll(vdir); err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+	if err := os.MkdirAll(vdir, 0o755); err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+	toolDir := filepath.Join(vdir, "tool")
+	binDir := filepath.Join(vdir, "bin")
+	cacheDir := filepath.Join(vdir, "cache")
+	env := append(os.Environ(),
+		"UV_TOOL_DIR="+toolDir,
+		"UV_TOOL_BIN_DIR="+binDir,
+		"UV_CACHE_DIR="+cacheDir,
+		"UV_NO_MODIFY_PATH=1",
+	)
+	args := []string{"tool", "install", "--bin-dir", binDir, "basedpyright==" + pythonCatalogEntry.Version}
+	if err := p.deps.RunUV(ctx, uv, args, env); err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+
+	shim := filepath.Join(binDir, "basedpyright-langserver")
+	if p.goos == "windows" {
+		shim += ".exe"
+	}
+	if _, err := os.Stat(shim); err != nil {
+		return Resolution{State: StateOffline, Err: errors.New("uv install produced no basedpyright-langserver shim")}
+	}
+	spec := launchSpec{Path: shim, Args: []string{"--stdio"}, Version: pythonCatalogEntry.Version, Abs: true}
+	if err := writeLaunchSpec(vdir, spec); err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+	progress(Progress{Phase: "done", Pct: 100})
+	return p.Resolve()
+}
+
+// uvBinDir extracts the --bin-dir value from uv args (shared by impl + test so
+// they agree on the flag name).
+func uvBinDir(args []string) string {
+	for i, a := range args {
+		if a == "--bin-dir" && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
 }
 
 // installManual downloads+verifies+unzips wheels into a staging dir, writes

--- a/internal/lsp/provision/python_test.go
+++ b/internal/lsp/provision/python_test.go
@@ -1,0 +1,79 @@
+package provision
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(path, body string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(body), 0o755)
+}
+
+func TestPython_Resolve_missingThenAvailable(t *testing.T) {
+	cache := t.TempDir()
+	p := NewPythonProvisioner(cache, "darwin", "arm64", PythonDeps{
+		LookPath: func(string) (string, error) { return "", os.ErrNotExist }, // no uv
+		Fetch: func(_ context.Context, a Artifact, destDir string) error {
+			if a.Kind == "node-wheel" {
+				return writeFile(filepath.Join(destDir, "nodejs_wheel", "node"), "#!node")
+			}
+			return writeFile(filepath.Join(destDir, "basedpyright", "langserver.index.js"), "ls")
+		},
+	})
+
+	if r := p.Resolve(); r.State != StateMissing {
+		t.Fatalf("pre-install Resolve = %v, want missing", r.State)
+	}
+	r := p.Install(context.Background(), func(Progress) {})
+	if r.State != StateAvailable {
+		t.Fatalf("Install = %v (%v), want available", r.State, r.Err)
+	}
+	got := p.Resolve()
+	if got.State != StateAvailable {
+		t.Fatalf("post-install Resolve = %v", got.State)
+	}
+	if _, err := os.Stat(got.Path); err != nil {
+		t.Errorf("launch path %q not on disk: %v", got.Path, err)
+	}
+	if len(got.Args) == 0 || got.Args[len(got.Args)-1] != "--stdio" {
+		t.Errorf("args = %v, want trailing --stdio", got.Args)
+	}
+	if _, err := os.Stat(filepath.Join(cache, "python", "1.39.9", "launch.json")); err != nil {
+		t.Errorf("launch.json missing: %v", err)
+	}
+}
+
+func TestPython_Install_unsupportedPlatform(t *testing.T) {
+	p := NewPythonProvisioner(t.TempDir(), "plan9", "mips", PythonDeps{
+		LookPath: func(string) (string, error) { return "", os.ErrNotExist },
+	})
+	if r := p.Install(context.Background(), func(Progress) {}); r.State != StateUnsupported {
+		t.Fatalf("Install = %v, want unsupported", r.State)
+	}
+}
+
+func TestPython_Install_fetchOffline(t *testing.T) {
+	p := NewPythonProvisioner(t.TempDir(), "darwin", "arm64", PythonDeps{
+		LookPath: func(string) (string, error) { return "", os.ErrNotExist },
+		Fetch:    func(context.Context, Artifact, string) error { return errors.New("dial tcp: offline") },
+	})
+	if r := p.Install(context.Background(), func(Progress) {}); r.State != StateOffline {
+		t.Fatalf("Install = %v, want offline", r.State)
+	}
+}
+
+func TestPython_Install_checksumFailMapsToChecksumState(t *testing.T) {
+	p := NewPythonProvisioner(t.TempDir(), "darwin", "arm64", PythonDeps{
+		LookPath: func(string) (string, error) { return "", os.ErrNotExist },
+		Fetch:    func(context.Context, Artifact, string) error { return &ChecksumError{URL: "u", Got: "a", Want: "b"} },
+	})
+	if r := p.Install(context.Background(), func(Progress) {}); r.State != StateChecksumFailed {
+		t.Fatalf("Install = %v, want checksum-failed", r.State)
+	}
+}

--- a/internal/lsp/provision/python_uv_test.go
+++ b/internal/lsp/provision/python_uv_test.go
@@ -1,0 +1,74 @@
+package provision
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPython_installViaUV(t *testing.T) {
+	cache := t.TempDir()
+	p := NewPythonProvisioner(cache, "darwin", "arm64", PythonDeps{
+		LookPath: func(name string) (string, error) {
+			if name == "uv" {
+				return "/usr/local/bin/uv", nil
+			}
+			return "", os.ErrNotExist
+		},
+		RunUV: func(_ context.Context, uv string, args, env []string) error {
+			// Simulate uv creating the langserver shim in the bin dir it was told to use.
+			binDir := uvBinDir(args)
+			if binDir == "" {
+				t.Fatalf("no --bin-dir in uv args: %v", args)
+			}
+			shim := filepath.Join(binDir, "basedpyright-langserver")
+			return writeFile(shim, "#!/bin/sh\n# uv shim")
+		},
+	})
+
+	r := p.Install(context.Background(), func(Progress) {})
+	if r.State != StateAvailable {
+		t.Fatalf("Install via uv = %v (%v)", r.State, r.Err)
+	}
+	if filepath.Base(r.Path) != "basedpyright-langserver" {
+		t.Errorf("launch path = %q, want basedpyright-langserver shim", r.Path)
+	}
+	if len(r.Args) != 1 || r.Args[0] != "--stdio" {
+		t.Errorf("args = %v, want [--stdio]", r.Args)
+	}
+	spec, err := readLaunchSpec(p.versionDir())
+	if err != nil || !spec.Abs {
+		t.Errorf("uv launch.json should be absolute: %+v err=%v", spec, err)
+	}
+}
+
+func TestPython_installViaUV_failureFallsThroughToManual(t *testing.T) {
+	cache := t.TempDir()
+	p := NewPythonProvisioner(cache, "darwin", "arm64", PythonDeps{
+		LookPath: func(name string) (string, error) {
+			if name == "uv" {
+				return "/usr/local/bin/uv", nil
+			}
+			return "", os.ErrNotExist
+		},
+		RunUV: func(context.Context, string, []string, []string) error {
+			return os.ErrPermission // uv fails
+		},
+		Fetch: func(_ context.Context, a Artifact, destDir string) error {
+			if a.Kind == "node-wheel" {
+				return writeFile(filepath.Join(destDir, "nodejs_wheel", "node"), "#!node")
+			}
+			return writeFile(filepath.Join(destDir, "basedpyright", "langserver.index.js"), "ls")
+		},
+	})
+	r := p.Install(context.Background(), func(Progress) {})
+	if r.State != StateAvailable {
+		t.Fatalf("expected manual fallback to succeed, got %v (%v)", r.State, r.Err)
+	}
+	// manual path stores a relative launch spec
+	spec, _ := readLaunchSpec(p.versionDir())
+	if spec.Abs {
+		t.Errorf("manual fallback should write a relative launch spec, got abs")
+	}
+}

--- a/internal/lsp/provision/types.go
+++ b/internal/lsp/provision/types.go
@@ -1,0 +1,42 @@
+// Package provision downloads and caches pinned language servers under
+// ~/.firn/servers/<family>/<version>/ so LSP works without any manual install.
+// It never mutates the user's global env or PATH.
+package provision
+
+import "context"
+
+// ResolveState classifies a managed-server lookup so the manager can map it to
+// a ServerStatus setup state without re-deriving anything.
+type ResolveState string
+
+const (
+	StateMissing        ResolveState = "missing"           // not installed, install not yet attempted
+	StateAvailable      ResolveState = "managed-available" // installed + verified; Path/Args set
+	StateInstalling     ResolveState = "installing"        // install in flight
+	StateOffline        ResolveState = "offline"           // network/download failure
+	StateChecksumFailed ResolveState = "checksum-failed"   // artifact hash mismatch (security stop)
+	StateUnsupported    ResolveState = "unsupported"       // no provisioner/catalog entry for this platform
+)
+
+// Resolution is the outcome of Resolve or Install.
+type Resolution struct {
+	State   ResolveState
+	Path    string   // launch command (cached node, or basedpyright-langserver shim)
+	Args    []string // launch args (e.g. [<langserver.index.js>, "--stdio"] or ["--stdio"])
+	Version string
+	Err     error // populated for offline/checksum-failed/unsupported
+}
+
+// Progress reports coarse install progress. Phase is one of
+// "download" | "verify" | "extract" | "done".
+type Progress struct {
+	Phase string
+	Pct   int
+}
+
+// Provisioner provisions one server family into the managed cache.
+type Provisioner interface {
+	Family() string
+	Resolve() Resolution // cache-only; never hits network
+	Install(ctx context.Context, progress func(Progress)) Resolution
+}

--- a/internal/lsp/provision/types_test.go
+++ b/internal/lsp/provision/types_test.go
@@ -1,0 +1,20 @@
+package provision
+
+import "testing"
+
+func TestResolveStateConstants(t *testing.T) {
+	// Guards against accidental value drift — manager maps on these strings.
+	cases := map[ResolveState]string{
+		StateMissing:        "missing",
+		StateAvailable:      "managed-available",
+		StateInstalling:     "installing",
+		StateOffline:        "offline",
+		StateChecksumFailed: "checksum-failed",
+		StateUnsupported:    "unsupported",
+	}
+	for got, want := range cases {
+		if string(got) != want {
+			t.Errorf("state = %q, want %q", got, want)
+		}
+	}
+}

--- a/internal/lsp/pythonenv/discover.go
+++ b/internal/lsp/pythonenv/discover.go
@@ -1,0 +1,87 @@
+package pythonenv
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// Runner executes a command in projectRoot and returns trimmed stdout.
+// Injected so DiscoverInterpreter stays testable without real uv/poetry.
+type Runner func(ctx context.Context, name string, args ...string) (string, error)
+
+// DiscoverInterpreter runs uv/poetry to locate the project interpreter, but
+// only when the matching lockfile/config marker is present. Returns ok=false
+// when no marker is present, the tool fails, or the result is not a real
+// executable. source is "uv" or "poetry".
+func DiscoverInterpreter(ctx context.Context, projectRoot string, run Runner) (string, string, bool) {
+	if projectRoot == "" || run == nil {
+		return "", "", false
+	}
+	if hasUVMarker(projectRoot) {
+		if out, err := run(ctx, "uv", "python", "find", "--directory", projectRoot); err == nil {
+			if p := validInterpreter(strings.TrimSpace(out)); p != "" {
+				return p, "uv", true
+			}
+		}
+	}
+	if hasPoetryMarker(projectRoot) {
+		if out, err := run(ctx, "poetry", "env", "info", "-p", "--directory", projectRoot); err == nil {
+			if p := interpreterUnderEnvRoot(strings.TrimSpace(out)); p != "" {
+				return p, "poetry", true
+			}
+		}
+	}
+	return "", "", false
+}
+
+func hasUVMarker(root string) bool {
+	if fileExists(filepath.Join(root, "uv.lock")) {
+		return true
+	}
+	return pyprojectHasTable(root, "tool.uv")
+}
+
+func hasPoetryMarker(root string) bool {
+	if fileExists(filepath.Join(root, "poetry.lock")) {
+		return true
+	}
+	return pyprojectHasTable(root, "tool.poetry")
+}
+
+func pyprojectHasTable(root, table string) bool {
+	b, err := os.ReadFile(filepath.Join(root, "pyproject.toml"))
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(b), "["+table+"]")
+}
+
+// interpreterUnderEnvRoot turns a poetry env root into its python executable.
+func interpreterUnderEnvRoot(envRoot string) string {
+	if envRoot == "" {
+		return ""
+	}
+	rel := filepath.Join("bin", "python")
+	if runtime.GOOS == "windows" {
+		rel = filepath.Join("Scripts", "python.exe")
+	}
+	return validInterpreter(filepath.Join(envRoot, rel))
+}
+
+func validInterpreter(p string) string {
+	if p == "" {
+		return ""
+	}
+	if info, err := os.Stat(p); err == nil && !info.IsDir() {
+		return p
+	}
+	return ""
+}
+
+func fileExists(p string) bool {
+	info, err := os.Stat(p)
+	return err == nil && !info.IsDir()
+}

--- a/internal/lsp/pythonenv/discover_test.go
+++ b/internal/lsp/pythonenv/discover_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestDiscoverInterpreter_uv(t *testing.T) {
 	root := t.TempDir()
-	os.WriteFile(filepath.Join(root, "uv.lock"), []byte(""), 0o644)
+	_ = os.WriteFile(filepath.Join(root, "uv.lock"), []byte(""), 0o644)
 	interp := filepath.Join(root, ".venv", "bin", "python")
-	os.MkdirAll(filepath.Dir(interp), 0o755)
-	os.WriteFile(interp, []byte("#!py"), 0o755)
+	_ = os.MkdirAll(filepath.Dir(interp), 0o755)
+	_ = os.WriteFile(interp, []byte("#!py"), 0o755)
 
 	run := func(_ context.Context, name string, args ...string) (string, error) {
 		if name == "uv" {
@@ -39,11 +39,11 @@ func TestDiscoverInterpreter_noMarkers(t *testing.T) {
 
 func TestDiscoverInterpreter_poetry(t *testing.T) {
 	root := t.TempDir()
-	os.WriteFile(filepath.Join(root, "poetry.lock"), []byte(""), 0o644)
+	_ = os.WriteFile(filepath.Join(root, "poetry.lock"), []byte(""), 0o644)
 	envRoot := t.TempDir()
 	interp := filepath.Join(envRoot, "bin", "python")
-	os.MkdirAll(filepath.Dir(interp), 0o755)
-	os.WriteFile(interp, []byte("#!py"), 0o755)
+	_ = os.MkdirAll(filepath.Dir(interp), 0o755)
+	_ = os.WriteFile(interp, []byte("#!py"), 0o755)
 	run := func(_ context.Context, name string, args ...string) (string, error) {
 		if name == "poetry" {
 			return envRoot, nil // `poetry env info -p` prints the env root
@@ -58,7 +58,7 @@ func TestDiscoverInterpreter_poetry(t *testing.T) {
 
 func TestDiscoverInterpreter_resultNotExecutableRejected(t *testing.T) {
 	root := t.TempDir()
-	os.WriteFile(filepath.Join(root, "uv.lock"), []byte(""), 0o644)
+	_ = os.WriteFile(filepath.Join(root, "uv.lock"), []byte(""), 0o644)
 	run := func(context.Context, string, ...string) (string, error) {
 		return filepath.Join(root, "does-not-exist"), nil
 	}

--- a/internal/lsp/pythonenv/discover_test.go
+++ b/internal/lsp/pythonenv/discover_test.go
@@ -1,0 +1,68 @@
+package pythonenv
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDiscoverInterpreter_uv(t *testing.T) {
+	root := t.TempDir()
+	os.WriteFile(filepath.Join(root, "uv.lock"), []byte(""), 0o644)
+	interp := filepath.Join(root, ".venv", "bin", "python")
+	os.MkdirAll(filepath.Dir(interp), 0o755)
+	os.WriteFile(interp, []byte("#!py"), 0o755)
+
+	run := func(_ context.Context, name string, args ...string) (string, error) {
+		if name == "uv" {
+			return interp, nil
+		}
+		return "", os.ErrNotExist
+	}
+	got, source, ok := DiscoverInterpreter(context.Background(), root, run)
+	if !ok || got != interp || source != "uv" {
+		t.Fatalf("got (%q,%q,%v)", got, source, ok)
+	}
+}
+
+func TestDiscoverInterpreter_noMarkers(t *testing.T) {
+	called := false
+	run := func(context.Context, string, ...string) (string, error) { called = true; return "", nil }
+	if _, _, ok := DiscoverInterpreter(context.Background(), t.TempDir(), run); ok {
+		t.Error("expected ok=false with no markers")
+	}
+	if called {
+		t.Error("runner must not be invoked without markers")
+	}
+}
+
+func TestDiscoverInterpreter_poetry(t *testing.T) {
+	root := t.TempDir()
+	os.WriteFile(filepath.Join(root, "poetry.lock"), []byte(""), 0o644)
+	envRoot := t.TempDir()
+	interp := filepath.Join(envRoot, "bin", "python")
+	os.MkdirAll(filepath.Dir(interp), 0o755)
+	os.WriteFile(interp, []byte("#!py"), 0o755)
+	run := func(_ context.Context, name string, args ...string) (string, error) {
+		if name == "poetry" {
+			return envRoot, nil // `poetry env info -p` prints the env root
+		}
+		return "", os.ErrNotExist
+	}
+	got, source, ok := DiscoverInterpreter(context.Background(), root, run)
+	if !ok || got != interp || source != "poetry" {
+		t.Fatalf("got (%q,%q,%v)", got, source, ok)
+	}
+}
+
+func TestDiscoverInterpreter_resultNotExecutableRejected(t *testing.T) {
+	root := t.TempDir()
+	os.WriteFile(filepath.Join(root, "uv.lock"), []byte(""), 0o644)
+	run := func(context.Context, string, ...string) (string, error) {
+		return filepath.Join(root, "does-not-exist"), nil
+	}
+	if _, _, ok := DiscoverInterpreter(context.Background(), root, run); ok {
+		t.Error("expected ok=false when returned interpreter does not exist")
+	}
+}

--- a/internal/lsp/registry.go
+++ b/internal/lsp/registry.go
@@ -7,7 +7,25 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"firn/internal/lsp/provision"
 )
+
+// ServerMissError is returned when no server binary could be resolved. When
+// Provisionable is true a managed provisioner exists for the family, so the
+// manager can trigger an async install instead of surfacing a raw error.
+type ServerMissError struct {
+	Family        string
+	Provisionable bool
+	Hint          string // human guidance for the unprovisionable case
+}
+
+func (e *ServerMissError) Error() string {
+	if e.Hint != "" {
+		return e.Hint
+	}
+	return fmt.Sprintf("no language server found for %q", e.Family)
+}
 
 // ServerConfig describes how to launch a language server for a given language family.
 type ServerConfig struct {
@@ -25,11 +43,34 @@ type ServerConfig struct {
 }
 
 // Registry maps file extensions and language contexts to server configurations.
-type Registry struct{}
+type Registry struct {
+	provisioners map[string]provision.Provisioner
+}
 
 // NewRegistry creates a new language server registry.
 func NewRegistry() *Registry {
-	return &Registry{}
+	return &Registry{provisioners: map[string]provision.Provisioner{}}
+}
+
+// SetProvisioners wires managed provisioners (called once by the manager).
+func (r *Registry) SetProvisioners(p map[string]provision.Provisioner) { r.provisioners = p }
+
+// managedOrMiss consults the family provisioner's cache (Resolve, never network).
+// When a managed binary is present it returns a ServerConfig; otherwise a typed
+// ServerMissError whose Provisionable reflects whether a provisioner exists.
+func (r *Registry) managedOrMiss(family, projectRoot, hint string) (*ServerConfig, error) {
+	prov, ok := r.provisioners[family]
+	if ok {
+		if res := prov.Resolve(); res.State == provision.StateAvailable {
+			return &ServerConfig{
+				LanguageFamily: family,
+				Command:        res.Path,
+				Args:           res.Args,
+				Dir:            projectRoot,
+			}, nil
+		}
+	}
+	return nil, &ServerMissError{Family: family, Provisionable: ok, Hint: hint}
 }
 
 // langInfo pairs an LSP languageId with its server family.
@@ -127,11 +168,9 @@ func (r *Registry) resolveTypeScriptServer(projectRoot string) (*ServerConfig, e
 	// 2. Fall back to system PATH
 	path, err := exec.LookPath(binary)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"typescript-language-server not found: install it with " +
-				"\"npm install -g typescript-language-server typescript\" " +
-				"or add it as a project dependency",
-		)
+		return nil, &ServerMissError{Family: "typescript", Provisionable: false, Hint: "typescript-language-server not found: install it with " +
+			"\"npm install -g typescript-language-server typescript\" " +
+			"or add it as a project dependency"}
 	}
 
 	args := []string{"--stdio"}
@@ -170,11 +209,9 @@ func (r *Registry) resolveGoServer(projectRoot string) (*ServerConfig, error) {
 	if err != nil {
 		path = findGoBinary("gopls")
 		if path == "" {
-			return nil, fmt.Errorf(
-				"gopls not found: install it with " +
-					"\"go install golang.org/x/tools/gopls@latest\" " +
-					"or add it to PATH",
-			)
+			return nil, &ServerMissError{Family: "go", Provisionable: false, Hint: "gopls not found: install it with " +
+				"\"go install golang.org/x/tools/gopls@latest\" " +
+				"or add it to PATH"}
 		}
 	}
 
@@ -273,21 +310,18 @@ func (r *Registry) resolvePythonServer(projectRoot string) (*ServerConfig, error
 		}, nil
 	}
 
-	path, err := exec.LookPath(binary)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"pyright-langserver not found: install it with " +
-				"\"npm install -g pyright\", add pyright as a project dependency, " +
-				"or activate a virtual environment that provides pyright-langserver",
-		)
+	if path, err := exec.LookPath(binary); err == nil {
+		return &ServerConfig{
+			LanguageFamily: "python",
+			Command:        path,
+			Args:           []string{"--stdio"},
+			Dir:            projectRoot,
+		}, nil
 	}
 
-	return &ServerConfig{
-		LanguageFamily: "python",
-		Command:        path,
-		Args:           []string{"--stdio"},
-		Dir:            projectRoot,
-	}, nil
+	return r.managedOrMiss("python", projectRoot,
+		"Python language server not found. Firn can install it automatically, "+
+			"or add basedpyright/pyright as a project dependency.")
 }
 
 func resolvePythonVirtualEnvBinary(projectRoot, binary string) (string, bool) {

--- a/internal/lsp/registry_test.go
+++ b/internal/lsp/registry_test.go
@@ -1,10 +1,14 @@
 package lsp
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"firn/internal/lsp/provision"
 )
 
 // fakeTSLSBin creates a fake typescript-language-server executable in a temp
@@ -138,9 +142,17 @@ func TestResolveTypeScriptServer_NotFound(t *testing.T) {
 		t.Fatal("expected error when typescript-language-server is not found")
 	}
 
-	// Error message should contain install instructions
-	if !contains(err.Error(), "npm install") {
-		t.Errorf("error message should contain install instructions, got: %s", err.Error())
+	// Typed miss: no managed provisioner for typescript yet, so unprovisionable,
+	// and the actionable install hint must be preserved.
+	var miss *ServerMissError
+	if !errors.As(err, &miss) {
+		t.Fatalf("err = %v, want *ServerMissError", err)
+	}
+	if miss.Provisionable {
+		t.Error("typescript has no managed provisioner; expected Provisionable=false")
+	}
+	if !contains(miss.Hint, "npm install") {
+		t.Errorf("hint should contain install instructions, got: %s", miss.Hint)
 	}
 }
 
@@ -299,6 +311,52 @@ func TestFindGoBinary_SkipsNonExecutableAndUsesLaterCandidate(t *testing.T) {
 	found := findGoBinary("gopls")
 	if found != wantPath {
 		t.Errorf("findGoBinary(gopls) = %q, want %q (non-executable candidate should be skipped)", found, wantPath)
+	}
+}
+
+type fakeProv struct{ res provision.Resolution }
+
+func (f fakeProv) Family() string                { return "python" }
+func (f fakeProv) Resolve() provision.Resolution { return f.res }
+func (f fakeProv) Install(context.Context, func(provision.Progress)) provision.Resolution {
+	return f.res
+}
+
+func TestManagedOrMiss_available(t *testing.T) {
+	r := NewRegistry()
+	r.SetProvisioners(map[string]provision.Provisioner{
+		"python": fakeProv{res: provision.Resolution{State: provision.StateAvailable, Path: "/cache/node", Args: []string{"/cache/ls.js", "--stdio"}}},
+	})
+	cfg, err := r.managedOrMiss("python", "/proj", "hint")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if cfg.Command != "/cache/node" || len(cfg.Args) != 2 || cfg.Dir != "/proj" {
+		t.Errorf("cfg = %+v", cfg)
+	}
+}
+
+func TestManagedOrMiss_typedMissProvisionable(t *testing.T) {
+	r := NewRegistry()
+	r.SetProvisioners(map[string]provision.Provisioner{
+		"python": fakeProv{res: provision.Resolution{State: provision.StateMissing}},
+	})
+	_, err := r.managedOrMiss("python", "/proj", "hint")
+	var miss *ServerMissError
+	if !errors.As(err, &miss) {
+		t.Fatalf("err = %v, want *ServerMissError", err)
+	}
+	if !miss.Provisionable {
+		t.Error("expected Provisionable=true when a provisioner exists")
+	}
+}
+
+func TestManagedOrMiss_noProvisioner(t *testing.T) {
+	r := NewRegistry()
+	_, err := r.managedOrMiss("go", "/proj", "hint")
+	var miss *ServerMissError
+	if !errors.As(err, &miss) || miss.Provisionable {
+		t.Fatalf("want unprovisionable ServerMissError, got %v", err)
 	}
 }
 

--- a/internal/workspace/store_test.go
+++ b/internal/workspace/store_test.go
@@ -519,3 +519,36 @@ func TestSaveLoad_ActiveWorkspaceID(t *testing.T) {
 		t.Errorf("ActiveWorkspaceID = %q, want %q", loaded.ActiveWorkspaceID, "frontend")
 	}
 }
+
+func TestState_LSPOverride_roundTrip(t *testing.T) {
+	store := NewStore(newMockFS(), "/home/.firn/workspaces")
+	state := State{
+		WorkspacePath: "/ws",
+		WorkspaceName: "ws",
+		LSP: LSPState{
+			InterpreterOverride: "/ws/.venv/bin/python",
+			ServerPathOverride:  map[string]string{"python": "/usr/local/bin/pyright"},
+		},
+	}
+
+	if err := store.Save(state); err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+	loaded, err := store.Load("/ws")
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if loaded.LSP.InterpreterOverride != "/ws/.venv/bin/python" {
+		t.Errorf("InterpreterOverride = %q, want %q", loaded.LSP.InterpreterOverride, "/ws/.venv/bin/python")
+	}
+	if loaded.LSP.ServerPathOverride["python"] != "/usr/local/bin/pyright" {
+		t.Errorf("ServerPathOverride[python] = %q, want %q", loaded.LSP.ServerPathOverride["python"], "/usr/local/bin/pyright")
+	}
+}
+
+func TestState_absentLSP_isZeroValue(t *testing.T) {
+	var st State
+	if st.LSP.InterpreterOverride != "" || st.LSP.ServerPathOverride != nil {
+		t.Error("zero State should have empty LSPState")
+	}
+}

--- a/internal/workspace/types.go
+++ b/internal/workspace/types.go
@@ -22,6 +22,15 @@ type State struct {
 	ActiveSidebar     string      `json:"activeSidebar"`
 	HiddenProfileIDs  []string    `json:"hiddenProfileIds,omitempty"`
 	ActiveWorkspaceID string      `json:"activeWorkspaceId,omitempty"`
+	LSP               LSPState    `json:"lsp,omitempty"`
+}
+
+// LSPState holds machine-local LSP overrides for a workspace. Persisted under
+// ~/.firn/workspaces (never in the repo) because interpreter/server paths are
+// machine-specific.
+type LSPState struct {
+	InterpreterOverride string            `json:"interpreterOverride,omitempty"`
+	ServerPathOverride  map[string]string `json:"serverPathOverride,omitempty"` // family -> path (reserved)
 }
 
 // Layout captures panel sizes and collapsed states.


### PR DESCRIPTION
## Summary

Implements the provisioning half of #112 (LSP managed servers). Phase 1 (env detection/config-forwarding/setup card) already shipped; this adds:

- Managed server provisioning: on a resolve-miss for the active workspace, download a pinned server into ~/.firn/servers/<family>/<version>/ with no manual install and no raw error string.
- Command-backed uv/poetry interpreter discovery, layered on the existing pure detector.
- A trimmed, doctor-backed interpreter-select affordance on the setup card, with per-workspace persistence.

Python is fully wired (basedpyright); the provisioner framework is family-pluggable so Go/TS/Rust can follow.

## What is in here (20 commits, TDD per task)

New package internal/lsp/provision:
- Artifact-type-aware pinned catalog (basedpyright 1.39.9 + nodejs-wheel-binaries 22.20.0 per OS/arch). basedpyright ships no standalone binary (py3-none-any wheel + node dep), so the catalog models wheel+node, not GOOS/GOARCH->binary.
- Secure installer: HTTPS download, SHA256 verify-before-rename, zip-slip-guarded + symlink-skipping wheel extraction, atomic staging->rename, single-flight per family, jailed to ~/.firn. Never mutates the user's global env or PATH.
- PythonProvisioner: uv fast-path (uv tool install, process-scoped env, UV_NO_MODIFY_PATH) with a pinned manual wheel+node fallback so a clean machine with neither the server nor uv still gets a working server.

Detection + wiring:
- internal/lsp/pythonenv/discover.go: marker-gated uv/poetry interpreter discovery (injected runner; detector stays pure/hermetic).
- registry: managed rung + typed ServerMissError{Family,Provisionable,Hint} replacing bare not-found strings.
- manager: async provisioning orchestration, new setup states provisioning|offline|provision_failed (+ ProvisionPct), interpreter-override map wired into config_provider, Doctor()/SetInterpreterOverride()/ClearInterpreterOverride()/RetryProvision().
- config_provider: interpreter override (highest precedence) + uv/poetry discovery overlay on low-confidence detection.
- workspace.State.LSP: per-workspace machine-local interpreter override (persisted under ~/.firn/workspaces, not the repo).

App + frontend:
- app.go bindings LSPDoctor / LSPSetInterpreter / LSPClearInterpreter / LSPRetryProvision; PythonProvisioner constructed + wired; override persisted + seeded on workspace switch. Regenerated frontend/wailsjs.
- LSPSetupCard is now interactive (Retry / Select interpreter / Reset) with an info tone for provisioning; setup-notice + store extended for the new states.

## Acceptance criteria (#112)

- Missing server auto-provisioned (managed, pinned), no manual install, no raw error string.
- Interpreter/venv auto-detected and forwarded; uv/poetry discovery upgrades low-confidence detection; project config still honored (Phase 1).
- Missing/uninstallable server or interpreter -> actionable, non-blocking card (retry / select interpreter / create venv), not an editor error string.
- Provisioning is lazy (active workspace only) and never writes global env/PATH.
- Plumbing generalizes across families (Python wired; others slot into the same interface).

## Deferred follow-ups (will file as issues)

- Managed provisioning for gopls / tsserver / rust-analyzer (framework is ready).
- Emit configSource "override" so the Reset-to-auto affordance becomes reachable (currently dead-UI; harmless).
- RetryProvision should thread the file's project root rather than re-deriving the workspace root (matters only for nested monorepo Python sub-projects).
- musllinux (Alpine) node wheels in the catalog (currently glibc/manylinux; uv path covers musl).

## Coordination

Built in an isolated worktree alongside #37 (file-tree lazy-load, PR #147), both branched off develop 1398399. Shared surfaces are app.go (new LSP bindings appended at the end of the LSP region) and the regenerated frontend/wailsjs. If #147 merges first, rebase and re-run wails generate module rather than hand-merging the generated files.

## Test plan

- go test ./... : 516 passing across 11 packages (race-clean).
- golangci-lint run ./... (pinned v2.11.4): 0 issues.
- Frontend: jest 1024 passing, tsc --noEmit clean, vite build OK.
- Provisioning, downloader (checksum-mismatch/offline), extraction (zip-slip/exec-bit/symlink), uv fast-path + manual fallback, discovery, override precedence, manager orchestration (-race), and the interactive card are all covered by tests.

Generated with Claude Code (claude.com/claude-code)