### PR TITLE
Set macOS minimum version to 11.0 to match the built binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Linux, and Windows built with Wails (Go + React/Vite), using the system webview
 for a small (~15MB) binary. This release consolidates the editor, workspace,
 run-profile, terminal, language-server, and search work completed to date.
 
+Requires macOS 11 (Big Sur) or later, a Linux distribution with WebKit2GTK 4.1,
+or Windows 10/11 (WebView2).
+
 ### Editor
 - CodeMirror 6 editor with multi-tab editing and per-tab state.
 - Per-file undo history and view state (cursor, scroll) preserved across tab

--- a/build/darwin/Info.dev.plist
+++ b/build/darwin/Info.dev.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
         <string>iconfile</string>
         <key>LSMinimumSystemVersion</key>
-        <string>10.13.0</string>
+        <string>11.0.0</string>
         <key>NSHighResolutionCapable</key>
         <string>true</string>
         <key>NSHumanReadableCopyright</key>

--- a/build/darwin/Info.plist
+++ b/build/darwin/Info.plist
@@ -18,7 +18,7 @@
         <key>CFBundleIconFile</key>
         <string>iconfile</string>
         <key>LSMinimumSystemVersion</key>
-        <string>10.13.0</string>
+        <string>11.0.0</string>
         <key>NSHighResolutionCapable</key>
         <string>true</string>
         <key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
Pre-v0.9.0 fix found during the release dry-run (`v0.9.0-rc.1`).

## Problem
The macOS build advertises `LSMinimumSystemVersion 10.13.0` in `Info.plist`, but the toolchain produces a binary with `minos 11.0`. On macOS 10.13-10.15 the app installs (plist allows it) but **fails to launch** — dyld rejects the newer `minos`. `otool -L` shows `UniformTypeIdentifiers` is only **weak**-linked, so this is a version-advertising mismatch, not the #145 crash class.

## Fix
Set `LSMinimumSystemVersion` to `11.0.0` in `build/darwin/Info.plist` and `Info.dev.plist` so the advertised floor matches the `minos 11.0` binary. Document the macOS 11+ requirement in the CHANGELOG.

macOS 11 (Big Sur, 2020) as the floor was confirmed as the intended baseline.

## Verified
Dry-run `v0.9.0-rc.1` built and published all four artifacts (macOS amd64/arm64, Linux amd64, Windows amd64); this only changes the advertised min-OS to match the binary. Blocks tagging `v0.9.0` until merged.