### PR TITLE
Fix workspace tab active underline striking through the tab name

### DIFF
--- a/frontend/src/components/FileExplorer/WorkspaceTabs.module.css
+++ b/frontend/src/components/FileExplorer/WorkspaceTabs.module.css
@@ -1,10 +1,36 @@
 .tabs {
   display: flex;
+  /* align-items:center keeps tab buttons at their intrinsic height. Without it,
+     the flex default (stretch) lets a first-paint layout — e.g. when a classic
+     "always shown" horizontal scrollbar claims space in an overflowing strip —
+     squash the buttons, dragging the active tab's inset box-shadow underline up
+     into the text (strike-through). Mirrors the immune Terminal .tabBar. */
+  align-items: center;
   gap: 4px;
   padding: 4px 6px;
+  /* flex-shrink:0 stops the sibling tree from compressing the strip;
+     overflow-y:hidden stops a lone overflow-x:auto from computing overflow-y to
+     auto and reserving vertical scrollbar space. */
+  flex-shrink: 0;
   overflow-x: auto;
+  overflow-y: hidden;
   border-bottom: 1px solid var(--surface-border-subtle);
   scrollbar-width: thin;
+}
+
+/* Thin, non-space-consuming horizontal scrollbar even under macOS
+   "Always show scroll bars" (matches Terminal .tabBar). */
+.tabs::-webkit-scrollbar {
+  height: 3px;
+}
+
+.tabs::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.tabs::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--accent) 30%, transparent);
+  border-radius: 3px;
 }
 
 .tab {


### PR DESCRIPTION
## Symptom

On the first render after toggling the file tree from **Project** to **Workspace** view, the active workspace tab's accent underline rendered as a line through the middle of the tab name instead of beneath it. It self-corrected after any subsequent interaction (e.g. clicking another tab). Only reproduced with macOS **"Always show scroll bars"** enabled; the bottom Terminal tabs (same underline technique) were unaffected.

## Root cause

`.tabs` is a flex row using the default `align-items: stretch`. When the four-tab strip overflows horizontally and macOS shows classic (space-consuming) scroll bars, the horizontal scrollbar claims vertical space on the **first layout pass**, shrinking the flex line box below the tab button's intrinsic height. With `stretch`, the buttons are squashed to that shorter height, so the active tab's bottom `box-shadow: inset 0 -2px 0` is dragged up into the text. A later reflow settles the layout — which is why interacting fixed it.

The Terminal `.tabBar` uses the identical box-shadow underline but is immune because it sets `align-items: center`, `flex-shrink: 0`, `overflow-y: hidden`, and a thin styled scrollbar.

## Fix

Bring `.tabs` in line with the proven-immune `.tabBar`:
- `align-items: center` — tab buttons keep their intrinsic height (no squash), so the underline stays pinned to the true bottom edge.
- `flex-shrink: 0` — the sibling tree can't compress the strip.
- `overflow-y: hidden` — a lone `overflow-x: auto` otherwise computes `overflow-y` to `auto` and reserves vertical scrollbar space.
- 3px styled `::-webkit-scrollbar` — avoids a fat space-consuming scrollbar under "Always show scroll bars".

CSS-only; no behavior change.

## Verification

Reproduced in **WebKit** (the app's engine) under the squash condition and confirmed the fix:
- Old CSS: tab collapses to 6px, underline **inside** the text (`STRIKE_THROUGH: true`).
- New CSS: tab stays 19px, underline **below** the text (`STRIKE_THROUGH: false`).

`WorkspaceTabs.test.tsx` (5) pass; prettier/eslint clean (pre-commit lint-staged passed).

Note: could not reproduce in headless Chromium or headless WebKit (both use overlay scroll bars that claim no space) — the trigger requires classic scroll bars, matching the reporter's "Always show scroll bars" setting.