### PR TITLE
Run-profile UX: expand-on-click, workspace reassignment on edit, form fixes

### DIFF
--- a/frontend/src/__tests__/components/RunProfileCard.test.tsx
+++ b/frontend/src/__tests__/components/RunProfileCard.test.tsx
@@ -128,6 +128,20 @@ describe('RunProfileCard adopt control', () => {
     expect(screen.queryByRole('button', { name: /adopt lint/i })).not.toBeInTheDocument();
   });
 
+  it('expands a dormant (never-run) card on click so Edit/actions are reachable', () => {
+    const { container } = render(
+      <RunProfileCard profile={detectedProfile} {...baseProps} isDormant={true} />
+    );
+
+    // Collapsed initially.
+    expect(container.querySelector('[class*="expanded"]')).toBeNull();
+
+    // Card root carries role="button"; click toggles the detail panel.
+    fireEvent.click(container.querySelector('[role="button"]')!);
+
+    expect(container.querySelector('[class*="expanded"]')).not.toBeNull();
+  });
+
   it('applies just-ran class when isFreshestRun is true', () => {
     const { container } = render(
       <RunProfileCard profile={detectedProfile} {...baseProps} isFreshestRun={true} />

--- a/frontend/src/__tests__/components/RunProfiles/RunProfileForm.test.tsx
+++ b/frontend/src/__tests__/components/RunProfiles/RunProfileForm.test.tsx
@@ -187,6 +187,42 @@ it('deletes a user profile after confirm and closes', async () => {
   await waitFor(() => expect(useIDEStore.getState().runProfileForm).toBeNull());
 });
 
+const defsWithGo = [
+  { id: 'project', name: 'Project', relDir: '', type: 'project', accent: 'project' },
+  { id: 'frontend', name: 'Frontend', relDir: 'frontend', type: 'frontend', accent: 'blue' },
+  { id: 'go', name: 'Go', relDir: '', type: 'go', accent: 'cyan' },
+] as workspace.WorkspaceDef[];
+
+it('defaults the workspace to the matching toolchain as the command is typed (create)', () => {
+  useIDEStore.setState({ workspaces: defsWithGo, activeWorkspaceId: 'frontend' });
+  render(<RunProfileForm state={{ mode: 'create' }} />);
+  const wsSelect = screen.getByLabelText('Workspace') as HTMLSelectElement;
+  expect(wsSelect.value).toBe('frontend');
+  fireEvent.change(screen.getByLabelText(/^command/i), { target: { value: 'go test ./...' } });
+  expect(wsSelect.value).toBe('go');
+});
+
+it('stops auto-selecting the workspace once the user picks one', () => {
+  useIDEStore.setState({ workspaces: defsWithGo, activeWorkspaceId: 'frontend' });
+  render(<RunProfileForm state={{ mode: 'create' }} />);
+  const wsSelect = screen.getByLabelText('Workspace') as HTMLSelectElement;
+  fireEvent.change(wsSelect, { target: { value: 'project' } });
+  fireEvent.change(screen.getByLabelText(/^command/i), { target: { value: 'go test ./...' } });
+  expect(wsSelect.value).toBe('project');
+});
+
+it('warns (non-blocking) when the command does not match the selected workspace', () => {
+  useIDEStore.setState({ workspaces: defsWithGo, activeWorkspaceId: 'frontend' });
+  render(<RunProfileForm state={{ mode: 'create' }} />);
+  // Pick Frontend explicitly, then type a Go command.
+  fireEvent.change(screen.getByLabelText('Workspace'), { target: { value: 'frontend' } });
+  fireEvent.change(screen.getByLabelText(/^command/i), { target: { value: 'go test ./...' } });
+  expect(screen.getByText(/looks like a Go command/i)).toBeInTheDocument();
+  // Warning is advisory only — Save stays enabled.
+  fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'gt' } });
+  expect(screen.getByRole('button', { name: /save/i })).toBeEnabled();
+});
+
 it('shows the Workspace dropdown when editing a user profile', () => {
   const user: RunProfile = { ...detected, id: 'u1', source: 'user' };
   render(<RunProfileForm state={{ mode: 'edit', profile: user }} />);

--- a/frontend/src/__tests__/components/RunProfiles/RunProfileForm.test.tsx
+++ b/frontend/src/__tests__/components/RunProfiles/RunProfileForm.test.tsx
@@ -187,6 +187,73 @@ it('deletes a user profile after confirm and closes', async () => {
   await waitFor(() => expect(useIDEStore.getState().runProfileForm).toBeNull());
 });
 
+it('shows the Workspace dropdown when editing a user profile', () => {
+  const user: RunProfile = { ...detected, id: 'u1', source: 'user' };
+  render(<RunProfileForm state={{ mode: 'edit', profile: user }} />);
+  expect(screen.getByLabelText('Workspace')).toBeInTheDocument();
+});
+
+it('hides the Workspace dropdown when customizing a detected profile', () => {
+  render(<RunProfileForm state={{ mode: 'edit', profile: detected }} />);
+  expect(screen.queryByLabelText('Workspace')).not.toBeInTheDocument();
+});
+
+it('reassigns a user profile to another workspace by moving it (delete old, then save new)', async () => {
+  (DeleteRunProfile as jest.Mock).mockResolvedValue(undefined);
+  (SaveRunProfile as jest.Mock).mockResolvedValue({ valid: true, errors: [] });
+  const user: RunProfile = {
+    ...detected,
+    id: 'u1',
+    source: 'user',
+    workspaceId: 'frontend',
+    workspaceName: 'Frontend',
+    workspaceRelDir: 'frontend',
+  };
+  useIDEStore.getState().openRunProfileForm({ mode: 'edit', profile: user });
+  render(<RunProfileForm state={{ mode: 'edit', profile: user }} />);
+
+  fireEvent.change(screen.getByLabelText('Workspace'), { target: { value: 'project' } });
+  fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+  await waitFor(() => expect(SaveRunProfile).toHaveBeenCalledTimes(1));
+  expect(DeleteRunProfile).toHaveBeenCalledWith('u1');
+  const saved = (SaveRunProfile as jest.Mock).mock.calls[0][0] as RunProfile;
+  expect(saved.workspaceId).toBe('project');
+  // Move ordering: the old copy must be removed before the new one is saved.
+  const delOrder = (DeleteRunProfile as jest.Mock).mock.invocationCallOrder[0];
+  const saveOrder = (SaveRunProfile as jest.Mock).mock.invocationCallOrder[0];
+  expect(delOrder).toBeLessThan(saveOrder);
+  await waitFor(() => expect(useIDEStore.getState().runProfileForm).toBeNull());
+});
+
+it('restores the original profile if the save fails after delete during reassignment', async () => {
+  (DeleteRunProfile as jest.Mock).mockResolvedValue(undefined);
+  (SaveRunProfile as jest.Mock)
+    .mockResolvedValueOnce({ valid: false, errors: [{ field: 'name', message: 'bad' }] })
+    .mockResolvedValueOnce({ valid: true, errors: [] });
+  const user: RunProfile = {
+    ...detected,
+    id: 'u1',
+    source: 'user',
+    workspaceId: 'frontend',
+    workspaceName: 'Frontend',
+    workspaceRelDir: 'frontend',
+  };
+  useIDEStore.getState().openRunProfileForm({ mode: 'edit', profile: user });
+  render(<RunProfileForm state={{ mode: 'edit', profile: user }} />);
+
+  fireEvent.change(screen.getByLabelText('Workspace'), { target: { value: 'project' } });
+  fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+  // Second SaveRunProfile call restores the original (frontend) profile.
+  await waitFor(() => expect(SaveRunProfile).toHaveBeenCalledTimes(2));
+  const restored = (SaveRunProfile as jest.Mock).mock.calls[1][0] as RunProfile;
+  expect(restored.workspaceId).toBe('frontend');
+  expect(restored.id).toBe('u1');
+  // Form stays open with the error surfaced.
+  expect(useIDEStore.getState().runProfileForm).not.toBeNull();
+});
+
 it('clears copied tags when customizing detected and command changes before save', () => {
   render(<RunProfileForm state={{ mode: 'edit', profile: detected }} />);
   expect(screen.getByText('dev')).toBeInTheDocument();

--- a/frontend/src/__tests__/utils/commandWorkspace.test.ts
+++ b/frontend/src/__tests__/utils/commandWorkspace.test.ts
@@ -1,0 +1,80 @@
+import {
+  inferCommandWorkspaceType,
+  pickWorkspaceForCommand,
+  commandWorkspaceMismatch,
+} from '../../utils/commandWorkspace';
+import type { workspace } from '../../../wailsjs/go/models';
+
+const ws = (id: string, type: string, name = id): workspace.WorkspaceDef =>
+  ({
+    id,
+    name,
+    relDir: id === 'project' ? '' : id,
+    type,
+    accent: 'blue',
+  }) as workspace.WorkspaceDef;
+
+const defs = [
+  ws('project', 'project', 'Project'),
+  ws('frontend', 'frontend', 'Frontend'),
+  ws('go', 'go', 'Go'),
+];
+
+describe('inferCommandWorkspaceType', () => {
+  it.each([
+    ['go test ./...', 'go'],
+    ['npm run dev', 'frontend'],
+    ['pnpm build', 'frontend'],
+    ['pytest -q', 'python'],
+    ['uv run app', 'python'],
+    ['/usr/bin/go test', 'go'],
+    ['VITE_KEY=1 npm run dev', 'frontend'],
+  ])('%s -> %s', (cmd, expected) => {
+    expect(inferCommandWorkspaceType(cmd)).toBe(expected);
+  });
+
+  it.each(['./run.sh', 'make build', 'docker compose up', 'sh -c "echo hi"', ''])(
+    'infers nothing for wrapper/unknown command %s',
+    (cmd) => {
+      expect(inferCommandWorkspaceType(cmd)).toBeNull();
+    }
+  );
+});
+
+describe('pickWorkspaceForCommand', () => {
+  it('picks the matching non-project workspace by command type', () => {
+    expect(pickWorkspaceForCommand('go test ./...', defs, 'frontend')).toBe('go');
+    expect(pickWorkspaceForCommand('npm run dev', defs, 'go')).toBe('frontend');
+  });
+
+  it('falls back when the command type is unknown', () => {
+    expect(pickWorkspaceForCommand('./deploy.sh', defs, 'frontend')).toBe('frontend');
+  });
+
+  it('falls back when no workspace of the matching type exists', () => {
+    const noGo = [ws('project', 'project'), ws('frontend', 'frontend')];
+    expect(pickWorkspaceForCommand('go test', noGo, 'frontend')).toBe('frontend');
+  });
+});
+
+describe('commandWorkspaceMismatch', () => {
+  it('warns when a language command lands in a different-language workspace', () => {
+    const msg = commandWorkspaceMismatch('go test ./...', ws('frontend', 'frontend', 'Frontend'));
+    expect(msg).toContain('Go');
+    expect(msg).toContain('Frontend');
+  });
+
+  it('does not warn when the command matches the workspace type', () => {
+    expect(commandWorkspaceMismatch('npm run dev', ws('frontend', 'frontend'))).toBeNull();
+  });
+
+  it('does not warn for project/infra workspaces that can host anything', () => {
+    expect(commandWorkspaceMismatch('go test', ws('project', 'project'))).toBeNull();
+    expect(commandWorkspaceMismatch('go test', ws('infra', 'docker'))).toBeNull();
+  });
+
+  it('does not warn for unknown commands or a missing workspace', () => {
+    expect(commandWorkspaceMismatch('./run.sh', ws('frontend', 'frontend'))).toBeNull();
+    expect(commandWorkspaceMismatch('go test', undefined)).toBeNull();
+  });
+});

--- a/frontend/src/components/RunProfiles/ExpandedPanel.module.css
+++ b/frontend/src/components/RunProfiles/ExpandedPanel.module.css
@@ -38,16 +38,14 @@
 
 .outputLine {
   color: #555;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .outputStderr {
   color: rgba(239, 68, 68, 0.6);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 /* ── Stats Row ──────────────────────────────────────────────── */
@@ -210,9 +208,12 @@
   font-size: 11px;
   font-family: 'SF Mono', 'Fira Code', var(--font-mono), monospace;
   color: var(--text-secondary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  /* Wrap the full command/source instead of truncating in the detail view.
+     flex:1 + min-width:0 makes it wrap at the row width, not the longest token. */
+  flex: 1;
+  min-width: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 /* ── Actions Row ────────────────────────────────────────────── */

--- a/frontend/src/components/RunProfiles/ExpandedPanel.module.css
+++ b/frontend/src/components/RunProfiles/ExpandedPanel.module.css
@@ -220,7 +220,11 @@
 
 .actions {
   display: flex;
+  /* wrap so action buttons reflow to a new line instead of overflowing/clipping
+     when the right panel is narrow. */
+  flex-wrap: wrap;
   gap: 5px;
+  row-gap: 6px;
   align-items: center;
   margin-top: 10px;
 }

--- a/frontend/src/components/RunProfiles/ExpandedPanel.tsx
+++ b/frontend/src/components/RunProfiles/ExpandedPanel.tsx
@@ -505,7 +505,7 @@ function ActionsRow({
           onClick={onUnadopt}
           aria-label={`Remove ${profile.name} from working set`}
         >
-          Remove from working set
+          Remove
         </button>
       )}
       {profile.source === 'detected' ? (

--- a/frontend/src/components/RunProfiles/RunProfileCard.module.css
+++ b/frontend/src/components/RunProfiles/RunProfileCard.module.css
@@ -129,9 +129,10 @@
   color: #cbd5e1;
   margin-top: 3px;
   margin-left: 34px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  /* Wrap long commands instead of truncating so the full command is visible.
+     overflow-wrap:anywhere also breaks unbroken tokens (long paths/URLs). */
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .cmdSource {

--- a/frontend/src/components/RunProfiles/RunProfileCard.tsx
+++ b/frontend/src/components/RunProfiles/RunProfileCard.tsx
@@ -206,8 +206,11 @@ export function RunProfileCard({
   const handleCardClick = () => {
     // Clicking anywhere on the card selects it as the Cmd+R target...
     useIDEStore.getState().setSelectedProfile(profile.id);
-    // ...and still toggles the expanded detail for non-dormant, non-active cards.
-    if (!isDormant && !isActiveState) {
+    // ...and toggles the expanded detail. Active states force-expand via CSS, so
+    // manual toggling only applies to non-active cards — including dormant
+    // (never-run) ones, so their Edit/Pin/Hide actions are reachable without
+    // having to run the profile first.
+    if (!isActiveState) {
       setManualExpanded((prev) => !prev);
     }
   };

--- a/frontend/src/components/RunProfiles/RunProfileForm.module.css
+++ b/frontend/src/components/RunProfiles/RunProfileForm.module.css
@@ -104,6 +104,12 @@
   background-position: right 9px center;
   cursor: pointer;
 }
+/* Keep the accent focus ring for keyboard users (:focus-visible), but don't
+   leave a persistent ring hugging the select after a mouse click/selection. */
+.select:focus:not(:focus-visible) {
+  border-color: var(--surface-border);
+  box-shadow: none;
+}
 .mono {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }

--- a/frontend/src/components/RunProfiles/RunProfileForm.module.css
+++ b/frontend/src/components/RunProfiles/RunProfileForm.module.css
@@ -196,6 +196,16 @@
   padding: 6px 8px;
   margin-bottom: 11px;
 }
+/* Non-blocking amber advisory (e.g. command/workspace toolchain mismatch). */
+.warning {
+  font-size: 10px;
+  color: #fbbf24;
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.28);
+  border-radius: 5px;
+  padding: 6px 8px;
+  margin: -4px 0 13px;
+}
 .deleteRow {
   display: flex;
   justify-content: space-between;

--- a/frontend/src/components/RunProfiles/RunProfileForm.tsx
+++ b/frontend/src/components/RunProfiles/RunProfileForm.tsx
@@ -18,6 +18,7 @@ import {
   type EnvRow,
   type RunProfileFormValues,
 } from '../../utils/runProfileForm';
+import { commandWorkspaceMismatch, pickWorkspaceForCommand } from '../../utils/commandWorkspace';
 import styles from './RunProfileForm.module.css';
 
 const ALL_TAGS: ProfileTag[] = ['build', 'test', 'dev', 'lint', 'deploy'];
@@ -71,6 +72,9 @@ export function RunProfileForm({ state }: RunProfileFormProps) {
   const [dirError, setDirError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
+  // While creating, the workspace auto-follows the command's toolchain until the
+  // user picks a workspace themselves.
+  const [workspaceTouched, setWorkspaceTouched] = useState(false);
 
   // For the "clear seeded tags when customizing and command changes" rule.
   const customizing = state.mode === 'edit' && state.profile.source === 'detected';
@@ -125,6 +129,15 @@ export function RunProfileForm({ state }: RunProfileFormProps) {
     if (customizing && seededTags.current && command !== seededCommand.current) {
       seededTags.current = false;
       patch({ command, tags: [] });
+      return;
+    }
+    // Smart default: while creating, steer the workspace to the one whose
+    // toolchain matches the command (go test -> Go), until the user overrides it.
+    if (state.mode === 'create' && !workspaceTouched) {
+      patch({
+        command,
+        workspaceId: pickWorkspaceForCommand(command, workspaces, activeWorkspaceId),
+      });
       return;
     }
     patch({ command });
@@ -243,6 +256,10 @@ export function RunProfileForm({ state }: RunProfileFormProps) {
 
   const multiWorkspace = workspaces.length > 1;
   const variantCount = state.mode === 'edit' ? (state.profile.envVariants?.length ?? 0) : 0;
+  const mismatchWarning = commandWorkspaceMismatch(
+    values.command,
+    workspaces.find((w) => w.id === values.workspaceId)
+  );
 
   return (
     <div className={styles.form}>
@@ -295,7 +312,10 @@ export function RunProfileForm({ state }: RunProfileFormProps) {
             <select
               className={`${styles.input} ${styles.select}`}
               value={values.workspaceId}
-              onChange={(e) => patch({ workspaceId: e.target.value })}
+              onChange={(e) => {
+                setWorkspaceTouched(true);
+                patch({ workspaceId: e.target.value });
+              }}
               aria-label="Workspace"
             >
               {workspaces.map((w) => (
@@ -305,6 +325,12 @@ export function RunProfileForm({ state }: RunProfileFormProps) {
               ))}
             </select>
           </label>
+        )}
+
+        {mismatchWarning && (
+          <div className={styles.warning} role="status">
+            {mismatchWarning}
+          </div>
         )}
 
         <label className={styles.group}>

--- a/frontend/src/components/RunProfiles/RunProfileForm.tsx
+++ b/frontend/src/components/RunProfiles/RunProfileForm.tsx
@@ -157,34 +157,69 @@ export function RunProfileForm({ state }: RunProfileFormProps) {
   const removeEnvRow = (i: number) =>
     patch({ envRows: values.envRows.filter((_, idx) => idx !== i) });
 
+  // The Wails-generated runprofile.RunProfile carries a convertValues helper the
+  // plain app type lacks; the binding only serializes the data, so cast.
+  const toBinding = (p: RunProfile) => p as unknown as runprofile.RunProfile;
+
+  // name/command render inline; surface every other backend error in the
+  // form-level banner so no validation failure is silently swallowed.
+  const applyBackendErrors = (result: runprofile.ValidationResult) => {
+    const errs: Record<string, string> = {};
+    const other: string[] = [];
+    for (const e of result.errors ?? []) {
+      if (e.field === 'name' || e.field === 'command') errs[e.field] = e.message;
+      else other.push(e.message);
+    }
+    setFieldErrors(errs);
+    if (other.length > 0) {
+      setFormError(other.join('; '));
+    } else if (Object.keys(errs).length === 0) {
+      setFormError('Could not save profile.');
+    }
+  };
+
   const onSave = async () => {
     if (!canSave) return;
     setSaving(true);
     setFormError(null);
     setFieldErrors({});
+
+    // Changing a user profile's workspace is a move: the backend rejects a
+    // same-id Save into a different workspace, so remove the old copy first.
+    const reassigning =
+      state.mode === 'edit' &&
+      state.profile.source === 'user' &&
+      (state.profile.workspaceId ?? '') !== (values.workspaceId ?? '');
+
     try {
       const profile = buildProfileFromForm(values, state);
-      // The Wails-generated runprofile.RunProfile carries a convertValues helper
-      // the plain app type lacks; the binding only serializes the data, so cast.
-      const result = await SaveRunProfile(profile as unknown as runprofile.RunProfile);
+
+      if (reassigning) {
+        const original = (state as { mode: 'edit'; profile: RunProfile }).profile;
+        await DeleteRunProfile(original.id);
+        let result: runprofile.ValidationResult;
+        try {
+          result = await SaveRunProfile(toBinding(profile));
+        } catch (err) {
+          // Save threw after the delete — restore the original so it isn't lost.
+          await SaveRunProfile(toBinding(original)).catch(() => {});
+          throw err;
+        }
+        if (!result.valid) {
+          await SaveRunProfile(toBinding(original)).catch(() => {});
+          applyBackendErrors(result);
+          return;
+        }
+        close(); // backend emits runprofiles:changed → list refreshes
+        return;
+      }
+
+      const result = await SaveRunProfile(toBinding(profile));
       if (result.valid) {
         close(); // backend emits runprofiles:changed → list refreshes
         return;
       }
-      // name/command render inline; surface every other backend error in the
-      // form-level banner so no validation failure is silently swallowed.
-      const errs: Record<string, string> = {};
-      const other: string[] = [];
-      for (const e of result.errors ?? []) {
-        if (e.field === 'name' || e.field === 'command') errs[e.field] = e.message;
-        else other.push(e.message);
-      }
-      setFieldErrors(errs);
-      if (other.length > 0) {
-        setFormError(other.join('; '));
-      } else if (Object.keys(errs).length === 0) {
-        setFormError('Could not save profile.');
-      }
+      applyBackendErrors(result);
     } catch (err) {
       setFormError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -254,7 +289,7 @@ export function RunProfileForm({ state }: RunProfileFormProps) {
           </label>
         )}
 
-        {!isEdit && multiWorkspace && (
+        {(!isEdit || isUserProfile) && multiWorkspace && (
           <label className={styles.group}>
             <span className={styles.label}>Workspace</span>
             <select

--- a/frontend/src/components/RunProfiles/RunProfileForm.tsx
+++ b/frontend/src/components/RunProfiles/RunProfileForm.tsx
@@ -241,7 +241,9 @@ export function RunProfileForm({ state }: RunProfileFormProps) {
               onChange={(e) => onPickStartFrom(e.target.value)}
               aria-label="Start from detected command"
             >
-              <option value="">Choose a detected command…</option>
+              <option value="" disabled>
+                Choose a detected command…
+              </option>
               {detectedOptions.map((p) => (
                 <option key={p.id} value={p.id}>
                   {p.name} — {p.command}

--- a/frontend/src/utils/commandWorkspace.ts
+++ b/frontend/src/utils/commandWorkspace.ts
@@ -1,0 +1,95 @@
+import type { workspace } from '../../wailsjs/go/models';
+
+/**
+ * Heuristics that map a run command to the workspace its toolchain implies, so
+ * profile creation can default to the right workspace and warn on an obvious
+ * mismatch (e.g. a `go` command assigned to a Frontend workspace, which would
+ * run in that workspace's folder with no go.mod).
+ *
+ * Intentionally conservative: only confident leading-token matches infer a type.
+ * Unknown / wrapper commands (./run.sh, make, docker, custom) infer nothing and
+ * never produce a warning.
+ */
+
+// Leading command token -> workspace type. Basename-matched, so /usr/bin/go works.
+const TOKEN_TYPE: Record<string, string> = {
+  go: 'go',
+  npm: 'frontend',
+  npx: 'frontend',
+  yarn: 'frontend',
+  pnpm: 'frontend',
+  bun: 'frontend',
+  node: 'frontend',
+  python: 'python',
+  python3: 'python',
+  pytest: 'python',
+  pip: 'python',
+  pip3: 'python',
+  uv: 'python',
+  poetry: 'python',
+};
+
+// Only these workspace types host a single language, so a cross-language command
+// is a real mismatch. project/docker/terraform/general can legitimately host any
+// command, so they never warn.
+const LANGUAGE_TYPES = new Set(['go', 'frontend', 'python']);
+
+const TYPE_LABEL: Record<string, string> = {
+  go: 'Go',
+  frontend: 'Frontend',
+  python: 'Python',
+};
+
+/** First real command token, skipping leading `KEY=value` env assignments. */
+function leadingToken(command: string): string | null {
+  const parts = command.trim().split(/\s+/);
+  for (const part of parts) {
+    if (!part) continue;
+    // Skip inline env assignments like FOO=bar (no path separator).
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(part) && !part.includes('/')) continue;
+    // Basename so /usr/bin/go and ./go both reduce to "go".
+    const base = part.split('/').pop() ?? part;
+    return base || null;
+  }
+  return null;
+}
+
+/** The workspace type a command's toolchain implies, or null if unknown. */
+export function inferCommandWorkspaceType(command: string): string | null {
+  const token = leadingToken(command);
+  if (!token) return null;
+  return TOKEN_TYPE[token] ?? null;
+}
+
+/**
+ * Picks the workspace a new profile should default to for `command`: the
+ * non-project workspace whose type matches the command's toolchain, else
+ * `fallbackId` (typically the active workspace).
+ */
+export function pickWorkspaceForCommand(
+  command: string,
+  workspaces: workspace.WorkspaceDef[],
+  fallbackId: string
+): string {
+  const inferred = inferCommandWorkspaceType(command);
+  if (!inferred) return fallbackId;
+  const match = workspaces.find((w) => w.id !== 'project' && w.type === inferred);
+  return match ? match.id : fallbackId;
+}
+
+/**
+ * A non-blocking warning when `command`'s toolchain doesn't match the selected
+ * workspace, or null when there's nothing to flag. Only fires for confident
+ * command inference against a single-language workspace of a different type.
+ */
+export function commandWorkspaceMismatch(
+  command: string,
+  ws: workspace.WorkspaceDef | undefined
+): string | null {
+  if (!ws) return null;
+  const inferred = inferCommandWorkspaceType(command);
+  if (!inferred) return null;
+  if (ws.type === inferred) return null;
+  if (!LANGUAGE_TYPES.has(ws.type)) return null;
+  return `This looks like a ${TYPE_LABEL[inferred]} command, but “${ws.name}” is a ${TYPE_LABEL[ws.type]} workspace — it will run in that folder and may not find its toolchain.`;
+}


### PR DESCRIPTION
Run-profile management + polish from testing. Six changes.

## 1. Cards expand on click even when never run

Cards only expanded once they had run output/history, so a never-run profile could not be expanded — and Edit/Pin/Hide (in the expanded panel) were unreachable until first run. Root cause: `handleCardClick` gated expand on `!isDormant` ([RunProfiles.tsx:146](frontend/src/components/RunProfiles/RunProfiles.tsx:146)). Now every non-active card toggles expand.

## 2. Reassign a user profile's workspace from the edit form

Workspace dropdown was create-only. Now shown when editing a **user** profile (hidden for detected-customize). Because the backend rejects a same-id `Save` into a different workspace (unique-id invariant, [project_manager.go:332](internal/runprofile/project_manager.go:332)), a workspace change is an explicit **move**: delete old → save new, restoring the original if the save fails.

## 3. Default the new-profile workspace from the command + warn on mismatch

Creating a profile defaulted its workspace to whatever was active, so `go test` created while a Frontend workspace was active got stamped Frontend and would run in `frontend/` (no go.mod) and fail.

- New pure util `commandWorkspace.ts` infers a command's toolchain from its leading token (`go`→go, `npm`/`pnpm`/`yarn`/`node`→frontend, `python`/`pytest`/`uv`/`poetry`→python; wrapper/unknown → nothing).
- **Smart default:** while creating, the Workspace select follows the command's toolchain as you type, until you pick a workspace yourself.
- **Soft warning:** a non-blocking advisory when the command doesn't match the selected workspace (only for single-language go/frontend/python workspaces, never project/docker/terraform). Save stays enabled. Not a hard block — wrapper scripts, make, docker, custom commands can live anywhere.

## 4. Wrap command / output text instead of truncating

The card command preview, the expanded COMMAND/SOURCE detail, and output-preview lines used `nowrap` + ellipsis, cutting off long commands/lines. Now `pre-wrap` + `overflow-wrap:anywhere` so the full text wraps.

## 5. "Start from" placeholder no longer selectable

`Choose a detected command…` is now a `disabled` placeholder.

## 6. Select focus ring no longer lingers after a mouse click

Themed `<select>` focus ring is keyboard-only (`:focus-visible`).

## Tests / verification

- New tests: dormant card expands on click; workspace dropdown on user edit / hidden on detected customize; reassignment move (ordered) + rollback on failure; command→workspace inference / pick / mismatch (19 util cases); smart default follows/stops; non-blocking warning shown.
- `npx jest` 1116 pass (115 suites); `npx tsc --noEmit` clean; eslint + prettier clean.