### PR TITLE
Fix cross-workspace file-tree contamination on project switch

### DIFF
--- a/frontend/src/__tests__/hooks/useWorkspacePersistence.test.ts
+++ b/frontend/src/__tests__/hooks/useWorkspacePersistence.test.ts
@@ -1,7 +1,11 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { useIDEStore } from '../../stores/ideStore';
 import { filesystem } from '../../../wailsjs/go/models';
-import { clearWorkspaceTreeCache, getCachedWorkspaceTree } from '../../utils/workspaceTreeCache';
+import {
+  clearWorkspaceTreeCache,
+  getCachedWorkspaceTree,
+  setCachedWorkspaceTree,
+} from '../../utils/workspaceTreeCache';
 
 const mockConfirmBeforeCloseReady = jest.fn(() => Promise.resolve());
 let lastSavedWorkspaceState: unknown = null;
@@ -310,5 +314,110 @@ describe('useWorkspacePersistence', () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+
+  it('saves the previous workspace tree, not the live one, when switching workspaces', async () => {
+    const treeA = filesystem.FileEntry.createFrom({
+      name: 'main.go',
+      path: '/workspace/A/main.go',
+      isDir: false,
+      size: 1,
+      modTime: new Date().toISOString(),
+    });
+    const treeB = filesystem.FileEntry.createFrom({
+      name: '_deployment',
+      path: '/workspace/B/_deployment',
+      isDir: true,
+      size: 0,
+      modTime: new Date().toISOString(),
+    });
+
+    // Workspace A is open with its tree cached (as the save subscription would
+    // have done while A was active).
+    setCachedWorkspaceTree('/workspace/A', [treeA]);
+    useIDEStore.setState({
+      workspace: { name: 'A', path: '/workspace/A' },
+      directoryTree: [treeA],
+      isLoadingTree: false,
+    });
+
+    renderHook(() => useWorkspacePersistence());
+    await waitFor(() => expect(mockLoadWorkspaceState).toHaveBeenCalledWith('/workspace/A'));
+    await waitFor(() => expect(useIDEStore.getState().isRestoringWorkspace).toBe(false));
+
+    mockSaveWorkspaceState.mockClear();
+
+    // Simulate openWorkspaceByPath: swap workspace AND live directoryTree to B
+    // in a single store update. This is the moment the switch-flush of A runs.
+    act(() => {
+      useIDEStore.setState({
+        workspace: { name: 'B', path: '/workspace/B' },
+        directoryTree: [treeB],
+        isLoadingTree: false,
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        mockSaveWorkspaceState.mock.calls.some(
+          (c) => (c[0] as { workspacePath: string }).workspacePath === '/workspace/A'
+        )
+      ).toBe(true)
+    );
+
+    const savedForA = mockSaveWorkspaceState.mock.calls
+      .map(
+        (c) =>
+          c[0] as {
+            workspacePath: string;
+            explorer: { treeSnapshot?: filesystem.FileEntry[] };
+          }
+      )
+      .find((s) => s.workspacePath === '/workspace/A');
+
+    // A's persisted snapshot must be A's tree, never B's live tree.
+    expect(savedForA?.explorer.treeSnapshot).toEqual([treeA]);
+  });
+
+  it('ignores a treeSnapshot whose entries are not under the workspace root', async () => {
+    // Simulates disk state already polluted by a prior cross-workspace switch:
+    // firn's saved snapshot actually holds quantum-trader's tree.
+    mockLoadWorkspaceState.mockResolvedValueOnce({
+      workspacePath: '/workspace/firn',
+      workspaceName: 'firn',
+      layout: null,
+      editor: { activeFilePath: '', openFiles: [] },
+      explorer: {
+        expandedPaths: [],
+        rootExpanded: true,
+        treeSnapshot: [
+          filesystem.FileEntry.createFrom({
+            name: '_deployment',
+            path: '/workspace/quantum/_deployment',
+            isDir: true,
+            size: 0,
+            modTime: new Date().toISOString(),
+          }),
+        ],
+      },
+      activeSidebar: 'explorer',
+      hiddenProfileIds: [],
+    });
+
+    useIDEStore.setState({
+      workspace: { name: 'firn', path: '/workspace/firn' },
+      directoryTree: [],
+      isLoadingTree: false,
+    });
+
+    renderHook(() => useWorkspacePersistence());
+
+    await waitFor(() => expect(mockLoadWorkspaceState).toHaveBeenCalledWith('/workspace/firn'));
+    await waitFor(() => expect(useIDEStore.getState().isRestoringWorkspace).toBe(false));
+
+    // The foreign (quantum) snapshot must be ignored, not painted under firn,
+    // and must not poison the in-memory cache for firn.
+    expect(useIDEStore.getState().directoryTree).toEqual([]);
+    expect(getCachedWorkspaceTree('/workspace/firn')).toBeUndefined();
   });
 });

--- a/frontend/src/__tests__/hooks/useWorkspacePersistence.test.ts
+++ b/frontend/src/__tests__/hooks/useWorkspacePersistence.test.ts
@@ -420,4 +420,42 @@ describe('useWorkspacePersistence', () => {
     expect(useIDEStore.getState().directoryTree).toEqual([]);
     expect(getCachedWorkspaceTree('/workspace/firn')).toBeUndefined();
   });
+
+  it('ignores a treeSnapshot whose top-level entries are nested descendants', async () => {
+    mockLoadWorkspaceState.mockResolvedValueOnce({
+      workspacePath: '/repo',
+      workspaceName: 'repo',
+      layout: null,
+      editor: { activeFilePath: '', openFiles: [] },
+      explorer: {
+        expandedPaths: [],
+        rootExpanded: true,
+        treeSnapshot: [
+          filesystem.FileEntry.createFrom({
+            name: 'src',
+            path: '/repo/frontend/src',
+            isDir: true,
+            size: 0,
+            modTime: new Date().toISOString(),
+          }),
+        ],
+      },
+      activeSidebar: 'explorer',
+      hiddenProfileIds: [],
+    });
+
+    useIDEStore.setState({
+      workspace: { name: 'repo', path: '/repo' },
+      directoryTree: [],
+      isLoadingTree: false,
+    });
+
+    renderHook(() => useWorkspacePersistence());
+
+    await waitFor(() => expect(mockLoadWorkspaceState).toHaveBeenCalledWith('/repo'));
+    await waitFor(() => expect(useIDEStore.getState().isRestoringWorkspace).toBe(false));
+
+    expect(useIDEStore.getState().directoryTree).toEqual([]);
+    expect(getCachedWorkspaceTree('/repo')).toBeUndefined();
+  });
 });

--- a/frontend/src/hooks/useWorkspacePersistence.ts
+++ b/frontend/src/hooks/useWorkspacePersistence.ts
@@ -26,7 +26,7 @@ interface CollectWorkspaceOptions {
 }
 
 /**
- * True when every top-level entry of `snapshot` lives under `workspacePath`.
+ * True when every top-level entry of `snapshot` is an immediate child of `workspacePath`.
  * A snapshot whose entries point elsewhere is cross-workspace pollution
  * (a wrong-project tree saved under this path by a buggy prior switch) and
  * must not be applied. Empty snapshots are never "belonging" — there is
@@ -34,7 +34,10 @@ interface CollectWorkspaceOptions {
  */
 function treeSnapshotBelongsTo(snapshot: filesystem.FileEntry[], workspacePath: string): boolean {
   if (!snapshot.length) return false;
-  return snapshot.every((entry) => relativePathFromRoot(entry.path, workspacePath) !== null);
+  return snapshot.every((entry) => {
+    const rel = relativePathFromRoot(entry.path, workspacePath);
+    return rel !== null && rel !== '' && !rel.includes('/');
+  });
 }
 
 /**

--- a/frontend/src/hooks/useWorkspacePersistence.ts
+++ b/frontend/src/hooks/useWorkspacePersistence.ts
@@ -7,7 +7,7 @@ import {
   ReadFile,
 } from '../../wailsjs/go/main/App';
 import { EventsOn } from '../../wailsjs/runtime/runtime';
-import type { workspace } from '../../wailsjs/go/models';
+import type { workspace, filesystem } from '../../wailsjs/go/models';
 import { createEditorFile } from '../utils/editorFile';
 import { pathsReferToSameFile } from '../utils/lspUri';
 import { relativePathFromRoot } from '../utils/workspaceRegions';
@@ -23,6 +23,38 @@ interface WorkspaceIdentity {
 
 interface CollectWorkspaceOptions {
   includeTreeSnapshot?: boolean;
+}
+
+/**
+ * True when every top-level entry of `snapshot` lives under `workspacePath`.
+ * A snapshot whose entries point elsewhere is cross-workspace pollution
+ * (a wrong-project tree saved under this path by a buggy prior switch) and
+ * must not be applied. Empty snapshots are never "belonging" — there is
+ * nothing to paint and applying `[]` would clobber a correct fresh fetch.
+ */
+function treeSnapshotBelongsTo(snapshot: filesystem.FileEntry[], workspacePath: string): boolean {
+  if (!snapshot.length) return false;
+  return snapshot.every((entry) => relativePathFromRoot(entry.path, workspacePath) !== null);
+}
+
+/**
+ * Resolves which directory tree to serialize as the explorer snapshot.
+ *
+ * With an identity override we're flushing a *different* workspace than the
+ * live one (a switch flush). At that moment `state.directoryTree` has already
+ * been swapped to the NEW workspace by openWorkspaceByPath, so serializing it
+ * would persist the wrong project's tree under the old path. Pull the old
+ * workspace's tree from the in-memory cache instead, and return undefined on a
+ * cache miss rather than the wrong live tree.
+ */
+function resolveTreeSnapshot(
+  directoryTree: filesystem.FileEntry[],
+  overrideIdentity?: WorkspaceIdentity
+): filesystem.FileEntry[] | undefined {
+  if (overrideIdentity) {
+    return getCachedWorkspaceTree(overrideIdentity.path);
+  }
+  return directoryTree;
 }
 
 /**
@@ -66,7 +98,9 @@ function collectWorkspaceState(
     explorer: {
       expandedPaths: Array.from(state.expandedPaths),
       rootExpanded: state.isRootExpanded,
-      treeSnapshot: includeTreeSnapshot ? state.directoryTree : undefined,
+      treeSnapshot: includeTreeSnapshot
+        ? resolveTreeSnapshot(state.directoryTree, overrideIdentity)
+        : undefined,
     },
     activeSidebar: state.activeSidebarView,
     hiddenProfileIds: state.hiddenProfileIds,
@@ -144,7 +178,13 @@ async function restoreWorkspaceState(workspacePath: string, signal: AbortSignal)
       if (state.explorer.rootExpanded !== undefined) {
         useIDEStore.setState({ isRootExpanded: state.explorer.rootExpanded });
       }
-      if (state.explorer.treeSnapshot) {
+      // Only apply a snapshot that actually belongs to this workspace. A
+      // foreign snapshot is disk pollution from a prior buggy switch; ignoring
+      // it here self-heals that state — fetchTree then repopulates correctly.
+      if (
+        state.explorer.treeSnapshot &&
+        treeSnapshotBelongsTo(state.explorer.treeSnapshot, workspacePath)
+      ) {
         setCachedWorkspaceTree(workspacePath, state.explorer.treeSnapshot);
         store.setDirectoryTree(state.explorer.treeSnapshot);
       }


### PR DESCRIPTION
## Problem

Switching projects via the header selector (e.g. firn-ide -> quantum-trader -> firn-ide) could render the **wrong project's file tree under the correct project label**, with downstream symptoms: a "Workspace folder not found" workspace and missing Project-view region colors. A cold client reproduced it too, proving the bad state was persisted on disk (`~/.firn` via `SaveWorkspaceState`), not just an in-memory glitch.

## Root cause

Two compounding `treeSnapshot` bugs in `useWorkspacePersistence`:

1. **Write side (pollution).** On a workspace switch the restore effect flushes the OLD workspace before updating its ref, but `collectWorkspaceState` read the live `state.directoryTree` — which `openWorkspaceByPath` had already swapped to the NEW workspace. So the new project's tree was persisted under the **old** project's path.
2. **Read side (blind apply).** `restoreWorkspaceState` applied any persisted `treeSnapshot` with no check that it belonged to the workspace being loaded (and `[]` is truthy), racing/clobbering the correct fresh `fetchTree`. The polluted snapshot won and painted the wrong project.

## Fix (surgical + self-healing)

- `resolveTreeSnapshot`: on a switch flush (identity override present), take the snapshot from the in-memory workspace tree cache for the *old* path instead of the already-swapped live tree; returns `undefined` on a cache miss rather than the wrong tree. Stops new pollution.
- `treeSnapshotBelongsTo`: only apply a restored snapshot when every top-level entry resolves under the workspace root (via the existing `relativePathFromRoot`). This **self-heals existing polluted disk state** — a foreign snapshot is ignored on load and `fetchTree` repopulates the correct tree. Empty snapshots are treated as non-belonging so they never clobber a correct fresh fetch.

## Tests

Added two targeted persistence tests (both written failing first, then made to pass):
- Write side: a switch A->B->A where B's tree is live at flush time asserts A's saved snapshot is A's tree, not B's.
- Read side: a `LoadWorkspaceState` snapshot whose entries are outside `workspacePath` is ignored (tree stays empty, cache not poisoned).

## Verification

- `npx jest` — 1091 passed (114 suites), including the 2 new cases.
- `npx tsc --noEmit` — clean.
- eslint + prettier — clean (pre-commit lint-staged passed).

Not CSS/virtualization (both ruled out during diagnosis — engine-independent state bug).