### PR TITLE
feat: current-file Structure view from LSP document symbols (#168)

### DIFF
--- a/app.go
+++ b/app.go
@@ -731,6 +731,17 @@ func (a *App) LSPDefinition(path string, line, character int) ([]lsp.Location, e
 	return a.lspManager.Definition(ctx, path, line, character)
 }
 
+// LSPDocumentSymbol requests the document symbols (structure/outline) for a file.
+// This is exposed to the frontend via Wails bindings.
+func (a *App) LSPDocumentSymbol(path string) ([]lsp.DocumentSymbol, error) {
+	if a.lspManager == nil {
+		return nil, fmt.Errorf("LSP not initialized")
+	}
+	ctx, cancel := context.WithTimeout(a.ctx, lsp.DefaultRequestTimeout)
+	defer cancel()
+	return a.lspManager.DocumentSymbol(ctx, path)
+}
+
 // LSPComplete requests completion items for a position in a document.
 // This is exposed to the frontend via Wails bindings.
 func (a *App) LSPComplete(path string, line, character int, triggerCharacter string) (*lsp.CompletionList, error) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { Sidebar } from './components/Sidebar';
 import { FileExplorer } from './components/FileExplorer';
 import { SearchPanel } from './components/Search';
 import { GitPanel } from './components/GitPanel';
+import { StructureView } from './components/Structure';
 import { Editor } from './components/Editor';
 import { Terminal } from './components/Terminal';
 import { RunProfiles } from './components/RunProfiles';
@@ -148,6 +149,8 @@ function App() {
             <SearchPanel />
           ) : sidebarView === 'git' ? (
             <GitPanel />
+          ) : sidebarView === 'structure' ? (
+            <StructureView />
           ) : (
             <FileExplorer />
           )

--- a/frontend/src/__tests__/components/Structure/StructureView.test.tsx
+++ b/frontend/src/__tests__/components/Structure/StructureView.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { DocumentSymbolNode } from '../../../utils/documentSymbols';
+import type { UseDocumentSymbolsResult } from '../../../hooks/useDocumentSymbols';
+
+const mockNavigate = jest.fn();
+jest.mock('../../../utils/editorNavigation', () => ({
+  navigateToEditorLocation: (...args: unknown[]) => mockNavigate(...args),
+}));
+
+let hookResult: UseDocumentSymbolsResult;
+const mockRefresh = jest.fn();
+jest.mock('../../../hooks/useDocumentSymbols', () => ({
+  useDocumentSymbols: () => hookResult,
+}));
+
+import { StructureView } from '../../../components/Structure/StructureView';
+
+function range(line: number, character = 0) {
+  return { start: { line, character }, end: { line, character: character + 1 } };
+}
+function sym(
+  name: string,
+  kind: number,
+  selLine: number,
+  children: DocumentSymbolNode[] = []
+): DocumentSymbolNode {
+  return { name, kind, range: range(selLine), selectionRange: range(selLine), children };
+}
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+  mockRefresh.mockClear();
+  hookResult = { status: 'no-file', symbols: [], filePath: null, refresh: mockRefresh };
+});
+
+it('renders the no-file state', () => {
+  render(<StructureView />);
+  expect(screen.getByText('No file open')).toBeInTheDocument();
+});
+
+it('renders unsupported state', () => {
+  hookResult = { status: 'unsupported', symbols: [], filePath: '/ws/x.env', refresh: mockRefresh };
+  render(<StructureView />);
+  expect(screen.getByText('Structure unavailable for this file')).toBeInTheDocument();
+});
+
+it('renders error state with a working Retry button', () => {
+  hookResult = { status: 'error', symbols: [], filePath: '/ws/x.ts', refresh: mockRefresh };
+  render(<StructureView />);
+  expect(screen.getByText("Couldn't load structure")).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+  expect(mockRefresh).toHaveBeenCalledTimes(1);
+});
+
+it('renders a nested symbol tree and jumps to the selection range on click', () => {
+  hookResult = {
+    status: 'ready',
+    filePath: '/ws/main.ts',
+    refresh: mockRefresh,
+    symbols: [sym('Widget', 5, 0, [sym('render', 6, 4)])],
+  };
+  render(<StructureView />);
+
+  expect(screen.getByText('Widget')).toBeInTheDocument();
+  const child = screen.getByText('render');
+  expect(child).toBeInTheDocument();
+
+  fireEvent.click(child);
+  // selectionRange.start is 0-based (line 4, char 0) → editor is 1-based (5, 1)
+  expect(mockNavigate).toHaveBeenCalledWith('/ws/main.ts', 5, 1);
+});
+
+it('jumps via keyboard (Enter) so the tree is operable without a mouse', () => {
+  hookResult = {
+    status: 'ready',
+    filePath: '/ws/main.ts',
+    refresh: mockRefresh,
+    symbols: [sym('Widget', 5, 0)],
+  };
+  render(<StructureView />);
+
+  const row = screen.getByText('Widget').closest('[role="treeitem"]') as HTMLElement;
+  expect(row).toHaveAttribute('tabindex', '0');
+  fireEvent.keyDown(row, { key: 'Enter' });
+  expect(mockNavigate).toHaveBeenCalledWith('/ws/main.ts', 1, 1);
+});
+
+it('collapses a subtree via ArrowLeft on the focused row', () => {
+  hookResult = {
+    status: 'ready',
+    filePath: '/ws/main.ts',
+    refresh: mockRefresh,
+    symbols: [sym('Widget', 5, 0, [sym('render', 6, 4)])],
+  };
+  render(<StructureView />);
+
+  const row = screen.getByText('Widget').closest('[role="treeitem"]') as HTMLElement;
+  expect(screen.getByText('render')).toBeInTheDocument();
+  fireEvent.keyDown(row, { key: 'ArrowLeft' });
+  expect(screen.queryByText('render')).not.toBeInTheDocument();
+  expect(mockNavigate).not.toHaveBeenCalled();
+});
+
+it('collapses a subtree via its twisty without triggering navigation', () => {
+  hookResult = {
+    status: 'ready',
+    filePath: '/ws/main.ts',
+    refresh: mockRefresh,
+    symbols: [sym('Widget', 5, 0, [sym('render', 6, 4)])],
+  };
+  render(<StructureView />);
+
+  const widgetRow = screen.getByText('Widget').closest('[role="treeitem"]') as HTMLElement;
+
+  // Child visible initially
+  expect(screen.getByText('render')).toBeInTheDocument();
+
+  // Click the twisty span (first child of the row) — should collapse, not navigate
+  const twistySpan = widgetRow.firstElementChild as HTMLElement;
+  fireEvent.click(twistySpan);
+  expect(screen.queryByText('render')).not.toBeInTheDocument();
+  expect(mockNavigate).not.toHaveBeenCalled();
+});
+
+it('filters symbols by the filter input', () => {
+  hookResult = {
+    status: 'ready',
+    filePath: '/ws/main.ts',
+    refresh: mockRefresh,
+    symbols: [sym('alpha', 12, 0), sym('beta', 12, 1)],
+  };
+  render(<StructureView />);
+
+  fireEvent.change(screen.getByLabelText('Filter symbols'), { target: { value: 'alph' } });
+  expect(screen.getByText('alpha')).toBeInTheDocument();
+  expect(screen.queryByText('beta')).not.toBeInTheDocument();
+});
+
+it('collapse-all collapses the visible tree even while a filter is active', () => {
+  // Two containers; filter narrows to one. Collapse-all must operate on the
+  // rendered (filtered) tree, not the full symbol list.
+  hookResult = {
+    status: 'ready',
+    filePath: '/ws/main.ts',
+    refresh: mockRefresh,
+    symbols: [sym('Widget', 5, 0, [sym('render', 6, 4)]), sym('Gadget', 5, 8, [sym('tick', 6, 9)])],
+  };
+  render(<StructureView />);
+
+  fireEvent.change(screen.getByLabelText('Filter symbols'), { target: { value: 'Widget' } });
+  expect(screen.getByText('render')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByTitle('Collapse all'));
+  expect(screen.queryByText('render')).not.toBeInTheDocument();
+});
+
+it('resets collapse state when the active file changes', () => {
+  hookResult = {
+    status: 'ready',
+    filePath: '/ws/a.ts',
+    refresh: mockRefresh,
+    symbols: [sym('Widget', 5, 0, [sym('render', 6, 4)])],
+  };
+  const { rerender } = render(<StructureView />);
+
+  fireEvent.click(screen.getByTitle('Collapse all'));
+  expect(screen.queryByText('render')).not.toBeInTheDocument();
+
+  // Switch to a different file with a same-shaped tree — collapse must reset so
+  // stale position-keyed collapse state can't hide the new file's symbols.
+  hookResult = {
+    status: 'ready',
+    filePath: '/ws/b.ts',
+    refresh: mockRefresh,
+    symbols: [sym('Widget', 5, 0, [sym('render', 6, 4)])],
+  };
+  rerender(<StructureView />);
+  expect(screen.getByText('render')).toBeInTheDocument();
+});

--- a/frontend/src/__tests__/hooks/useDocumentSymbols.test.ts
+++ b/frontend/src/__tests__/hooks/useDocumentSymbols.test.ts
@@ -33,7 +33,9 @@ function setActiveFile(path: string | null, content = 'x') {
         },
       ]
     : [];
-  useIDEStore.setState({ openFiles: file as never, activeFileId: path });
+  act(() => {
+    useIDEStore.setState({ openFiles: file as never, activeFileId: path });
+  });
 }
 
 function setServer(
@@ -43,7 +45,9 @@ function setServer(
     state: LSPServerStatus['state'];
   }
 ) {
-  useLSPStore.getState().setServerStatus(status as LSPServerStatus);
+  act(() => {
+    useLSPStore.getState().setServerStatus(status as LSPServerStatus);
+  });
 }
 
 beforeEach(() => {

--- a/frontend/src/__tests__/hooks/useDocumentSymbols.test.ts
+++ b/frontend/src/__tests__/hooks/useDocumentSymbols.test.ts
@@ -1,0 +1,174 @@
+import { renderHook, act } from '@testing-library/react';
+import { useIDEStore } from '../../stores/ideStore';
+import { useLSPStore, type LSPServerStatus } from '../../stores/lspStore';
+
+const mockDocumentSymbol = jest.fn();
+const mockFlush = jest.fn().mockResolvedValue(true);
+
+jest.mock('../../../wailsjs/go/main/App', () => ({
+  LSPDocumentSymbol: (...args: unknown[]) => mockDocumentSymbol(...args),
+}));
+
+jest.mock('../../utils/lspDocumentSync', () => ({
+  flushLSPDocumentChange: (...args: unknown[]) => mockFlush(...args),
+}));
+
+import { useDocumentSymbols, STRUCTURE_FETCH_DEBOUNCE_MS } from '../../hooks/useDocumentSymbols';
+
+const RANGE = { start: { line: 3, character: 2 }, end: { line: 5, character: 1 } };
+const SYMBOLS = [{ name: 'Widget', kind: 5, range: RANGE, selectionRange: RANGE, children: [] }];
+
+function setActiveFile(path: string | null, content = 'x') {
+  const file = path
+    ? [
+        {
+          id: path,
+          name: path.split('/').pop()!,
+          path,
+          language: 'typescript',
+          encoding: 'utf-8',
+          lineEndings: 'lf',
+          content,
+          isModified: false,
+        },
+      ]
+    : [];
+  useIDEStore.setState({ openFiles: file as never, activeFileId: path });
+}
+
+function setServer(
+  status: Partial<LSPServerStatus> & {
+    workspace: string;
+    family: string;
+    state: LSPServerStatus['state'];
+  }
+) {
+  useLSPStore.getState().setServerStatus(status as LSPServerStatus);
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockDocumentSymbol.mockReset();
+  mockDocumentSymbol.mockResolvedValue(SYMBOLS);
+  mockFlush.mockClear();
+  useLSPStore.getState().clearAllStatuses();
+  setActiveFile(null);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+// Advance timers and flush the microtask queue so awaited promises resolve.
+async function flushAsync(ms = STRUCTURE_FETCH_DEBOUNCE_MS) {
+  await act(async () => {
+    jest.advanceTimersByTime(ms);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+it('reports no-file when nothing is open', () => {
+  const { result } = renderHook(() => useDocumentSymbols());
+  expect(result.current.status).toBe('no-file');
+  expect(mockDocumentSymbol).not.toHaveBeenCalled();
+});
+
+it('reports unsupported for a file with no known LSP family', async () => {
+  setActiveFile('/ws/notes.txt');
+  const { result } = renderHook(() => useDocumentSymbols());
+  await flushAsync();
+  expect(result.current.status).toBe('unsupported');
+  expect(mockDocumentSymbol).not.toHaveBeenCalled();
+});
+
+it('reports lsp-unavailable when no ready server covers the file', async () => {
+  setActiveFile('/ws/main.ts');
+  setServer({ workspace: '/ws', family: 'typescript', state: 'starting' });
+  const { result } = renderHook(() => useDocumentSymbols());
+  await flushAsync();
+  expect(result.current.status).toBe('lsp-unavailable');
+  expect(mockDocumentSymbol).not.toHaveBeenCalled();
+});
+
+it('fetches and reports ready with symbols when a server is ready', async () => {
+  setActiveFile('/ws/main.ts');
+  setServer({ workspace: '/ws', family: 'typescript', state: 'ready' });
+  const { result } = renderHook(() => useDocumentSymbols());
+  await flushAsync();
+  expect(mockFlush).toHaveBeenCalledWith('/ws/main.ts');
+  expect(mockDocumentSymbol).toHaveBeenCalledWith('/ws/main.ts');
+  expect(result.current.status).toBe('ready');
+  expect(result.current.symbols).toHaveLength(1);
+  expect(result.current.symbols[0].name).toBe('Widget');
+});
+
+it('reports empty when the server returns no symbols', async () => {
+  mockDocumentSymbol.mockResolvedValue([]);
+  setActiveFile('/ws/main.ts');
+  setServer({ workspace: '/ws', family: 'typescript', state: 'ready' });
+  const { result } = renderHook(() => useDocumentSymbols());
+  await flushAsync();
+  expect(result.current.status).toBe('empty');
+});
+
+it('reports empty when the server returns null', async () => {
+  mockDocumentSymbol.mockResolvedValue(null);
+  setActiveFile('/ws/main.ts');
+  setServer({ workspace: '/ws', family: 'typescript', state: 'ready' });
+  const { result } = renderHook(() => useDocumentSymbols());
+  await flushAsync();
+  expect(result.current.status).toBe('empty');
+});
+
+it('reports error when the request fails', async () => {
+  mockDocumentSymbol.mockRejectedValue(new Error('boom'));
+  setActiveFile('/ws/main.ts');
+  setServer({ workspace: '/ws', family: 'typescript', state: 'ready' });
+  const { result } = renderHook(() => useDocumentSymbols());
+  await flushAsync();
+  expect(result.current.status).toBe('error');
+});
+
+it('drops a stale response when the active file changed mid-flight', async () => {
+  setServer({ workspace: '/ws', family: 'typescript', state: 'ready' });
+
+  // File A resolves slowly with A's symbols; File B resolves fast with B's.
+  const slow = [{ name: 'FromA', kind: 12, range: RANGE, selectionRange: RANGE, children: [] }];
+  const fast = [{ name: 'FromB', kind: 12, range: RANGE, selectionRange: RANGE, children: [] }];
+  mockDocumentSymbol.mockImplementation((path: string) => {
+    if (path === '/ws/a.ts') return new Promise((r) => setTimeout(() => r(slow), 500));
+    return Promise.resolve(fast);
+  });
+
+  setActiveFile('/ws/a.ts');
+  const { result, rerender } = renderHook(() => useDocumentSymbols());
+  await flushAsync(0); // kick off A's (slow) fetch
+
+  // Switch to B before A resolves.
+  setActiveFile('/ws/b.ts');
+  rerender();
+  await flushAsync(0); // B resolves fast
+  expect(result.current.symbols[0]?.name).toBe('FromB');
+
+  // Now let A's slow response arrive — it must be discarded.
+  await flushAsync(500);
+  expect(result.current.symbols[0]?.name).toBe('FromB');
+  expect(result.current.filePath).toBe('/ws/b.ts');
+});
+
+it('re-fetches when refresh() is called', async () => {
+  setActiveFile('/ws/main.ts');
+  setServer({ workspace: '/ws', family: 'typescript', state: 'ready' });
+  const { result } = renderHook(() => useDocumentSymbols());
+  await flushAsync();
+  expect(mockDocumentSymbol).toHaveBeenCalledTimes(1);
+
+  // refresh() bumps state; let the re-render commit its effect (which schedules
+  // the fetch timer) before advancing timers.
+  act(() => {
+    result.current.refresh();
+  });
+  await flushAsync(0);
+  expect(mockDocumentSymbol).toHaveBeenCalledTimes(2);
+});

--- a/frontend/src/__tests__/utils/documentSymbols.test.ts
+++ b/frontend/src/__tests__/utils/documentSymbols.test.ts
@@ -1,0 +1,79 @@
+import {
+  symbolKindMeta,
+  filterSymbolTree,
+  type DocumentSymbolNode,
+} from '../../utils/documentSymbols';
+
+function sym(name: string, kind: number, children: DocumentSymbolNode[] = []): DocumentSymbolNode {
+  const range = { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } };
+  return { name, kind, range, selectionRange: range, children };
+}
+
+describe('symbolKindMeta', () => {
+  it('maps known LSP kinds to a glyph, class, and label', () => {
+    const cls = symbolKindMeta(5); // Class
+    expect(cls.label).toBe('Class');
+    expect(cls.glyph).toBeTruthy();
+    expect(cls.className).toBeTruthy();
+
+    expect(symbolKindMeta(12).label).toBe('Function');
+    expect(symbolKindMeta(6).label).toBe('Method');
+    expect(symbolKindMeta(11).label).toBe('Interface');
+  });
+
+  it('distinguishes function and field glyphs (readability fix)', () => {
+    // Function and field must not collide on the same glyph.
+    expect(symbolKindMeta(12).glyph).not.toBe(symbolKindMeta(8).glyph);
+  });
+
+  it('falls back gracefully for unknown kinds', () => {
+    const meta = symbolKindMeta(999);
+    expect(meta.label).toBe('Symbol');
+    expect(meta.glyph).toBeTruthy();
+    expect(meta.className).toBeTruthy();
+  });
+});
+
+describe('filterSymbolTree', () => {
+  const tree: DocumentSymbolNode[] = [
+    sym('ProfileRunner', 5, [
+      sym('start', 6),
+      sym('stop', 6),
+      sym('handleExit', 6, [sym('nextStatus', 13)]),
+    ]),
+    sym('detectProfiles', 12),
+  ];
+
+  it('returns the tree unchanged for an empty query', () => {
+    expect(filterSymbolTree(tree, '')).toBe(tree);
+    expect(filterSymbolTree(tree, '   ')).toBe(tree);
+  });
+
+  it('keeps a node and its full subtree when the node name matches', () => {
+    const out = filterSymbolTree(tree, 'ProfileRunner');
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('ProfileRunner');
+    // Matching node keeps all descendants
+    expect(out[0].children).toHaveLength(3);
+  });
+
+  it('keeps ancestors when a descendant matches, pruning non-matching siblings', () => {
+    const out = filterSymbolTree(tree, 'nextStatus');
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('ProfileRunner');
+    // Only the branch leading to the match survives
+    expect(out[0].children).toHaveLength(1);
+    expect(out[0].children![0].name).toBe('handleExit');
+    expect(out[0].children![0].children![0].name).toBe('nextStatus');
+  });
+
+  it('matches case-insensitively and by substring', () => {
+    const out = filterSymbolTree(tree, 'PROFILE');
+    // Matches both 'ProfileRunner' and 'detectProfiles'
+    expect(out.map((s) => s.name).sort()).toEqual(['ProfileRunner', 'detectProfiles']);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    expect(filterSymbolTree(tree, 'zzzz')).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,13 @@
 import { useCallback } from 'react';
 import styles from './Sidebar.module.css';
-import { FilesIcon, SearchIcon, GitBranchIcon, PlayIcon, SettingsIcon } from '../icons';
+import {
+  FilesIcon,
+  SearchIcon,
+  GitBranchIcon,
+  PlayIcon,
+  StructureIcon,
+  SettingsIcon,
+} from '../icons';
 import { useIDEStore, SidebarView, useIsLeftPanelCollapsed } from '../../stores/ideStore';
 import { formatShortcut } from '../../utils/platform';
 
@@ -14,6 +21,7 @@ const SIDEBAR_ITEMS: Array<{
   { view: 'search', icon: SearchIcon, label: 'Search', shortcut: '⌘⇧F' },
   { view: 'git', icon: GitBranchIcon, label: 'Source Control', shortcut: '⌘⇧G' },
   { view: 'run', icon: PlayIcon, label: 'Run Profiles', shortcut: '⌘⇧P' },
+  { view: 'structure', icon: StructureIcon, label: 'Structure', shortcut: '⌘⇧Y' },
 ];
 
 export function Sidebar() {

--- a/frontend/src/components/Structure/StructureView.module.css
+++ b/frontend/src/components/Structure/StructureView.module.css
@@ -1,0 +1,361 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--surface-panel);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 12px 10px 14px;
+  border-bottom: 1px solid var(--surface-border-subtle);
+  flex: none;
+}
+
+.title {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  font-weight: 650;
+}
+
+.actions {
+  display: flex;
+  gap: 2px;
+}
+
+.iconBtn {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.iconBtn:hover:not(:disabled) {
+  background: var(--surface-hover);
+  color: var(--text-secondary);
+}
+
+.iconBtn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.iconBtn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+}
+
+.actionIcon {
+  width: 15px;
+  height: 15px;
+}
+
+.filterRow {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 8px 12px;
+  padding: 5px 9px;
+  background: var(--surface-base);
+  border: 1px solid var(--surface-border-subtle);
+  border-radius: 6px;
+  flex: none;
+}
+
+.filterRow:focus-within {
+  border-color: var(--accent);
+}
+
+.filterIcon {
+  width: 13px;
+  height: 13px;
+  color: var(--text-muted);
+  flex: none;
+}
+
+.filterInput {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text-secondary);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px;
+}
+
+.filterInput::placeholder {
+  color: var(--text-muted);
+}
+
+.body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.tree {
+  padding: 4px 0 12px;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 24px;
+  padding-right: 12px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12.5px;
+  color: var(--text-primary);
+  cursor: pointer;
+  white-space: nowrap;
+  position: relative;
+}
+
+.row:hover {
+  background: var(--surface-hover);
+}
+
+.row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.twisty {
+  width: 12px;
+  height: 12px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.twisty.leaf {
+  cursor: default;
+  visibility: hidden;
+}
+
+.twistyIcon {
+  width: 10px;
+  height: 10px;
+}
+
+.kind {
+  width: 16px;
+  height: 16px;
+  flex: none;
+  border-radius: 4px;
+  display: grid;
+  place-items: center;
+  font-size: 10px;
+  font-weight: 700;
+  font-family: var(--font-sans, sans-serif);
+  color: #04121f;
+  user-select: none;
+}
+
+.name {
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.detail {
+  color: var(--text-muted);
+  font-size: 11.5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Symbol-kind badge colors, mapped to Firn accents. */
+.kClass {
+  background: var(--accent-orange);
+}
+.kInterface {
+  background: var(--accent-blue);
+  color: #dbeafe;
+}
+.kMethod {
+  background: var(--accent-purple);
+  color: #faf5ff;
+}
+.kFunction {
+  background: var(--accent-purple);
+  color: #faf5ff;
+}
+.kProperty {
+  background: var(--accent-cyan);
+}
+.kField {
+  background: var(--accent-cyan);
+}
+.kVariable {
+  background: var(--accent-blue);
+  color: #dbeafe;
+}
+.kConstant {
+  background: var(--accent-amber);
+}
+.kEnum {
+  background: var(--accent-green);
+}
+.kStruct {
+  background: var(--accent-orange);
+}
+.kModule,
+.kNamespace,
+.kTypeParam {
+  background: var(--accent-cyan);
+}
+.kFile,
+.kString,
+.kNumber,
+.kBoolean,
+.kArray,
+.kObject,
+.kNull,
+.kEvent,
+.kOperator,
+.kUnknown {
+  background: var(--accent-general, #6b7280);
+  color: #e5e7eb;
+}
+
+/* --- Empty / error / loading states --- */
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 40px 22px;
+  gap: 10px;
+  height: 100%;
+}
+
+.emptyGlyph {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  background: var(--surface-elevated);
+  color: var(--text-muted);
+}
+
+.emptyGlyph svg {
+  width: 20px;
+  height: 20px;
+}
+
+.emptyGlyph.warn {
+  color: var(--accent-amber);
+  background: rgba(245, 158, 11, 0.1);
+}
+
+.emptyGlyph.error {
+  color: #f87171;
+  background: rgba(248, 113, 113, 0.1);
+}
+
+.emptyTitle {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.emptyMsg {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
+  max-width: 32ch;
+}
+
+.emptyAction {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--accent);
+  border: 1px solid var(--accent-glow);
+  background: var(--accent-dim);
+  padding: 5px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.emptyAction:hover {
+  background: var(--accent-glow);
+}
+
+.emptyAction:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.loading {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 0;
+}
+
+.skelRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 24px;
+  padding-right: 14px;
+}
+
+.skelBox {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  flex: none;
+}
+
+.skelBar {
+  height: 9px;
+  border-radius: 3px;
+}
+
+.skelBox,
+.skelBar {
+  background: linear-gradient(
+    90deg,
+    var(--surface-elevated),
+    var(--surface-hover),
+    var(--surface-elevated)
+  );
+  background-size: 200% 100%;
+  animation: structureShimmer 1.3s ease-in-out infinite;
+}
+
+@keyframes structureShimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skelBox,
+  .skelBar {
+    animation: none;
+  }
+}

--- a/frontend/src/components/Structure/StructureView.tsx
+++ b/frontend/src/components/Structure/StructureView.tsx
@@ -1,0 +1,347 @@
+import { useCallback, useMemo, useState } from 'react';
+import styles from './StructureView.module.css';
+import { ChevronDownIcon, ChevronRightIcon, SearchIcon, CollapseIcon } from '../icons';
+import { useDocumentSymbols } from '../../hooks/useDocumentSymbols';
+import {
+  filterSymbolTree,
+  symbolKindMeta,
+  type DocumentSymbolNode,
+} from '../../utils/documentSymbols';
+import { navigateToEditorLocation } from '../../utils/editorNavigation';
+
+/** Stable key for a node's position in the tree (used for collapse state). */
+function nodeKey(parentKey: string, index: number, node: DocumentSymbolNode): string {
+  return `${parentKey}/${index}:${node.name}:${node.kind}`;
+}
+
+/** Collects the keys of every container (has children) node in the tree. */
+function collectContainerKeys(
+  nodes: DocumentSymbolNode[],
+  parentKey: string,
+  acc: Set<string>
+): void {
+  nodes.forEach((node, i) => {
+    if (node.children && node.children.length > 0) {
+      const key = nodeKey(parentKey, i, node);
+      acc.add(key);
+      collectContainerKeys(node.children, key, acc);
+    }
+  });
+}
+
+interface RefreshIconProps {
+  className?: string;
+}
+function RefreshIcon({ className }: RefreshIconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      className={className}
+    >
+      <path d="M21 12a9 9 0 1 1-2.64-6.36M21 4v5h-5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+interface SymbolRowProps {
+  node: DocumentSymbolNode;
+  depth: number;
+  nodeId: string;
+  collapsed: Set<string>;
+  onToggle: (key: string) => void;
+  onSelect: (node: DocumentSymbolNode) => void;
+}
+
+function SymbolRow({ node, depth, nodeId, collapsed, onToggle, onSelect }: SymbolRowProps) {
+  const meta = symbolKindMeta(node.kind);
+  const hasChildren = !!node.children && node.children.length > 0;
+  const isCollapsed = collapsed.has(nodeId);
+
+  return (
+    <>
+      <div
+        className={styles.row}
+        role="treeitem"
+        aria-expanded={hasChildren ? !isCollapsed : undefined}
+        tabIndex={0}
+        style={{ paddingLeft: 8 + depth * 14 }}
+        onClick={() => onSelect(node)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onSelect(node);
+          } else if (e.key === 'ArrowRight' && hasChildren && isCollapsed) {
+            e.preventDefault();
+            onToggle(nodeId);
+          } else if (e.key === 'ArrowLeft' && hasChildren && !isCollapsed) {
+            e.preventDefault();
+            onToggle(nodeId);
+          }
+        }}
+        title={`${meta.label}: ${node.name}`}
+      >
+        <span
+          className={`${styles.twisty} ${hasChildren ? '' : styles.leaf}`}
+          onClick={(e) => {
+            if (!hasChildren) return;
+            e.stopPropagation();
+            onToggle(nodeId);
+          }}
+          aria-hidden={!hasChildren}
+        >
+          {hasChildren &&
+            (isCollapsed ? (
+              <ChevronRightIcon className={styles.twistyIcon} />
+            ) : (
+              <ChevronDownIcon className={styles.twistyIcon} />
+            ))}
+        </span>
+        <span className={`${styles.kind} ${styles[meta.className] ?? ''}`}>{meta.glyph}</span>
+        <span className={styles.name}>{node.name}</span>
+        {node.detail && <span className={styles.detail}>{node.detail}</span>}
+      </div>
+      {hasChildren && !isCollapsed && (
+        <div role="group">
+          {node.children!.map((child, i) => {
+            const childId = nodeKey(nodeId, i, child);
+            return (
+              <SymbolRow
+                key={childId}
+                node={child}
+                depth={depth + 1}
+                nodeId={childId}
+                collapsed={collapsed}
+                onToggle={onToggle}
+                onSelect={onSelect}
+              />
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+}
+
+interface EmptyStateProps {
+  title: string;
+  message: string;
+  tone?: 'neutral' | 'warn' | 'error';
+  action?: { label: string; onClick: () => void };
+  icon: React.ReactNode;
+}
+function EmptyState({ title, message, tone = 'neutral', action, icon }: EmptyStateProps) {
+  return (
+    <div className={styles.empty}>
+      <div
+        className={`${styles.emptyGlyph} ${tone === 'warn' ? styles.warn : ''} ${tone === 'error' ? styles.error : ''}`}
+      >
+        {icon}
+      </div>
+      <h4 className={styles.emptyTitle}>{title}</h4>
+      <p className={styles.emptyMsg}>{message}</p>
+      {action && (
+        <button type="button" className={styles.emptyAction} onClick={action.onClick}>
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+}
+
+const InfoIcon = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7">
+    <path d="M4 6h10M4 12h7M4 18h9" strokeLinecap="round" />
+  </svg>
+);
+const BlockedIcon = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6">
+    <rect x="4" y="4" width="16" height="16" rx="2" />
+    <path d="M9 9l6 6M15 9l-6 6" strokeLinecap="round" />
+  </svg>
+);
+const WarnIcon = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7">
+    <path d="M12 3l9 16H3z" strokeLinejoin="round" />
+    <path d="M12 9v5M12 17h.01" strokeLinecap="round" />
+  </svg>
+);
+const ErrorIcon = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7">
+    <circle cx="12" cy="12" r="9" />
+    <path d="M12 8v4M12 16h.01" strokeLinecap="round" />
+  </svg>
+);
+
+export function StructureView() {
+  const { status, symbols, filePath, refresh } = useDocumentSymbols();
+  const [query, setQuery] = useState('');
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+
+  // Reset collapse state when the file changes — position-based keys would
+  // otherwise bleed across files and the Set would grow unbounded over a
+  // session. Storing the previous file in state and adjusting during render is
+  // React's documented "reset state on prop change" pattern (no effect needed).
+  const [prevFile, setPrevFile] = useState(filePath);
+  if (prevFile !== filePath) {
+    setPrevFile(filePath);
+    if (collapsed.size > 0) setCollapsed(new Set());
+  }
+
+  const filtered = useMemo(() => filterSymbolTree(symbols, query), [symbols, query]);
+
+  const handleToggle = useCallback((key: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  // Collapse the *rendered* tree — using `filtered`, not `symbols`, so the keys
+  // line up with the visible nodes when a filter is active.
+  const handleCollapseAll = useCallback(() => {
+    const keys = new Set<string>();
+    collectContainerKeys(filtered, 'root', keys);
+    setCollapsed(keys);
+  }, [filtered]);
+
+  const handleSelect = useCallback(
+    (node: DocumentSymbolNode) => {
+      if (!filePath) return;
+      const pos = node.selectionRange?.start ?? node.range.start;
+      navigateToEditorLocation(filePath, pos.line + 1, pos.character + 1);
+    },
+    [filePath]
+  );
+
+  const showTree = status === 'ready';
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <span className={styles.title}>Structure</span>
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={styles.iconBtn}
+            title="Collapse all"
+            onClick={handleCollapseAll}
+            disabled={!showTree}
+          >
+            <CollapseIcon className={styles.actionIcon} />
+          </button>
+          <button
+            type="button"
+            className={styles.iconBtn}
+            title="Refresh"
+            onClick={refresh}
+            disabled={status === 'no-file'}
+          >
+            <RefreshIcon className={styles.actionIcon} />
+          </button>
+        </div>
+      </div>
+
+      {showTree && (
+        <div className={styles.filterRow}>
+          <SearchIcon className={styles.filterIcon} />
+          <input
+            className={styles.filterInput}
+            placeholder="Filter symbols…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            aria-label="Filter symbols"
+          />
+        </div>
+      )}
+
+      <div className={styles.body}>
+        {status === 'loading' && (
+          <div className={styles.loading} role="status" aria-label="Loading symbols">
+            {[0, 1, 2, 3, 4].map((i) => (
+              <div key={i} className={styles.skelRow} style={{ paddingLeft: 8 + (i % 2) * 20 }}>
+                <span className={styles.skelBox} />
+                <span className={styles.skelBar} style={{ width: `${40 + ((i * 13) % 40)}%` }} />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {status === 'no-file' && (
+          <EmptyState
+            icon={InfoIcon}
+            title="No file open"
+            message="Open a file in the editor to see its structure."
+          />
+        )}
+
+        {status === 'unsupported' && (
+          <EmptyState
+            icon={BlockedIcon}
+            title="Structure unavailable for this file"
+            message="No language server covers this file type. Open a source file to see its outline."
+          />
+        )}
+
+        {status === 'lsp-unavailable' && (
+          <EmptyState
+            icon={WarnIcon}
+            tone="warn"
+            title="Language server not ready"
+            message="Structure will populate once the language server for this file is ready."
+            action={{ label: 'Retry', onClick: refresh }}
+          />
+        )}
+
+        {status === 'empty' && (
+          <EmptyState
+            icon={InfoIcon}
+            title="No symbols in this file"
+            message="The language server returned no symbols for this file."
+          />
+        )}
+
+        {status === 'error' && (
+          <EmptyState
+            icon={ErrorIcon}
+            tone="error"
+            title="Couldn't load structure"
+            message="The documentSymbol request failed or timed out."
+            action={{ label: 'Retry', onClick: refresh }}
+          />
+        )}
+
+        {showTree && filtered.length === 0 && (
+          <EmptyState
+            icon={InfoIcon}
+            title="No matching symbols"
+            message={`Nothing matches “${query.trim()}”.`}
+          />
+        )}
+
+        {showTree && filtered.length > 0 && (
+          <div className={styles.tree} role="tree" aria-label="Document symbols">
+            {filtered.map((node, i) => {
+              const id = nodeKey('root', i, node);
+              return (
+                <SymbolRow
+                  key={id}
+                  node={node}
+                  depth={0}
+                  nodeId={id}
+                  collapsed={collapsed}
+                  onToggle={handleToggle}
+                  onSelect={handleSelect}
+                />
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Structure/index.ts
+++ b/frontend/src/components/Structure/index.ts
@@ -1,0 +1,1 @@
+export { StructureView } from './StructureView';

--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -70,6 +70,16 @@ export function PlayIcon(props: IconProps) {
   );
 }
 
+export function StructureIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+      <path d="M4 6h6M4 12h9M4 18h5" strokeLinecap="round" />
+      <circle cx="18" cy="6" r="1.6" fill="currentColor" stroke="none" />
+      <circle cx="18" cy="12" r="1.6" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
 export function SettingsIcon(props: IconProps) {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>

--- a/frontend/src/hooks/useDocumentSymbols.ts
+++ b/frontend/src/hooks/useDocumentSymbols.ts
@@ -1,0 +1,136 @@
+/**
+ * useDocumentSymbols — drives the Structure view (issue #168).
+ *
+ * Fetches `textDocument/documentSymbol` for the active editor file and exposes a
+ * discriminated status so the view can render populated / empty / error /
+ * unavailable states without inventing placeholder data.
+ *
+ * Refresh triggers:
+ *  - active file changes    → immediate fetch (with a loading state)
+ *  - active file edited     → debounced re-fetch (keeps current symbols visible)
+ *  - server becomes ready   → fetch
+ *  - refresh() called       → immediate re-fetch
+ *
+ * Stale-response guard: every fetch captures a monotonic token; a response is
+ * applied only if its token is still the latest. Rapid tab/edit switches can
+ * never surface another file's symbols.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useIDEStore } from '../stores/ideStore';
+import { useLSPStore, findServerStatusForFile } from '../stores/lspStore';
+import { lspFamilyForFile } from '../utils/lspLanguageId';
+import { flushLSPDocumentChange } from '../utils/lspDocumentSync';
+import { LSPDocumentSymbol } from '../../wailsjs/go/main/App';
+import type { DocumentSymbolNode } from '../utils/documentSymbols';
+
+export const STRUCTURE_FETCH_DEBOUNCE_MS = 300;
+
+export type StructureStatus =
+  | 'no-file'
+  | 'loading'
+  | 'ready'
+  | 'empty'
+  | 'unsupported'
+  | 'lsp-unavailable'
+  | 'error';
+
+export interface UseDocumentSymbolsResult {
+  status: StructureStatus;
+  symbols: DocumentSymbolNode[];
+  filePath: string | null;
+  refresh: () => void;
+}
+
+type GateKind = 'no-file' | 'unsupported' | 'lsp-unavailable' | 'fetch';
+
+interface FetchState {
+  status: 'loading' | 'ready' | 'empty' | 'error';
+  symbols: DocumentSymbolNode[];
+  filePath: string | null;
+}
+
+const EMPTY: DocumentSymbolNode[] = [];
+
+export function useDocumentSymbols(): UseDocumentSymbolsResult {
+  const activeFileId = useIDEStore((s) => s.activeFileId);
+  const openFiles = useIDEStore((s) => s.openFiles);
+  const serverStatuses = useLSPStore((s) => s.serverStatuses);
+
+  const activeFile = useMemo(
+    () => openFiles.find((f) => f.id === activeFileId) ?? null,
+    [openFiles, activeFileId]
+  );
+  const path = activeFile?.path ?? null;
+  const name = activeFile?.name ?? null;
+  const content = activeFile?.content ?? '';
+
+  const [nonce, setNonce] = useState(0);
+  const refresh = useCallback(() => setNonce((n) => n + 1), []);
+
+  // The gate is derived during render — cheap and side-effect free — so we only
+  // reach for state + an effect when an async documentSymbol call is actually
+  // needed. This keeps synchronous setState out of the effect body.
+  const gate: GateKind = useMemo(() => {
+    if (!path || !name) return 'no-file';
+    if (!lspFamilyForFile(name)) return 'unsupported';
+    const server = findServerStatusForFile(serverStatuses, path, lspFamilyForFile(name));
+    if (!server || server.state !== 'ready') return 'lsp-unavailable';
+    return 'fetch';
+  }, [path, name, serverStatuses]);
+
+  const [fetchState, setFetchState] = useState<FetchState>({
+    status: 'loading',
+    symbols: EMPTY,
+    filePath: null,
+  });
+
+  const tokenRef = useRef(0);
+  const prevPathRef = useRef<string | null>(null);
+  const prevNonceRef = useRef(0);
+
+  useEffect(() => {
+    if (gate !== 'fetch' || !path) return;
+
+    const switched = path !== prevPathRef.current;
+    const nonceChanged = nonce !== prevNonceRef.current;
+    const immediate = switched || nonceChanged;
+    prevPathRef.current = path;
+    prevNonceRef.current = nonce;
+
+    const token = ++tokenRef.current;
+    const fetchPath = path;
+
+    const run = async () => {
+      try {
+        await flushLSPDocumentChange(fetchPath);
+        const result = await LSPDocumentSymbol(fetchPath);
+        if (token !== tokenRef.current) return; // stale — a newer request won
+        const symbols = (result ?? EMPTY) as DocumentSymbolNode[];
+        setFetchState({
+          status: symbols.length > 0 ? 'ready' : 'empty',
+          symbols,
+          filePath: fetchPath,
+        });
+      } catch {
+        if (token !== tokenRef.current) return;
+        setFetchState({ status: 'error', symbols: EMPTY, filePath: fetchPath });
+      }
+    };
+
+    const timer = setTimeout(run, immediate ? 0 : STRUCTURE_FETCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+    // `content` is an intentional trigger: edits re-fetch (debounced).
+  }, [gate, path, content, nonce]);
+
+  // --- Derive the exposed status. ---
+  if (gate !== 'fetch') {
+    return { status: gate, symbols: EMPTY, filePath: gate === 'no-file' ? null : path, refresh };
+  }
+  // A fetch is in flight (or done). Until results for the *current* file land,
+  // report loading — this covers the file-switch gap without a setState flash.
+  if (fetchState.filePath === path) {
+    return { status: fetchState.status, symbols: fetchState.symbols, filePath: path, refresh };
+  }
+  return { status: 'loading', symbols: EMPTY, filePath: path, refresh };
+}

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -96,6 +96,19 @@ export function useKeyboardShortcuts() {
         return;
       }
 
+      // Cmd+Shift+Y / Ctrl+Shift+Y — Structure (current-file outline).
+      if (modifier && e.shiftKey && (e.key === 'y' || e.key === 'Y')) {
+        e.preventDefault();
+        const ide = useIDEStore.getState();
+        if (ide.activeSidebarView !== 'structure') {
+          ide.setSidebarView('structure');
+        }
+        if (ide.isLeftPanelCollapsed) {
+          ide.toggleLeftPanel();
+        }
+        return;
+      }
+
       // Cmd+[ / Cmd+] on macOS, Alt+Left / Alt+Right elsewhere — editor navigation history.
       // On macOS these may also arrive via Wails native menu events (navigate:back/forward)
       // because WKWebView sometimes intercepts Cmd+[/Cmd+] before JavaScript can handle them.

--- a/frontend/src/stores/ideStore.ts
+++ b/frontend/src/stores/ideStore.ts
@@ -41,7 +41,7 @@ export function loadInitialSyntaxTheme(): SyntaxThemeId {
 }
 
 // Types
-export type SidebarView = 'explorer' | 'search' | 'git' | 'run';
+export type SidebarView = 'explorer' | 'search' | 'git' | 'run' | 'structure';
 export type TerminalTab = 'terminal' | 'output' | 'problems';
 export type WorkspaceAccent =
   | 'project'

--- a/frontend/src/utils/documentSymbols.ts
+++ b/frontend/src/utils/documentSymbols.ts
@@ -1,0 +1,104 @@
+/**
+ * Document-symbol helpers for the Structure view (issue #168).
+ *
+ * Pure functions only — kind→glyph mapping and tree filtering — so they can be
+ * unit-tested without React or the Wails bridge. The node shape mirrors the
+ * backend `lsp.DocumentSymbol` (normalized; SymbolInformation is flattened into
+ * this same shape server-side).
+ */
+
+export interface SymbolRange {
+  start: { line: number; character: number };
+  end: { line: number; character: number };
+}
+
+export interface DocumentSymbolNode {
+  name: string;
+  detail?: string;
+  kind: number;
+  range: SymbolRange;
+  selectionRange: SymbolRange;
+  children?: DocumentSymbolNode[];
+}
+
+export interface SymbolKindMeta {
+  /** Single-character badge glyph shown in the tree. */
+  glyph: string;
+  /** CSS-module class controlling the badge color. */
+  className: string;
+  /** Human label for tooltips/accessibility. */
+  label: string;
+}
+
+// LSP SymbolKind codes (1-26). Glyphs are chosen for at-a-glance legibility:
+// function (F) and field (●) deliberately differ so they never collide.
+const KIND_META: Record<number, SymbolKindMeta> = {
+  1: { glyph: '⊡', className: 'kFile', label: 'File' },
+  2: { glyph: 'M', className: 'kModule', label: 'Module' },
+  3: { glyph: 'N', className: 'kNamespace', label: 'Namespace' },
+  4: { glyph: 'P', className: 'kNamespace', label: 'Package' },
+  5: { glyph: 'C', className: 'kClass', label: 'Class' },
+  6: { glyph: 'M', className: 'kMethod', label: 'Method' },
+  7: { glyph: 'P', className: 'kProperty', label: 'Property' },
+  8: { glyph: 'f', className: 'kField', label: 'Field' },
+  9: { glyph: 'C', className: 'kMethod', label: 'Constructor' },
+  10: { glyph: 'E', className: 'kEnum', label: 'Enum' },
+  11: { glyph: 'I', className: 'kInterface', label: 'Interface' },
+  12: { glyph: 'ƒ', className: 'kFunction', label: 'Function' },
+  13: { glyph: 'v', className: 'kVariable', label: 'Variable' },
+  14: { glyph: 'k', className: 'kConstant', label: 'Constant' },
+  15: { glyph: 's', className: 'kString', label: 'String' },
+  16: { glyph: '#', className: 'kNumber', label: 'Number' },
+  17: { glyph: 'b', className: 'kBoolean', label: 'Boolean' },
+  18: { glyph: '[]', className: 'kArray', label: 'Array' },
+  19: { glyph: '{}', className: 'kObject', label: 'Object' },
+  20: { glyph: 'k', className: 'kProperty', label: 'Key' },
+  21: { glyph: '∅', className: 'kNull', label: 'Null' },
+  22: { glyph: 'e', className: 'kEnum', label: 'EnumMember' },
+  23: { glyph: 'S', className: 'kStruct', label: 'Struct' },
+  24: { glyph: '⚡', className: 'kEvent', label: 'Event' },
+  25: { glyph: '±', className: 'kOperator', label: 'Operator' },
+  26: { glyph: 'T', className: 'kTypeParam', label: 'TypeParameter' },
+};
+
+const FALLBACK_META: SymbolKindMeta = { glyph: '•', className: 'kUnknown', label: 'Symbol' };
+
+/** Returns the badge metadata for an LSP SymbolKind, with a safe fallback. */
+export function symbolKindMeta(kind: number): SymbolKindMeta {
+  return KIND_META[kind] ?? FALLBACK_META;
+}
+
+/**
+ * Filters a symbol tree by a case-insensitive substring query.
+ *
+ * - Empty/whitespace query returns the original tree by reference (no copy).
+ * - A node whose own name matches keeps its entire subtree.
+ * - A non-matching node is kept only if a descendant matches, and then only its
+ *   matching branches survive (VS Code Outline filter behavior).
+ */
+export function filterSymbolTree(
+  symbols: DocumentSymbolNode[],
+  query: string
+): DocumentSymbolNode[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return symbols;
+
+  const walk = (nodes: DocumentSymbolNode[]): DocumentSymbolNode[] => {
+    const out: DocumentSymbolNode[] = [];
+    for (const node of nodes) {
+      const selfMatch = node.name.toLowerCase().includes(q);
+      if (selfMatch) {
+        // Keep the whole subtree so users see everything under a matched symbol.
+        out.push(node);
+        continue;
+      }
+      const keptChildren = node.children ? walk(node.children) : [];
+      if (keptChildren.length > 0) {
+        out.push({ ...node, children: keptChildren });
+      }
+    }
+    return out;
+  };
+
+  return walk(symbols);
+}

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -66,6 +66,8 @@ export function LSPComplete(arg1:string,arg2:number,arg3:number,arg4:string):Pro
 
 export function LSPDefinition(arg1:string,arg2:number,arg3:number):Promise<Array<lsp.Location>>;
 
+export function LSPDocumentSymbol(arg1:string):Promise<Array<lsp.DocumentSymbol>>;
+
 export function LSPDidChange(arg1:string,arg2:number,arg3:Array<lsp.TextDocumentContentChangeEvent>):Promise<void>;
 
 export function LSPDidClose(arg1:string):Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -118,6 +118,10 @@ export function LSPDefinition(arg1, arg2, arg3) {
   return window['go']['main']['App']['LSPDefinition'](arg1, arg2, arg3);
 }
 
+export function LSPDocumentSymbol(arg1) {
+  return window['go']['main']['App']['LSPDocumentSymbol'](arg1);
+}
+
 export function LSPDidChange(arg1, arg2, arg3) {
   return window['go']['main']['App']['LSPDidChange'](arg1, arg2, arg3);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -380,6 +380,46 @@ export namespace lsp {
 		    return a;
 		}
 	}
+	export class DocumentSymbol {
+	    name: string;
+	    detail?: string;
+	    kind: number;
+	    range: Range;
+	    selectionRange: Range;
+	    children?: DocumentSymbol[];
+
+	    static createFrom(source: any = {}) {
+	        return new DocumentSymbol(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.name = source["name"];
+	        this.detail = source["detail"];
+	        this.kind = source["kind"];
+	        this.range = this.convertValues(source["range"], Range);
+	        this.selectionRange = this.convertValues(source["selectionRange"], Range);
+	        this.children = this.convertValues(source["children"], DocumentSymbol);
+	    }
+
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
 	export class Location {
 	    uri: string;
 	    range: Range;

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -34,6 +34,7 @@ var clientCapabilities = json.RawMessage(`{
 		},
 		"hover": {"contentFormat": ["markdown", "plaintext"]},
 		"definition": {},
+		"documentSymbol": {"hierarchicalDocumentSymbolSupport": true},
 		"publishDiagnostics": {"versionSupport": true}
 	}
 }`)
@@ -278,6 +279,72 @@ func (c *Client) Definition(ctx context.Context, uri string, line, character int
 		locations = []Location{single}
 	}
 	return locations, nil
+}
+
+// DocumentSymbol sends a textDocument/documentSymbol request and returns the
+// file's symbols normalized to the hierarchical DocumentSymbol shape.
+func (c *Client) DocumentSymbol(ctx context.Context, uri string) ([]DocumentSymbol, error) {
+	params := DocumentSymbolParams{
+		TextDocument: TextDocumentIdentifier{URI: uri},
+	}
+
+	var raw json.RawMessage
+	if err := c.call(ctx, "textDocument/documentSymbol", params, &raw); err != nil {
+		return nil, err
+	}
+	return normalizeDocumentSymbols(raw)
+}
+
+// normalizeDocumentSymbols converts a raw textDocument/documentSymbol result
+// into a slice of hierarchical DocumentSymbols.
+//
+// The LSP result is either DocumentSymbol[] (hierarchical, has selectionRange)
+// or the legacy SymbolInformation[] (flat, has location). We disambiguate by
+// inspecting the first element's keys: presence of "location" means the flat
+// shape, which we convert element-by-element into flat DocumentSymbols. An
+// empty array or JSON null yields an empty slice (not an error) — those are
+// valid "no symbols" responses.
+func normalizeDocumentSymbols(raw json.RawMessage) ([]DocumentSymbol, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+
+	var elements []json.RawMessage
+	if err := json.Unmarshal(raw, &elements); err != nil {
+		return nil, fmt.Errorf("unmarshal documentSymbol result: %w", err)
+	}
+	if len(elements) == 0 {
+		return nil, nil
+	}
+
+	// Peek at the first element to decide which shape the server returned.
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(elements[0], &probe); err != nil {
+		return nil, fmt.Errorf("unmarshal documentSymbol element: %w", err)
+	}
+
+	if _, isFlat := probe["location"]; isFlat {
+		symbols := make([]DocumentSymbol, 0, len(elements))
+		for _, el := range elements {
+			var info symbolInformation
+			if err := json.Unmarshal(el, &info); err != nil {
+				return nil, fmt.Errorf("unmarshal SymbolInformation: %w", err)
+			}
+			symbols = append(symbols, DocumentSymbol{
+				Name:           info.Name,
+				Kind:           info.Kind,
+				Range:          info.Location.Range,
+				SelectionRange: info.Location.Range,
+			})
+		}
+		return symbols, nil
+	}
+
+	var symbols []DocumentSymbol
+	if err := json.Unmarshal(raw, &symbols); err != nil {
+		return nil, fmt.Errorf("unmarshal DocumentSymbol[]: %w", err)
+	}
+	return symbols, nil
 }
 
 // Complete sends a textDocument/completion request.

--- a/internal/lsp/client_test.go
+++ b/internal/lsp/client_test.go
@@ -33,6 +33,9 @@ func TestClient_InitializeAndShutdown(t *testing.T) {
 	if caps.DefinitionProvider == nil {
 		t.Error("DefinitionProvider capability not stored")
 	}
+	if caps.DocumentSymbolProvider == nil {
+		t.Error("DocumentSymbolProvider capability not stored")
+	}
 
 	if err := client.Shutdown(ctx); err != nil {
 		t.Fatalf("Shutdown: %v", err)
@@ -110,6 +113,120 @@ func TestClient_Definition(t *testing.T) {
 	}
 
 	_ = client.Shutdown(ctx)
+}
+
+func TestClient_DocumentSymbol(t *testing.T) {
+	transport := startMockTransport(t)
+	client := NewClient(transport, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := client.Initialize(ctx, "file:///tmp/test", nil); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	symbols, err := client.DocumentSymbol(ctx, "file:///tmp/test/main.ts")
+	if err != nil {
+		t.Fatalf("DocumentSymbol: %v", err)
+	}
+	if len(symbols) != 1 {
+		t.Fatalf("got %d top-level symbols, want 1", len(symbols))
+	}
+	if symbols[0].Name != "Widget" || symbols[0].Kind != 5 {
+		t.Errorf("top symbol = %q kind %d, want Widget kind 5", symbols[0].Name, symbols[0].Kind)
+	}
+	if len(symbols[0].Children) != 1 || symbols[0].Children[0].Name != "render" {
+		t.Errorf("expected one child 'render', got %+v", symbols[0].Children)
+	}
+
+	_ = client.Shutdown(ctx)
+}
+
+func TestNormalizeDocumentSymbols(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantLen   int
+		wantFirst string
+		wantChild string // name of first child of first symbol, "" if none expected
+		wantRange Range
+	}{
+		{
+			name:    "null result",
+			raw:     "null",
+			wantLen: 0,
+		},
+		{
+			name:    "empty array",
+			raw:     "[]",
+			wantLen: 0,
+		},
+		{
+			name:      "hierarchical DocumentSymbol with children",
+			raw:       `[{"name":"App","kind":5,"range":{"start":{"line":0,"character":0},"end":{"line":9,"character":1}},"selectionRange":{"start":{"line":0,"character":6},"end":{"line":0,"character":9}},"children":[{"name":"run","kind":6,"range":{"start":{"line":1,"character":2},"end":{"line":3,"character":3}},"selectionRange":{"start":{"line":1,"character":2},"end":{"line":1,"character":5}}}]}]`,
+			wantLen:   1,
+			wantFirst: "App",
+			wantChild: "run",
+			wantRange: Range{Start: Position{Line: 0, Character: 0}, End: Position{Line: 9, Character: 1}},
+		},
+		{
+			name:      "flat SymbolInformation is converted and flattened",
+			raw:       `[{"name":"helper","kind":12,"location":{"uri":"file:///a.ts","range":{"start":{"line":4,"character":0},"end":{"line":6,"character":1}}},"containerName":"mod"}]`,
+			wantLen:   1,
+			wantFirst: "helper",
+			wantChild: "",
+			// For the flat shape, both Range and SelectionRange come from location.range.
+			wantRange: Range{Start: Position{Line: 4, Character: 0}, End: Position{Line: 6, Character: 1}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeDocumentSymbols(json.RawMessage(tt.raw))
+			if err != nil {
+				t.Fatalf("normalizeDocumentSymbols: %v", err)
+			}
+			if len(got) != tt.wantLen {
+				t.Fatalf("len = %d, want %d", len(got), tt.wantLen)
+			}
+			if tt.wantLen == 0 {
+				return
+			}
+			if got[0].Name != tt.wantFirst {
+				t.Errorf("first name = %q, want %q", got[0].Name, tt.wantFirst)
+			}
+			if got[0].Range != tt.wantRange {
+				t.Errorf("first range = %+v, want %+v", got[0].Range, tt.wantRange)
+			}
+			if tt.wantChild == "" {
+				if len(got[0].Children) != 0 {
+					t.Errorf("expected no children, got %d", len(got[0].Children))
+				}
+			} else {
+				if len(got[0].Children) != 1 || got[0].Children[0].Name != tt.wantChild {
+					t.Errorf("expected child %q, got %+v", tt.wantChild, got[0].Children)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeDocumentSymbols_FlatUsesLocationForSelection(t *testing.T) {
+	// A flat SymbolInformation must map location.range to SelectionRange so
+	// click-to-jump reveals the symbol even without a distinct selection range.
+	raw := `[{"name":"x","kind":13,"location":{"uri":"file:///a.ts","range":{"start":{"line":2,"character":4},"end":{"line":2,"character":5}}}}]`
+	got, err := normalizeDocumentSymbols(json.RawMessage(raw))
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	want := Range{Start: Position{Line: 2, Character: 4}, End: Position{Line: 2, Character: 5}}
+	if got[0].SelectionRange != want {
+		t.Errorf("SelectionRange = %+v, want %+v", got[0].SelectionRange, want)
+	}
 }
 
 func TestClient_Completion(t *testing.T) {

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -400,6 +400,27 @@ func (m *Manager) Definition(ctx context.Context, path string, line, character i
 	return result, err
 }
 
+// DocumentSymbol sends a documentSymbol request for the given file and returns
+// its normalized symbol tree. Returns nil when no server covers the file.
+func (m *Manager) DocumentSymbol(ctx context.Context, path string) ([]DocumentSymbol, error) {
+	entry, uri, key := m.serverForPath(path)
+	if entry == nil {
+		return nil, nil
+	}
+	// Skip servers that don't advertise documentSymbol support. The Structure
+	// view fetches on every file switch and (debounced) edit, so blindly
+	// sending the request to a server that will reject it would spam
+	// request-failure logs and surface a misleading error state to the user.
+	if entry.client.ServerCapabilities().DocumentSymbolProvider == nil {
+		return nil, nil
+	}
+	result, err := entry.client.DocumentSymbol(ctx, uri)
+	if err != nil {
+		m.logRequestFailure(key, "textDocument/documentSymbol", err)
+	}
+	return result, err
+}
+
 // Complete sends a completion request for the given file position.
 func (m *Manager) Complete(ctx context.Context, path string, line, character int, triggerChar string) (*CompletionList, error) {
 	entry, uri, key := m.serverForPath(path)

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -411,7 +411,7 @@ func (m *Manager) DocumentSymbol(ctx context.Context, path string) ([]DocumentSy
 	// view fetches on every file switch and (debounced) edit, so blindly
 	// sending the request to a server that will reject it would spam
 	// request-failure logs and surface a misleading error state to the user.
-	if entry.client.ServerCapabilities().DocumentSymbolProvider == nil {
+	if !documentSymbolSupported(entry.client.ServerCapabilities().DocumentSymbolProvider) {
 		return nil, nil
 	}
 	result, err := entry.client.DocumentSymbol(ctx, uri)
@@ -1337,4 +1337,15 @@ func completionTriggerChars(entry *serverEntry) []string {
 		return nil
 	}
 	return opts.TriggerCharacters
+}
+
+func documentSymbolSupported(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var enabled bool
+	if err := json.Unmarshal(raw, &enabled); err == nil {
+		return enabled
+	}
+	return true
 }

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -354,6 +354,21 @@ func TestManager_DidOpenUnsupported(t *testing.T) {
 	}
 }
 
+func TestManager_DocumentSymbolNoServer(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mgr.SetWorkspaceRoot("/tmp/test")
+
+	// No language server covers .rs in the test registry, so DocumentSymbol
+	// must return (nil, nil) rather than erroring.
+	symbols, err := mgr.DocumentSymbol(context.Background(), "/tmp/test/main.rs")
+	if err != nil {
+		t.Errorf("DocumentSymbol on unsupported file should not error, got: %v", err)
+	}
+	if symbols != nil {
+		t.Errorf("expected nil symbols for unsupported file, got %+v", symbols)
+	}
+}
+
 func TestManager_SetWorkspaceRootClearsStoppedFlag(t *testing.T) {
 	mgr, _ := newTestManager(t)
 	mgr.SetWorkspaceRoot("/tmp/old")

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -369,6 +369,72 @@ func TestManager_DocumentSymbolNoServer(t *testing.T) {
 	}
 }
 
+func TestManager_DocumentSymbolProviderFalseSkipsRequest(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	root := t.TempDir()
+	mgr.SetWorkspaceRoot(root)
+
+	path := filepath.Join(root, "main.ts")
+	uri, err := FileToURI(path)
+	if err != nil {
+		t.Fatalf("FileToURI: %v", err)
+	}
+
+	transport := newFakeTransport()
+	client := NewClient(transport, nil)
+	t.Cleanup(func() { _ = transport.Close() })
+	client.capabilities = ServerCapabilities{DocumentSymbolProvider: json.RawMessage(`false`)}
+
+	key := serverKey{family: "typescript", workspace: root}
+	mgr.mu.Lock()
+	mgr.servers[key] = &serverEntry{
+		client: client,
+		config: &ServerConfig{Command: "typescript-language-server"},
+		openDocs: map[string]*docState{
+			uri: {refCount: 1, version: 1},
+		},
+	}
+	mgr.docKeys[uri] = key
+	mgr.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	symbols, err := mgr.DocumentSymbol(ctx, path)
+	if err != nil {
+		t.Fatalf("DocumentSymbol: %v", err)
+	}
+	if symbols != nil {
+		t.Fatalf("symbols = %+v, want nil", symbols)
+	}
+	select {
+	case msg := <-transport.outgoing:
+		t.Fatalf("sent %s despite documentSymbolProvider=false", msg.Method)
+	default:
+	}
+}
+
+func TestDocumentSymbolSupported(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  json.RawMessage
+		want bool
+	}{
+		{name: "missing", raw: nil, want: false},
+		{name: "null", raw: json.RawMessage(`null`), want: false},
+		{name: "false", raw: json.RawMessage(`false`), want: false},
+		{name: "true", raw: json.RawMessage(`true`), want: true},
+		{name: "options", raw: json.RawMessage(`{"workDoneProgress":true}`), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := documentSymbolSupported(tt.raw); got != tt.want {
+				t.Fatalf("documentSymbolSupported(%s) = %v, want %v", string(tt.raw), got, tt.want)
+			}
+		})
+	}
+}
+
 func TestManager_SetWorkspaceRootClearsStoppedFlag(t *testing.T) {
 	mgr, _ := newTestManager(t)
 	mgr.SetWorkspaceRoot("/tmp/old")

--- a/internal/lsp/mockserver_test.go
+++ b/internal/lsp/mockserver_test.go
@@ -76,10 +76,11 @@ func handleMockRequest(msg *JSONRPCMessage, initialized bool) *JSONRPCMessage {
 		}
 		return respondWithResult(msg.ID, InitializeResult{
 			Capabilities: ServerCapabilities{
-				TextDocumentSync:   mustJSON(TextDocumentSyncOptions{OpenClose: true, Change: TextDocumentSyncFull}),
-				CompletionProvider: mustJSON(map[string]any{"triggerCharacters": []string{".", ":"}}),
-				HoverProvider:      mustJSON(true),
-				DefinitionProvider: mustJSON(true),
+				TextDocumentSync:       mustJSON(TextDocumentSyncOptions{OpenClose: true, Change: TextDocumentSyncFull}),
+				CompletionProvider:     mustJSON(map[string]any{"triggerCharacters": []string{".", ":"}}),
+				HoverProvider:          mustJSON(true),
+				DefinitionProvider:     mustJSON(true),
+				DocumentSymbolProvider: mustJSON(true),
 			},
 		})
 
@@ -97,6 +98,25 @@ func handleMockRequest(msg *JSONRPCMessage, initialized bool) *JSONRPCMessage {
 		return respondWithResult(msg.ID, Location{
 			URI:   params.TextDocument.URI,
 			Range: Range{Start: Position{Line: 0, Character: 0}, End: Position{Line: 0, Character: 10}},
+		})
+
+	case "textDocument/documentSymbol":
+		// Return a small hierarchical DocumentSymbol[] result.
+		return respondWithResult(msg.ID, []DocumentSymbol{
+			{
+				Name:           "Widget",
+				Kind:           5, // Class
+				Range:          Range{Start: Position{Line: 0, Character: 0}, End: Position{Line: 10, Character: 1}},
+				SelectionRange: Range{Start: Position{Line: 0, Character: 6}, End: Position{Line: 0, Character: 12}},
+				Children: []DocumentSymbol{
+					{
+						Name:           "render",
+						Kind:           6, // Method
+						Range:          Range{Start: Position{Line: 2, Character: 2}, End: Position{Line: 4, Character: 3}},
+						SelectionRange: Range{Start: Position{Line: 2, Character: 2}, End: Position{Line: 2, Character: 8}},
+					},
+				},
+			},
 		})
 
 	case "textDocument/completion":

--- a/internal/lsp/types.go
+++ b/internal/lsp/types.go
@@ -157,10 +157,43 @@ type InitializeResult struct {
 
 // ServerCapabilities describe the capabilities provided by the language server.
 type ServerCapabilities struct {
-	TextDocumentSync   json.RawMessage `json:"textDocumentSync,omitempty"`
-	CompletionProvider json.RawMessage `json:"completionProvider,omitempty"`
-	HoverProvider      json.RawMessage `json:"hoverProvider,omitempty"`
-	DefinitionProvider json.RawMessage `json:"definitionProvider,omitempty"`
+	TextDocumentSync       json.RawMessage `json:"textDocumentSync,omitempty"`
+	CompletionProvider     json.RawMessage `json:"completionProvider,omitempty"`
+	HoverProvider          json.RawMessage `json:"hoverProvider,omitempty"`
+	DefinitionProvider     json.RawMessage `json:"definitionProvider,omitempty"`
+	DocumentSymbolProvider json.RawMessage `json:"documentSymbolProvider,omitempty"`
+}
+
+// SymbolKind enumerates the kind of a document symbol per the LSP spec.
+// Values match the protocol's numeric codes (1-26).
+type SymbolKind int
+
+// DocumentSymbol represents a programming construct in a document, such as a
+// class, method, or variable. Symbols can nest via Children when the server
+// supports hierarchical document symbols.
+//
+// This is the normalized shape Firn works with. Servers that only return the
+// legacy flat SymbolInformation[] are converted into a flat slice of these
+// (no Children) before reaching the manager — see normalizeDocumentSymbols.
+type DocumentSymbol struct {
+	Name   string     `json:"name"`
+	Detail string     `json:"detail,omitempty"`
+	Kind   SymbolKind `json:"kind"`
+	// Range is the full source range enclosing the symbol (including its body).
+	Range Range `json:"range"`
+	// SelectionRange is the range that should be selected/revealed when the
+	// symbol is picked (typically the identifier). Always contained in Range.
+	SelectionRange Range            `json:"selectionRange"`
+	Children       []DocumentSymbol `json:"children,omitempty"`
+}
+
+// symbolInformation is the legacy flat symbol shape returned by servers that
+// don't support hierarchicalDocumentSymbolSupport. It is only used internally
+// during normalization and never crosses the Wails boundary.
+type symbolInformation struct {
+	Name     string     `json:"name"`
+	Kind     SymbolKind `json:"kind"`
+	Location Location   `json:"location"`
 }
 
 // CompletionProviderOptions describes the server's completion capabilities.
@@ -203,6 +236,11 @@ type DidSaveTextDocumentParams struct {
 
 // DidCloseTextDocumentParams are the parameters for textDocument/didClose.
 type DidCloseTextDocumentParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+}
+
+// DocumentSymbolParams are the parameters for textDocument/documentSymbol.
+type DocumentSymbolParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 }
 


### PR DESCRIPTION
Closes #168

## Summary

Adds a persistent Structure/Outline view for the active editor file, populated from real `textDocument/documentSymbol` results. Clicking a symbol jumps the editor to its selection range. New `structure` sidebar view alongside Explorer / Search / Source Control / Run, with an activity-bar entry and a Cmd/Ctrl+Shift+Y shortcut.

## Backend (Go)

- `lsp.DocumentSymbol` type + `SymbolKind`; `normalizeDocumentSymbols` handles both server shapes — hierarchical `DocumentSymbol[]` and legacy flat `SymbolInformation[]` — returning one normalized tree.
- `Client.DocumentSymbol` request; declares `hierarchicalDocumentSymbolSupport` and tracks the `documentSymbol` server capability.
- `Manager.DocumentSymbol` returns nil when no server covers the file **or** the server does not advertise the capability (avoids request-failure log spam on every file switch/edit). New `LSPDocumentSymbol` Wails binding.

## Frontend

- `documentSymbols` util: kind→glyph/color mapping and a VS-Code-style tree filter (pure, unit-tested).
- `useDocumentSymbols` hook: gate derived during render (`no-file` / `unsupported` / `lsp-unavailable`) and an async fetch for ready servers, with a monotonic stale-response guard, immediate refetch on file switch, and debounced refetch on edits.
- `StructureView`: nested tree with twisties, filter, collapse-all, manual refresh, keyboard operability (Enter/Space to jump, Arrow to expand/collapse), and distinct empty / unsupported / unavailable / error / loading states.

No hard-coded or placeholder symbol data — every non-data path routes to an explicit visible state.

## Tests

- Go: client normalization (both shapes, null/empty), capability handling, manager no-server.
- Frontend: util (kind map + filter), hook (all states + stale-drop + refresh), component (states + click/keyboard jump + collapse + filter + file-switch reset).
- 1313 jest + 137 Go pass; lint / format / vet / build clean.

## Follow-ups (out of scope)

- Virtualize the tree for pathologically large symbol counts (repo already virtualizes the file tree).
- Roving `tabindex` + `aria-selected` for full tree ARIA.
- Optional sort of symbols by position.

Generated with [Claude Code](https://claude.com/claude-code)