### PR TITLE
feat: add curl one-command install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,17 @@ Each workspace has independent layout state, scoped language servers (only the a
 curl -fsSL https://raw.githubusercontent.com/kstruzzieri/firn-ide/develop/install.sh | sh
 ```
 
-Pin a version with `FIRN_VERSION=v0.10.0`, or preview what it will do with `FIRN_DRY_RUN=1`. Windows users: use the manual zip below.
+Put the assignment on the `sh` side of the pipe so the script actually receives it — pin a version with `FIRN_VERSION`, or preview without installing with `FIRN_DRY_RUN`:
+
+```bash
+# preview the resolved download URL and target dir without installing
+curl -fsSL https://raw.githubusercontent.com/kstruzzieri/firn-ide/develop/install.sh | FIRN_DRY_RUN=1 sh
+
+# pin a specific release instead of the latest
+curl -fsSL https://raw.githubusercontent.com/kstruzzieri/firn-ide/develop/install.sh | FIRN_VERSION=v0.10.0 sh
+```
+
+Windows users: use the manual zip below.
 
 Prefer to do it by hand? Download the latest build for your platform from the [Releases page](https://github.com/kstruzzieri/firn-ide/releases/latest).
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,15 @@ Each workspace has independent layout state, scoped language servers (only the a
 
 ## Install
 
-Download the latest build for your platform from the [Releases page](https://github.com/kstruzzieri/firn-ide/releases/latest).
+**Quick install** (macOS and Linux) — downloads the latest release and installs it:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kstruzzieri/firn-ide/develop/install.sh | sh
+```
+
+Pin a version with `FIRN_VERSION=v0.10.0`, or preview what it will do with `FIRN_DRY_RUN=1`. Windows users: use the manual zip below.
+
+Prefer to do it by hand? Download the latest build for your platform from the [Releases page](https://github.com/kstruzzieri/firn-ide/releases/latest).
 
 > **Preview builds are unsigned**, so macOS and Windows warn on first launch. The per-platform steps below get you past it.
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# Firn IDE one-command installer.
+#
+#   curl -fsSL https://raw.githubusercontent.com/kstruzzieri/firn-ide/develop/install.sh | sh
+#
+# Resolves the platform binary from the latest GitHub release, downloads it, and
+# installs it. Supports macOS (arm64/amd64) and Linux (amd64). Windows users:
+# use the manual zip from the Releases page.
+#
+# Env overrides:
+#   FIRN_VERSION   pin a release tag (e.g. v0.10.0) instead of "latest"
+#   FIRN_DRY_RUN   set to 1 to print the resolved URL + target dir and exit
+#
+# ponytail: no checksum/signature verification of the download -- binaries are
+# unsigned today; add when code signing/notarization lands.
+
+set -e
+
+REPO="kstruzzieri/firn-ide"
+
+err() {
+	echo "firn-install: $*" >&2
+	exit 1
+}
+
+# Detect OS -> macos|linux
+os_raw=$(uname -s)
+case "$os_raw" in
+	Darwin) OS=macos ;;
+	Linux) OS=linux ;;
+	*) err "unsupported OS '$os_raw' (macOS and Linux only; Windows: download the zip from https://github.com/$REPO/releases/latest)" ;;
+esac
+
+# Detect arch -> amd64|arm64
+arch_raw=$(uname -m)
+case "$arch_raw" in
+	x86_64 | amd64) ARCH=amd64 ;;
+	arm64 | aarch64) ARCH=arm64 ;;
+	*) err "unsupported architecture '$arch_raw'" ;;
+esac
+
+# Map platform -> release asset name
+if [ "$OS" = macos ]; then
+	ASSET="Firn-macos-$ARCH.zip"
+else
+	# Linux has only an amd64 build today.
+	if [ "$ARCH" != amd64 ]; then
+		err "no Linux $ARCH build available yet (only amd64). Build from source: https://github.com/$REPO#development"
+	fi
+	ASSET="Firn-linux-amd64.tar.gz"
+fi
+
+# Resolve download URL: pinned tag, or scrape the latest release for the asset.
+if [ -n "$FIRN_VERSION" ]; then
+	URL="https://github.com/$REPO/releases/download/$FIRN_VERSION/$ASSET"
+else
+	api="https://api.github.com/repos/$REPO/releases/latest"
+	# Grab the browser_download_url whose value ends in our asset name.
+	URL=$(curl -fsSL "$api" \
+		| grep -o "https://github.com/$REPO/releases/download/[^\"]*/$ASSET" \
+		| head -n 1)
+	[ -n "$URL" ] || err "could not find asset '$ASSET' in the latest release ($api)"
+fi
+
+# Pick install target (per-OS), preferring a system location, falling back to
+# a user-writable one so the script works without sudo.
+if [ "$OS" = macos ]; then
+	if [ -w /Applications ] || [ ! -e /Applications ]; then
+		DEST_DIR=/Applications
+	else
+		DEST_DIR="$HOME/Applications"
+	fi
+else
+	if [ -w /usr/local/bin ]; then
+		DEST_DIR=/usr/local/bin
+	else
+		DEST_DIR="$HOME/.local/bin"
+	fi
+fi
+
+if [ "$FIRN_DRY_RUN" = 1 ]; then
+	echo "os:       $OS"
+	echo "arch:     $ARCH"
+	echo "asset:    $ASSET"
+	echo "url:      $URL"
+	echo "dest_dir: $DEST_DIR"
+	exit 0
+fi
+
+command -v curl >/dev/null 2>&1 || err "curl is required but not found"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+echo "Downloading $ASSET ..."
+curl -fsSL "$URL" -o "$tmp/$ASSET" || err "download failed: $URL"
+
+if [ "$OS" = macos ]; then
+	command -v unzip >/dev/null 2>&1 || err "unzip is required but not found"
+	unzip -q "$tmp/$ASSET" -d "$tmp" || err "unzip failed"
+	[ -d "$tmp/Firn.app" ] || err "Firn.app not found in archive"
+
+	mkdir -p "$DEST_DIR"
+	app="$DEST_DIR/Firn.app"
+	rm -rf "$app"
+	mv "$tmp/Firn.app" "$app"
+	# Clear the quarantine flag so Gatekeeper does not block first launch.
+	xattr -dr com.apple.quarantine "$app" 2>/dev/null || true
+
+	echo "Installed Firn.app to $DEST_DIR"
+	echo "Launch it from Finder, or run: open '$app'"
+else
+	command -v tar >/dev/null 2>&1 || err "tar is required but not found"
+	tar -xzf "$tmp/$ASSET" -C "$tmp" || err "extract failed"
+	[ -f "$tmp/firn" ] || err "firn binary not found in archive"
+
+	mkdir -p "$DEST_DIR"
+	bin="$DEST_DIR/firn"
+	mv "$tmp/firn" "$bin"
+	chmod +x "$bin"
+
+	echo "Installed firn to $DEST_DIR"
+	case ":$PATH:" in
+		*":$DEST_DIR:"*) echo "Launch it with: firn" ;;
+		*) echo "Add $DEST_DIR to your PATH, then launch with: firn" ;;
+	esac
+fi


### PR DESCRIPTION
## Summary

Adds a one-command installer so users can install Firn without cloning or building:

```bash
curl -fsSL https://raw.githubusercontent.com/kstruzzieri/firn-ide/develop/install.sh | sh
```

- New `install.sh` (POSIX sh) at repo root.
- Detects OS (`uname -s`) and arch (`uname -m`), maps to the release asset, and resolves the download URL from the **latest** GitHub release at runtime (so it stays current with zero `release.yml` changes).
- macOS (arm64/amd64): unzips `Firn.app` to `/Applications` (falls back to `~/Applications`), clears the Gatekeeper quarantine flag.
- Linux (amd64): untars `firn` to `/usr/local/bin` (falls back to `~/.local/bin`), `chmod +x`. Errors clearly on Linux arm64 (no build yet).
- `FIRN_VERSION` pins a release tag; `FIRN_DRY_RUN=1` prints the resolved URL and target dir without downloading.
- README gains a Quick install one-liner above the manual per-platform steps, which remain as the fallback.
- Windows stays on the manual zip (a PowerShell one-liner is a possible later follow-up).

## Notes

- Served from `raw.githubusercontent.com/.../develop/install.sh`; it reads the latest release at runtime, so no per-release upkeep.
- Binaries are unsigned, so the script clears the macOS quarantine flag. Real fix (code signing/notarization) is a separate track — a `# ponytail:` comment marks the skipped checksum/signature verification for when signing lands.

## Testing

All offline (no downloads), via `FIRN_DRY_RUN` plus a mocked `uname`:

- `sh -n install.sh` — clean.
- macOS/arm64 -> `Firn-macos-arm64.zip` -> `/Applications` (latest-release scrape resolved the real v0.10.0 asset).
- `FIRN_VERSION=v0.10.0` -> same URL via the pinned-tag path.
- Linux/amd64 -> `Firn-linux-amd64.tar.gz` -> `~/.local/bin`.
- Linux/arm64 -> clear error, exit 1.

Generated with [Claude Code](https://claude.com/claude-code)