### PR TITLE
feat: hunk-level staging in the diff viewer (#163)

### DIFF
--- a/app_git.go
+++ b/app_git.go
@@ -104,6 +104,26 @@ func (a *App) GitFileAtRev(root, rev, path string) (git.FileContent, error) {
 	return a.gitService.FileAtRev(ctx, root, rev, path)
 }
 
+// GitFileHunks returns the per-hunk breakdown of a file's diff. staged=false
+// yields working-tree-vs-index hunks (stageable); staged=true yields
+// index-vs-HEAD hunks (unstageable). Each hunk carries a standalone patch for
+// GitApplyHunk.
+// This is exposed to the frontend via Wails bindings.
+func (a *App) GitFileHunks(root, path string, staged bool) (git.FileHunks, error) {
+	ctx, cancel := a.gitCtx(gitLocalTimeout)
+	defer cancel()
+	return a.gitService.FileHunks(ctx, root, path, staged)
+}
+
+// GitApplyHunk stages (reverse=false) or unstages (reverse=true) a single hunk
+// by applying its patch to the index with `git apply --cached`.
+// This is exposed to the frontend via Wails bindings.
+func (a *App) GitApplyHunk(root, patch string, reverse bool) error {
+	ctx, cancel := a.gitCtx(gitLocalTimeout)
+	defer cancel()
+	return a.gitService.ApplyPatch(ctx, root, patch, reverse)
+}
+
 // GitCommitMessageAvailable reports whether AI commit-message generation is
 // usable (golem with one-shot support on PATH). The frontend hides the
 // generate button when false.

--- a/app_git_test.go
+++ b/app_git_test.go
@@ -105,6 +105,35 @@ func TestGitGenerateCommitMessage_Binding(t *testing.T) {
 	}
 }
 
+func TestGitFileHunksAndApply_Binding(t *testing.T) {
+	dir := initGitRepoForApp(t)
+	app := NewApp()
+	_ = app.GitStage(dir, []string{"f.txt"})
+	if _, err := app.GitCommit(dir, "init", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x\ny\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fh, err := app.GitFileHunks(dir, "f.txt", false)
+	if err != nil {
+		t.Fatalf("GitFileHunks() error = %v", err)
+	}
+	if len(fh.Hunks) != 1 {
+		t.Fatalf("hunks = %d, want 1 (%+v)", len(fh.Hunks), fh.Hunks)
+	}
+
+	if err := app.GitApplyHunk(dir, fh.Hunks[0].Patch, false); err != nil {
+		t.Fatalf("GitApplyHunk() error = %v", err)
+	}
+
+	st, _ := app.GitStatus(dir)
+	if len(st.Files) != 1 || st.Files[0].Index != "M" {
+		t.Errorf("Files = %+v, want f.txt staged-modified", st.Files)
+	}
+}
+
 func TestGitBranchesAndCheckout_Binding(t *testing.T) {
 	dir := initGitRepoForApp(t)
 	app := NewApp()

--- a/frontend/src/__tests__/Editor.diff.test.tsx
+++ b/frontend/src/__tests__/Editor.diff.test.tsx
@@ -46,6 +46,7 @@ const session: DiffSession = {
   right: { label: 'Working Tree', content: 'new' },
   binary: false,
   truncated: false,
+  hunks: [],
 };
 
 function openFile(id: string, name: string) {

--- a/frontend/src/__tests__/components/Editor/GitDiffView.test.tsx
+++ b/frontend/src/__tests__/components/Editor/GitDiffView.test.tsx
@@ -18,13 +18,17 @@ jest.mock('@codemirror/merge', () => ({
   goToPreviousChunk: (arg: unknown) => goToPreviousChunkMock(arg),
   getChunks: (arg: unknown) => getChunksMock(arg),
 }));
+const gutterMock = jest.fn((_config?: unknown) => ({ __gutter: true }));
 jest.mock('@codemirror/view', () => ({
   EditorView: { editable: { of: jest.fn() }, lineWrapping: {} },
   lineNumbers: jest.fn(),
   keymap: { of: jest.fn() },
+  gutter: (config: unknown) => gutterMock(config),
+  GutterMarker: class {},
 }));
 jest.mock('@codemirror/state', () => ({
   EditorState: { readOnly: { of: jest.fn() } },
+  RangeSet: { of: jest.fn() },
 }));
 jest.mock('../../../components/Editor/codemirror', () => ({
   buildTheme: jest.fn(() => []),
@@ -48,6 +52,8 @@ jest.mock('../../../../wailsjs/go/main/App', () => ({
   GitCommitMessageAvailable: jest.fn(),
   GitGenerateCommitMessage: jest.fn(),
   GitFileAtRev: jest.fn(),
+  GitFileHunks: jest.fn(),
+  GitApplyHunk: jest.fn(),
   ReadFile: jest.fn(),
 }));
 
@@ -63,6 +69,7 @@ const base: DiffSession = {
   right: { label: 'Working Tree', content: 'const a = 2;\n' },
   binary: false,
   truncated: false,
+  hunks: [],
 };
 
 beforeEach(() => {
@@ -163,6 +170,23 @@ describe('GitDiffView', () => {
     fireEvent.keyDown(divider, { key: 'ArrowLeft' });
 
     expect(screen.getByTestId('diff-root').style.getPropertyValue('--diff-left')).toBe('48%');
+  });
+
+  it('builds a hunk-staging gutter on the right pane when the diff has hunks', () => {
+    render(
+      <GitDiffView session={{ ...base, hunks: [{ patch: 'P', newStart: 1, newLines: 1 }] }} />
+    );
+
+    // The right pane (b) gets the extra gutter; the left pane (a) does not.
+    expect(gutterMock).toHaveBeenCalledWith(expect.objectContaining({ class: 'cm-hunkGutter' }));
+    const config = mergeViewMock.mock.calls[0][0];
+    expect(config.b.extensions.length).toBeGreaterThan(config.a.extensions.length);
+  });
+
+  it('adds no hunk gutter when there are no hunks', () => {
+    render(<GitDiffView session={base} />);
+
+    expect(gutterMock).not.toHaveBeenCalled();
   });
 
   it('renders a binary state instead of a merge view', () => {

--- a/frontend/src/__tests__/components/GitPanel/GitPanel.test.tsx
+++ b/frontend/src/__tests__/components/GitPanel/GitPanel.test.tsx
@@ -10,6 +10,8 @@ jest.mock('../../../../wailsjs/go/main/App', () => ({
   GitCommitMessageAvailable: jest.fn(),
   GitGenerateCommitMessage: jest.fn(),
   GitFileAtRev: jest.fn(),
+  GitFileHunks: jest.fn(),
+  GitApplyHunk: jest.fn(),
   ReadFile: jest.fn(),
 }));
 
@@ -27,6 +29,7 @@ import {
   GitCheckout,
   GitGenerateCommitMessage,
   GitFileAtRev,
+  GitFileHunks,
   ReadFile,
 } from '../../../../wailsjs/go/main/App';
 import type { git, workspace } from '../../../../wailsjs/go/models';
@@ -239,6 +242,7 @@ describe('GitPanel diff open', () => {
       binary: false,
       truncated: false,
     });
+    (GitFileHunks as jest.Mock).mockResolvedValue({ path: '', hunks: [] });
     (ReadFile as jest.Mock).mockResolvedValue({ content: 'y' });
   });
 

--- a/frontend/src/components/Editor/GitDiffView.module.css
+++ b/frontend/src/components/Editor/GitDiffView.module.css
@@ -162,3 +162,31 @@
   color: var(--text-muted);
   font-size: 13px;
 }
+
+/* Per-hunk staging gutter (right pane): a compact +/− button anchored at each
+ * hunk's first new-side line. Global because CodeMirror owns the class names. */
+.mergeHost :global(.cm-hunkGutter) {
+  min-width: 18px;
+}
+
+.mergeHost :global(.cm-hunkStageBtn) {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--surface);
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.mergeHost :global(.cm-hunkStageBtn:hover) {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--surface-hover);
+}

--- a/frontend/src/components/Editor/GitDiffView.tsx
+++ b/frontend/src/components/Editor/GitDiffView.tsx
@@ -7,6 +7,7 @@ import { useEditorSyntaxTheme } from '../../stores/ideStore';
 import { diffLines } from '../../utils/lineDiff';
 import { ensureEditorFileOpen } from '../../utils/editorNavigation';
 import { buildTheme, getLanguageExtension } from './codemirror';
+import { hunkStagingGutter } from './codemirror/hunkStagingGutter';
 import styles from './GitDiffView.module.css';
 
 /**
@@ -66,9 +67,17 @@ export function GitDiffView({
       getLanguageExtension(filename) ?? [],
     ];
 
+    // Only the right pane (the new side: working tree for unstaged, index for
+    // staged) carries the per-hunk stage/unstage buttons — git hunks are keyed
+    // by their new-side start line, which always matches this pane's content
+    // (the store suppresses hunks when the pane shows an unsaved editor buffer
+    // git hasn't diffed, so anchors never drift).
     const view = new MergeView({
       a: { doc: session.left.content, extensions: shared },
-      b: { doc: session.right.content, extensions: shared },
+      b: {
+        doc: session.right.content,
+        extensions: [...shared, hunkStagingGutter(session.hunks, session.context)],
+      },
       parent: hostRef.current,
       gutter: true,
       highlightChanges: true,

--- a/frontend/src/components/Editor/codemirror/hunkStagingGutter.test.ts
+++ b/frontend/src/components/Editor/codemirror/hunkStagingGutter.test.ts
@@ -1,0 +1,51 @@
+// @codemirror/* ships untransformed ESM jest cannot parse; the module only
+// needs `gutter`/`GutterMarker` to exist at import time here (the marker
+// callback is driven by a live view, never in these unit tests). The store is
+// mocked so the click→applyHunk wiring is asserted directly.
+jest.mock('@codemirror/view', () => ({
+  gutter: jest.fn(() => ({})),
+  GutterMarker: class {},
+  EditorView: {},
+}));
+jest.mock('@codemirror/state', () => ({ RangeSet: { of: jest.fn() } }));
+
+const applyHunk = jest.fn();
+jest.mock('../../../stores/gitStore', () => ({
+  useGitStore: { getState: () => ({ applyHunk }) },
+}));
+
+import { hunkStagingAction, createHunkButton } from './hunkStagingGutter';
+
+const hunk = { patch: 'THE PATCH', newStart: 4, newLines: 2 };
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('hunkStagingAction', () => {
+  it('an unstaged diff stages its hunks', () => {
+    expect(hunkStagingAction('unstaged')).toEqual({ reverse: false, label: 'Stage hunk' });
+  });
+
+  it('a staged diff unstages its hunks', () => {
+    expect(hunkStagingAction('staged')).toEqual({ reverse: true, label: 'Unstage hunk' });
+  });
+});
+
+describe('createHunkButton', () => {
+  it('clicking a button in an unstaged diff stages that hunk (reverse=false)', () => {
+    const btn = createHunkButton(hunk, 'unstaged');
+    expect(btn.title).toBe('Stage hunk');
+
+    btn.click();
+
+    expect(applyHunk).toHaveBeenCalledWith('THE PATCH', false);
+  });
+
+  it('clicking a button in a staged diff unstages that hunk (reverse=true)', () => {
+    const btn = createHunkButton(hunk, 'staged');
+    expect(btn.title).toBe('Unstage hunk');
+
+    btn.click();
+
+    expect(applyHunk).toHaveBeenCalledWith('THE PATCH', true);
+  });
+});

--- a/frontend/src/components/Editor/codemirror/hunkStagingGutter.ts
+++ b/frontend/src/components/Editor/codemirror/hunkStagingGutter.ts
@@ -1,0 +1,74 @@
+/**
+ * Per-hunk staging gutter for the diff viewer. Renders a stage/unstage button
+ * at each git hunk's new-side start line in the right pane, backed by the
+ * store's applyHunk (git apply --cached). The hunk set is fixed for a given
+ * diff session, so the markers are static — a fresh session rebuilds the pane.
+ */
+import { EditorView, gutter, GutterMarker } from '@codemirror/view';
+import { RangeSet, type Extension } from '@codemirror/state';
+import type { git } from '../../../../wailsjs/go/models';
+import { useGitStore, type DiffContext } from '../../../stores/gitStore';
+
+/**
+ * How a hunk control behaves in a given diff context. An 'unstaged' diff
+ * (index → working tree) stages its hunks into the index; a 'staged' diff
+ * (HEAD → index) unstages them (git apply --reverse).
+ */
+export function hunkStagingAction(context: DiffContext): { reverse: boolean; label: string } {
+  return context === 'staged'
+    ? { reverse: true, label: 'Unstage hunk' }
+    : { reverse: false, label: 'Stage hunk' };
+}
+
+/**
+ * The clickable gutter button for one hunk. Extracted from the GutterMarker so
+ * the click → applyHunk wiring is testable without a live CodeMirror view.
+ */
+export function createHunkButton(hunk: git.Hunk, context: DiffContext): HTMLButtonElement {
+  const { reverse, label } = hunkStagingAction(context);
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'cm-hunkStageBtn';
+  btn.textContent = reverse ? '−' : '+';
+  btn.title = label;
+  btn.setAttribute('aria-label', `${label} at line ${hunk.newStart}`);
+  // stopPropagation so the click doesn't reach the editor's own gutter/selection
+  // handlers; preventDefault so the read-only view doesn't try to focus.
+  btn.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    void useGitStore.getState().applyHunk(hunk.patch, reverse);
+  });
+  return btn;
+}
+
+class HunkMarker extends GutterMarker {
+  constructor(
+    private readonly hunk: git.Hunk,
+    private readonly context: DiffContext
+  ) {
+    super();
+  }
+  override toDOM(): Node {
+    return createHunkButton(this.hunk, this.context);
+  }
+}
+
+/**
+ * A gutter for the right pane carrying a stage/unstage button at each hunk's
+ * new-side start line. Returns nothing when there are no hunks (untracked,
+ * binary, too-large, or clean diffs) so the pane stays plain.
+ */
+export function hunkStagingGutter(hunks: git.Hunk[], context: DiffContext): Extension {
+  if (hunks.length === 0) return [];
+  return gutter({
+    class: 'cm-hunkGutter',
+    markers: (view: EditorView) => {
+      const doc = view.state.doc;
+      const ranges = hunks
+        .filter((h) => h.newStart >= 1 && h.newStart <= doc.lines)
+        .map((h) => new HunkMarker(h, context).range(doc.line(h.newStart).from));
+      return RangeSet.of(ranges, true); // true = sort; hunks are already ascending
+    },
+  });
+}

--- a/frontend/src/stores/gitStore.test.ts
+++ b/frontend/src/stores/gitStore.test.ts
@@ -10,6 +10,8 @@ jest.mock('../../wailsjs/go/main/App', () => ({
   GitCommitMessageAvailable: jest.fn(),
   GitGenerateCommitMessage: jest.fn(),
   GitFileAtRev: jest.fn(),
+  GitFileHunks: jest.fn(),
+  GitApplyHunk: jest.fn(),
   ReadFile: jest.fn(),
 }));
 
@@ -23,6 +25,8 @@ import {
   GitCommitMessageAvailable,
   GitGenerateCommitMessage,
   GitFileAtRev,
+  GitFileHunks,
+  GitApplyHunk,
   ReadFile,
 } from '../../wailsjs/go/main/App';
 import { useGitStore, GIT_REFRESH_DEBOUNCE_MS } from './gitStore';
@@ -273,17 +277,106 @@ describe('gitStore operations', () => {
 describe('gitStore diff sessions', () => {
   const mockFileAtRev = GitFileAtRev as jest.MockedFunction<typeof GitFileAtRev>;
   const mockReadFile = ReadFile as jest.MockedFunction<typeof ReadFile>;
+  const mockFileHunks = GitFileHunks as jest.MockedFunction<typeof GitFileHunks>;
+  const mockApplyHunk = GitApplyHunk as jest.MockedFunction<typeof GitApplyHunk>;
   const rev = (content: string, flags: Partial<{ binary: boolean; truncated: boolean }> = {}) =>
     ({ content, binary: false, truncated: false, ...flags }) as Awaited<
       ReturnType<typeof GitFileAtRev>
     >;
+  const hunks = (...list: { patch: string; newStart: number; newLines: number }[]) =>
+    ({ path: 'src/a.ts', hunks: list }) as Awaited<ReturnType<typeof GitFileHunks>>;
 
   beforeEach(() => {
     mockGitStatus.mockResolvedValue(repoStatus());
     mockFileAtRev.mockResolvedValue(rev(''));
+    mockFileHunks.mockResolvedValue(hunks());
+    mockApplyHunk.mockResolvedValue(undefined);
     mockReadFile.mockResolvedValue({
       content: 'worktree text',
     } as Awaited<ReturnType<typeof ReadFile>>);
+  });
+
+  it('fetches per-hunk staging data for a tracked unstaged diff', async () => {
+    mockFileAtRev.mockResolvedValueOnce(rev('index text'));
+    mockFileHunks.mockResolvedValueOnce(hunks({ patch: 'PATCH', newStart: 2, newLines: 1 }));
+
+    await useGitStore
+      .getState()
+      .openDiff({ path: 'src/a.ts', index: '.', worktree: 'M' }, 'unstaged');
+
+    // staged=false for the working-tree-vs-index (stageable) hunks.
+    expect(mockFileHunks).toHaveBeenCalledWith('/repo', 'src/a.ts', false);
+    expect(useGitStore.getState().diffSession?.hunks).toEqual([
+      { patch: 'PATCH', newStart: 2, newLines: 1 },
+    ]);
+  });
+
+  it('fetches staged hunks (staged=true) for a staged diff', async () => {
+    mockFileAtRev.mockResolvedValueOnce(rev('head')).mockResolvedValueOnce(rev('index'));
+
+    await useGitStore
+      .getState()
+      .openDiff({ path: 'src/a.ts', index: 'M', worktree: '.' }, 'staged');
+
+    expect(mockFileHunks).toHaveBeenCalledWith('/repo', 'src/a.ts', true);
+  });
+
+  it('suppresses hunks while the working-tree side is an unsaved editor buffer', async () => {
+    // git diffs disk, but the pane shows the dirty buffer — disk hunks would
+    // neither line up with nor stage what's on screen, so no per-hunk buttons.
+    useIDEStore.setState({
+      openFiles: [
+        { id: 'f', path: '/repo/src/a.ts', name: 'a.ts', content: 'unsaved\n', isModified: true },
+      ] as unknown as ReturnType<typeof useIDEStore.getState>['openFiles'],
+    });
+    mockFileAtRev.mockResolvedValueOnce(rev('index text'));
+
+    await useGitStore
+      .getState()
+      .openDiff({ path: 'src/a.ts', index: '.', worktree: 'M' }, 'unstaged');
+
+    expect(mockFileHunks).not.toHaveBeenCalled();
+    expect(useGitStore.getState().diffSession?.hunks).toEqual([]);
+    useIDEStore.setState({ openFiles: [] });
+  });
+
+  it('still fetches hunks when the open file is saved (buffer matches disk)', async () => {
+    useIDEStore.setState({
+      openFiles: [
+        { id: 'f', path: '/repo/src/a.ts', name: 'a.ts', content: 'saved\n', isModified: false },
+      ] as unknown as ReturnType<typeof useIDEStore.getState>['openFiles'],
+    });
+    mockFileAtRev.mockResolvedValueOnce(rev('index text'));
+
+    await useGitStore
+      .getState()
+      .openDiff({ path: 'src/a.ts', index: '.', worktree: 'M' }, 'unstaged');
+
+    expect(mockFileHunks).toHaveBeenCalledWith('/repo', 'src/a.ts', false);
+    useIDEStore.setState({ openFiles: [] });
+  });
+
+  it('skips hunk fetching for untracked files (no per-hunk staging)', async () => {
+    await useGitStore
+      .getState()
+      .openDiff({ path: 'new.ts', index: '?', worktree: '?' }, 'unstaged');
+
+    expect(mockFileHunks).not.toHaveBeenCalled();
+    expect(useGitStore.getState().diffSession?.hunks).toEqual([]);
+  });
+
+  it('applyHunk stages a hunk (reverse=false) and refreshes', async () => {
+    await useGitStore.getState().applyHunk('PATCH', false);
+
+    expect(mockApplyHunk).toHaveBeenCalledWith('/repo', 'PATCH', false);
+    // runOp refreshes afterward so the diff view reflects the new index.
+    expect(mockGitStatus).toHaveBeenCalled();
+  });
+
+  it('applyHunk unstages a hunk (reverse=true)', async () => {
+    await useGitStore.getState().applyHunk('PATCH', true);
+
+    expect(mockApplyHunk).toHaveBeenCalledWith('/repo', 'PATCH', true);
   });
 
   it('staged context diffs HEAD against the index', async () => {

--- a/frontend/src/stores/gitStore.ts
+++ b/frontend/src/stores/gitStore.ts
@@ -13,6 +13,8 @@ import {
   GitCommitMessageAvailable,
   GitGenerateCommitMessage,
   GitFileAtRev,
+  GitFileHunks,
+  GitApplyHunk,
   ReadFile,
 } from '../../wailsjs/go/main/App';
 import type { git } from '../../wailsjs/go/models';
@@ -48,6 +50,10 @@ export interface DiffSession {
   binary: boolean;
   /** Either side exceeded the diffable size cap. */
   truncated: boolean;
+  /** Per-hunk staging affordances, from `git diff` of this file. Empty for
+   * untracked/binary/too-large diffs (whole-file staging only). In an
+   * 'unstaged' diff these stage; in a 'staged' diff they unstage. */
+  hunks: git.Hunk[];
 }
 
 /** Friendly post-commit summary shown in the panel instead of raw git output. */
@@ -130,6 +136,9 @@ interface GitActions {
   scheduleRefresh: () => void;
   stage: (paths: string[]) => Promise<void>;
   unstage: (paths: string[]) => Promise<void>;
+  /** Stage (reverse=false) or unstage (reverse=true) a single diff hunk by
+   * applying its patch to the index. Refreshes status + the open diff after. */
+  applyHunk: (patch: string, reverse: boolean) => Promise<void>;
   setCommitMessage: (message: string) => void;
   commit: (amend: boolean) => Promise<void>;
   pull: () => Promise<void>;
@@ -259,6 +268,16 @@ export const useGitStore = create<GitStore>()(
         });
       },
 
+      // Applying a hunk IS a stage/unstage op, so it reuses runOp: single-flight
+      // against other git ops and an automatic status + open-diff refresh, which
+      // repaints the diff with the now-reduced hunk set.
+      applyHunk: async (patch, reverse) => {
+        await runOp(reverse ? 'unstage' : 'stage', get, set, async (root) => {
+          await GitApplyHunk(root, patch, reverse);
+          return null;
+        });
+      },
+
       setCommitMessage: (commitMessage) => set({ commitMessage }, false, 'git/setCommitMessage'),
 
       commit: async (amend) => {
@@ -346,6 +365,10 @@ export const useGitStore = create<GitStore>()(
           let right: DiffSide;
           let binary = false;
           let truncated = false;
+          // The working-tree side is showing an unsaved editor buffer, which
+          // git hasn't diffed — its disk-based hunks wouldn't line up with (or
+          // stage) what's on screen, so per-hunk staging is suppressed until save.
+          let dirtyBufferWorktree = false;
 
           const fetchRev = async (
             rev: 'HEAD' | ':0',
@@ -375,6 +398,7 @@ export const useGitStore = create<GitStore>()(
             let worktree = '';
             if (openFile) {
               worktree = openFile.content ?? '';
+              dirtyBufferWorktree = openFile.isModified === true;
             } else {
               try {
                 const result = await ReadFile(abs);
@@ -386,6 +410,15 @@ export const useGitStore = create<GitStore>()(
             right = { label: 'Working Tree', content: worktree };
           }
 
+          // Per-hunk staging data for tracked, textual, in-size diffs.
+          // Untracked/binary/too-large diffs stage whole-file only, so skip the
+          // extra git call and leave hunks empty (the UI shows no gutter button).
+          let hunks: git.Hunk[] = [];
+          if (!untracked && !binary && !truncated && !dirtyBufferWorktree) {
+            const fh = await GitFileHunks(repoRoot, change.path, context === 'staged');
+            hunks = fh.hunks ?? [];
+          }
+
           if (get().epoch !== epoch) return; // workspace switched mid-fetch
           const next: DiffSession = {
             path: change.path,
@@ -395,6 +428,7 @@ export const useGitStore = create<GitStore>()(
             right,
             binary,
             truncated,
+            hunks,
           };
           set(
             (state) => ({

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -36,6 +36,8 @@ export function GetWatchedPath():Promise<string>;
 
 export function GetWorkspaceInfo():Promise<main.WorkspaceInfo>;
 
+export function GitApplyHunk(arg1:string,arg2:string,arg3:boolean):Promise<void>;
+
 export function GitBranches(arg1:string):Promise<Array<string>>;
 
 export function GitCheckout(arg1:string,arg2:string,arg3:boolean):Promise<void>;
@@ -45,6 +47,8 @@ export function GitCommit(arg1:string,arg2:string,arg3:boolean):Promise<string>;
 export function GitCommitMessageAvailable():Promise<boolean>;
 
 export function GitFileAtRev(arg1:string,arg2:string,arg3:string):Promise<git.FileContent>;
+
+export function GitFileHunks(arg1:string,arg2:string,arg3:boolean):Promise<git.FileHunks>;
 
 export function GitGenerateCommitMessage(arg1:string):Promise<string>;
 
@@ -66,8 +70,6 @@ export function LSPComplete(arg1:string,arg2:number,arg3:number,arg4:string):Pro
 
 export function LSPDefinition(arg1:string,arg2:number,arg3:number):Promise<Array<lsp.Location>>;
 
-export function LSPDocumentSymbol(arg1:string):Promise<Array<lsp.DocumentSymbol>>;
-
 export function LSPDidChange(arg1:string,arg2:number,arg3:Array<lsp.TextDocumentContentChangeEvent>):Promise<void>;
 
 export function LSPDidClose(arg1:string):Promise<void>;
@@ -77,6 +79,8 @@ export function LSPDidOpen(arg1:string,arg2:string,arg3:number,arg4:string):Prom
 export function LSPDidSave(arg1:string):Promise<void>;
 
 export function LSPDoctor(arg1:string):Promise<lsp.DoctorReport>;
+
+export function LSPDocumentSymbol(arg1:string):Promise<Array<lsp.DocumentSymbol>>;
 
 export function LSPHover(arg1:string,arg2:number,arg3:number):Promise<lsp.Hover>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -58,6 +58,10 @@ export function GetWorkspaceInfo() {
   return window['go']['main']['App']['GetWorkspaceInfo']();
 }
 
+export function GitApplyHunk(arg1, arg2, arg3) {
+  return window['go']['main']['App']['GitApplyHunk'](arg1, arg2, arg3);
+}
+
 export function GitBranches(arg1) {
   return window['go']['main']['App']['GitBranches'](arg1);
 }
@@ -76,6 +80,10 @@ export function GitCommitMessageAvailable() {
 
 export function GitFileAtRev(arg1, arg2, arg3) {
   return window['go']['main']['App']['GitFileAtRev'](arg1, arg2, arg3);
+}
+
+export function GitFileHunks(arg1, arg2, arg3) {
+  return window['go']['main']['App']['GitFileHunks'](arg1, arg2, arg3);
 }
 
 export function GitGenerateCommitMessage(arg1) {
@@ -118,10 +126,6 @@ export function LSPDefinition(arg1, arg2, arg3) {
   return window['go']['main']['App']['LSPDefinition'](arg1, arg2, arg3);
 }
 
-export function LSPDocumentSymbol(arg1) {
-  return window['go']['main']['App']['LSPDocumentSymbol'](arg1);
-}
-
 export function LSPDidChange(arg1, arg2, arg3) {
   return window['go']['main']['App']['LSPDidChange'](arg1, arg2, arg3);
 }
@@ -140,6 +144,10 @@ export function LSPDidSave(arg1) {
 
 export function LSPDoctor(arg1) {
   return window['go']['main']['App']['LSPDoctor'](arg1);
+}
+
+export function LSPDocumentSymbol(arg1) {
+  return window['go']['main']['App']['LSPDocumentSymbol'](arg1);
 }
 
 export function LSPHover(arg1, arg2, arg3) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -102,6 +102,55 @@ export namespace git {
 	        this.truncated = source["truncated"];
 	    }
 	}
+	export class Hunk {
+	    patch: string;
+	    newStart: number;
+	    newLines: number;
+
+	    static createFrom(source: any = {}) {
+	        return new Hunk(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.patch = source["patch"];
+	        this.newStart = source["newStart"];
+	        this.newLines = source["newLines"];
+	    }
+	}
+	export class FileHunks {
+	    path: string;
+	    hunks: Hunk[];
+
+	    static createFrom(source: any = {}) {
+	        return new FileHunks(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.path = source["path"];
+	        this.hunks = this.convertValues(source["hunks"], Hunk);
+	    }
+
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+
 	export class RepoStatus {
 	    isRepo: boolean;
 	    repoRoot: string;
@@ -348,38 +397,6 @@ export namespace lsp {
 	        this.candidates = source["candidates"];
 	    }
 	}
-	export class Hover {
-	    contents: number[];
-	    range?: Range;
-
-	    static createFrom(source: any = {}) {
-	        return new Hover(source);
-	    }
-
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.contents = source["contents"];
-	        this.range = this.convertValues(source["range"], Range);
-	    }
-
-		convertValues(a: any, classs: any, asMap: boolean = false): any {
-		    if (!a) {
-		        return a;
-		    }
-		    if (a.slice && a.map) {
-		        return (a as any[]).map(elem => this.convertValues(elem, classs));
-		    } else if ("object" === typeof a) {
-		        if (asMap) {
-		            for (const key of Object.keys(a)) {
-		                a[key] = new classs(a[key]);
-		            }
-		            return a;
-		        }
-		        return new classs(a);
-		    }
-		    return a;
-		}
-	}
 	export class DocumentSymbol {
 	    name: string;
 	    detail?: string;
@@ -400,6 +417,38 @@ export namespace lsp {
 	        this.range = this.convertValues(source["range"], Range);
 	        this.selectionRange = this.convertValues(source["selectionRange"], Range);
 	        this.children = this.convertValues(source["children"], DocumentSymbol);
+	    }
+
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	export class Hover {
+	    contents: number[];
+	    range?: Range;
+
+	    static createFrom(source: any = {}) {
+	        return new Hover(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.contents = source["contents"];
+	        this.range = this.convertValues(source["range"], Range);
 	    }
 
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/git/hunks.go
+++ b/internal/git/hunks.go
@@ -1,0 +1,176 @@
+package git
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// Hunk is one @@-block of a file's unified diff. Patch is a standalone,
+// applyable patch — the file header followed by this single hunk — so the
+// frontend can replay exactly what the user saw through `git apply` without
+// reconstructing anything. NewStart/NewLines locate the hunk on the new side
+// (the right pane of the diff view) so the UI can anchor a gutter control.
+type Hunk struct {
+	Patch    string `json:"patch"`
+	NewStart int    `json:"newStart"`
+	NewLines int    `json:"newLines"`
+}
+
+// FileHunks is the per-hunk breakdown of a single file's diff. A binary file
+// or a file with no diff yields an empty Hunks slice (never nil, for stable
+// JSON), which the UI renders as "no per-hunk staging here".
+type FileHunks struct {
+	Path  string `json:"path"`
+	Hunks []Hunk `json:"hunks"`
+}
+
+// FileHunks returns the unified diff of path split into hunks. staged=false
+// diffs the working tree against the index (hunks the user can stage);
+// staged=true diffs the index against HEAD (hunks the user can unstage).
+// --no-color/--no-ext-diff pin plain, applyable output regardless of user
+// config or diff drivers.
+func (s *Service) FileHunks(ctx context.Context, dir, path string, staged bool) (FileHunks, error) {
+	if err := validateRepoRelPaths([]string{path}); err != nil {
+		return FileHunks{}, err
+	}
+	args := []string{"diff", "--no-color", "--no-ext-diff"}
+	if staged {
+		args = append(args, "--cached")
+	}
+	args = append(args, "--", path)
+	out, err := s.runAtRoot(ctx, dir, args...)
+	if err != nil {
+		return FileHunks{}, err
+	}
+	return parseFileHunks(out, path), nil
+}
+
+// ApplyPatch applies a single-hunk patch to the index via `git apply --cached`
+// (reverse=true adds --reverse, which unstages). The patch must be one git
+// produced; it is validated as a diff and then run against the index, whose
+// content matches the patch's preimage by construction.
+func (s *Service) ApplyPatch(ctx context.Context, dir, patch string, reverse bool) error {
+	if !looksLikePatch(patch) {
+		return fmt.Errorf("not a git patch")
+	}
+	args := []string{"apply", "--cached"}
+	if reverse {
+		args = append(args, "--reverse")
+	}
+	_, err := s.runAtRootStdin(ctx, dir, patch, args...)
+	return err
+}
+
+// looksLikePatch is a cheap guard at the bindings boundary: reject anything
+// that is not a unified diff before it reaches `git apply`. git itself does
+// the real validation and rejects patches that do not apply.
+func looksLikePatch(patch string) bool {
+	return strings.HasPrefix(patch, "diff --git ") || strings.HasPrefix(patch, "--- ")
+}
+
+// parseFileHunks splits one file's unified diff into a header (everything
+// before the first @@) and its hunks. Each hunk's Patch is header+hunk-text so
+// it applies on its own. A single `git diff -- <path>` yields at most one file
+// section; content before the first @@ that isn't a diff (empty output, binary
+// notice) simply produces no hunks.
+func parseFileHunks(raw, path string) FileHunks {
+	result := FileHunks{Path: path, Hunks: []Hunk{}}
+	firstHunk := strings.Index(raw, "\n@@")
+	if firstHunk < 0 {
+		if strings.HasPrefix(raw, "@@") {
+			firstHunk = -1 // header is empty; hunks start at offset 0
+		} else {
+			return result // no hunks (empty, binary, or mode-only change)
+		}
+	}
+	var header, body string
+	if firstHunk < 0 {
+		body = raw
+	} else {
+		header = raw[:firstHunk+1] // include the newline before the first @@
+		body = raw[firstHunk+1:]
+	}
+
+	// Split body into hunks at each line that begins with "@@".
+	lines := strings.SplitAfter(body, "\n")
+	var cur strings.Builder
+	var curStart, curLines int
+	flush := func() {
+		if cur.Len() == 0 {
+			return
+		}
+		result.Hunks = append(result.Hunks, Hunk{
+			Patch:    header + cur.String(),
+			NewStart: curStart,
+			NewLines: curLines,
+		})
+		cur.Reset()
+	}
+	for _, line := range lines {
+		if strings.HasPrefix(line, "@@") {
+			flush()
+			curStart, curLines = parseHunkHeader(line)
+		}
+		if cur.Len() > 0 || strings.HasPrefix(line, "@@") {
+			cur.WriteString(line)
+		}
+	}
+	flush()
+	return result
+}
+
+// parseHunkHeader extracts the new-side start line and line count from an
+// "@@ -old,oldN +new,newN @@" header. A missing count means 1 (git omits it
+// for single-line ranges). Malformed headers degrade to 0/0 rather than
+// dropping the hunk — the patch text is still authoritative for applying.
+func parseHunkHeader(line string) (start, count int) {
+	_, rest, ok := strings.Cut(line, "+")
+	if !ok {
+		return 0, 0
+	}
+	end := strings.IndexAny(rest, " \t")
+	if end >= 0 {
+		rest = rest[:end]
+	}
+	startStr, countStr, hasCount := strings.Cut(rest, ",")
+	start, _ = strconv.Atoi(startStr)
+	if !hasCount {
+		return start, 1
+	}
+	count, _ = strconv.Atoi(countStr)
+	return start, count
+}
+
+// runStdin is run() with a patch piped to git's stdin, for `git apply`.
+func (s *Service) runStdin(ctx context.Context, dir, stdin string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "LC_ALL=C")
+	cmd.Stdin = strings.NewReader(stdin)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return stdout.String(), fmt.Errorf("git %s: %s", args[0], msg)
+	}
+	return stdout.String(), nil
+}
+
+// runAtRootStdin runs runStdin from the repo top-level so the a/ b/ paths in
+// the patch resolve regardless of which subdirectory dir points at.
+func (s *Service) runAtRootStdin(ctx context.Context, dir, stdin string, args ...string) (string, error) {
+	root := dir
+	if out, err := s.run(ctx, dir, "rev-parse", "--show-toplevel"); err == nil {
+		root = strings.TrimSpace(out)
+	}
+	return s.runStdin(ctx, root, stdin, args...)
+}

--- a/internal/git/hunks_test.go
+++ b/internal/git/hunks_test.go
@@ -1,0 +1,239 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestService_FileHunks_StageSingleHunk is the tracer: a real `git diff` for a
+// one-line modification parses into exactly one hunk, and replaying that hunk's
+// patch through `git apply --cached` stages it — proving the full round-trip.
+func TestService_FileHunks_StageSingleHunk(t *testing.T) {
+	requireGit(t)
+	dir := initRepo(t) // README.md committed as "hello\n"
+	writeFile(t, dir, "README.md", "hello\nworld\n")
+	svc := NewService()
+
+	fh, err := svc.FileHunks(ctx(), dir, "README.md", false) // unstaged
+	if err != nil {
+		t.Fatalf("FileHunks() error = %v", err)
+	}
+	if len(fh.Hunks) != 1 {
+		t.Fatalf("hunks = %d, want 1 (%+v)", len(fh.Hunks), fh.Hunks)
+	}
+	if !strings.Contains(fh.Hunks[0].Patch, "+world") {
+		t.Errorf("hunk patch missing +world:\n%s", fh.Hunks[0].Patch)
+	}
+
+	if err := svc.ApplyPatch(ctx(), dir, fh.Hunks[0].Patch, false); err != nil {
+		t.Fatalf("ApplyPatch() error = %v", err)
+	}
+
+	st, _ := svc.Status(ctx(), dir)
+	n := countWhere(st.Files, func(f FileChange) bool {
+		return f.Path == "README.md" && f.Index == "M"
+	})
+	if n != 1 {
+		t.Errorf("staged-modified README.md = %d, want 1 (files %+v)", n, st.Files)
+	}
+}
+
+// TestService_FileHunks_UnstageSingleHunk drives the staged side: a staged
+// change parses from `git diff --cached`, and reverse-applying its hunk unstages
+// it — the index returns to HEAD while the worktree edit survives.
+func TestService_FileHunks_UnstageSingleHunk(t *testing.T) {
+	requireGit(t)
+	dir := initRepo(t)
+	writeFile(t, dir, "README.md", "hello\nworld\n")
+	svc := NewService()
+	if err := svc.Stage(ctx(), dir, []string{"README.md"}); err != nil {
+		t.Fatal(err)
+	}
+
+	fh, err := svc.FileHunks(ctx(), dir, "README.md", true) // staged
+	if err != nil {
+		t.Fatalf("FileHunks(staged) error = %v", err)
+	}
+	if len(fh.Hunks) != 1 {
+		t.Fatalf("staged hunks = %d, want 1 (%+v)", len(fh.Hunks), fh.Hunks)
+	}
+
+	if err := svc.ApplyPatch(ctx(), dir, fh.Hunks[0].Patch, true); err != nil {
+		t.Fatalf("ApplyPatch(reverse) error = %v", err)
+	}
+
+	st, _ := svc.Status(ctx(), dir)
+	f := findFile(st.Files, "README.md")
+	if f == nil {
+		t.Fatalf("README.md missing from status %+v", st.Files)
+	}
+	if f.Index == "M" {
+		t.Errorf("README.md still staged after unstage (index=%q)", f.Index)
+	}
+	if f.Worktree != "M" {
+		t.Errorf("worktree edit lost: worktree=%q, want M", f.Worktree)
+	}
+}
+
+// TestService_FileHunks_StageOneOfTwo is the crux: a file with two separate
+// hunks, staging only the second must move that hunk into the index and leave
+// the first untouched. Proves single-hunk selection applies against the live
+// index and that NewStart anchors each hunk correctly.
+func TestService_FileHunks_StageOneOfTwo(t *testing.T) {
+	requireGit(t)
+	dir := initRepo(t)
+	// 20 lines; edits at line 2 and line 19 sit far enough apart (well past
+	// 2x the 3-line context) that git emits two separate hunks.
+	var base, edited strings.Builder
+	for i := 1; i <= 20; i++ {
+		fmt.Fprintf(&base, "%d\n", i)
+		switch i {
+		case 2:
+			edited.WriteString("TWO\n")
+		case 19:
+			edited.WriteString("NINETEEN\n")
+		default:
+			fmt.Fprintf(&edited, "%d\n", i)
+		}
+	}
+	writeFile(t, dir, "nums.txt", base.String())
+	svc := NewService()
+	if err := svc.Stage(ctx(), dir, []string{"nums.txt"}); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "commit", "-m", "add nums")
+	writeFile(t, dir, "nums.txt", edited.String())
+
+	fh, err := svc.FileHunks(ctx(), dir, "nums.txt", false)
+	if err != nil {
+		t.Fatalf("FileHunks() error = %v", err)
+	}
+	if len(fh.Hunks) != 2 {
+		t.Fatalf("hunks = %d, want 2 (%+v)", len(fh.Hunks), fh.Hunks)
+	}
+	if fh.Hunks[0].NewStart != 1 {
+		t.Errorf("hunk[0].NewStart = %d, want 1", fh.Hunks[0].NewStart)
+	}
+	if fh.Hunks[1].NewStart != 16 {
+		t.Errorf("hunk[1].NewStart = %d, want 16", fh.Hunks[1].NewStart)
+	}
+
+	// Stage only the second hunk (NINETEEN), not the first (TWO).
+	if err := svc.ApplyPatch(ctx(), dir, fh.Hunks[1].Patch, false); err != nil {
+		t.Fatalf("ApplyPatch() error = %v", err)
+	}
+
+	index, err := svc.FileAtRev(ctx(), dir, ":0", "nums.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := strings.Replace(base.String(), "19\n", "NINETEEN\n", 1) // only line 19 staged
+	if index.Content != want {
+		t.Errorf("index content = %q, want %q", index.Content, want)
+	}
+}
+
+// TestService_FileHunks_DeletionHunk covers a hunk that only removes lines
+// (new-side count 0): it must parse, anchor at the surviving line, and stage.
+func TestService_FileHunks_DeletionHunk(t *testing.T) {
+	requireGit(t)
+	dir := initRepo(t)
+	writeFile(t, dir, "d.txt", "keep1\ndrop\nkeep2\n")
+	svc := NewService()
+	if err := svc.Stage(ctx(), dir, []string{"d.txt"}); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "commit", "-m", "add d")
+	writeFile(t, dir, "d.txt", "keep1\nkeep2\n") // drop the middle line
+
+	fh, err := svc.FileHunks(ctx(), dir, "d.txt", false)
+	if err != nil {
+		t.Fatalf("FileHunks() error = %v", err)
+	}
+	if len(fh.Hunks) != 1 {
+		t.Fatalf("hunks = %d, want 1 (%+v)", len(fh.Hunks), fh.Hunks)
+	}
+	if err := svc.ApplyPatch(ctx(), dir, fh.Hunks[0].Patch, false); err != nil {
+		t.Fatalf("ApplyPatch() error = %v", err)
+	}
+	index, _ := svc.FileAtRev(ctx(), dir, ":0", "d.txt")
+	if index.Content != "keep1\nkeep2\n" {
+		t.Errorf("index content = %q, want deletion staged", index.Content)
+	}
+}
+
+// TestService_FileHunks_BinaryHasNoHunks: a binary change yields no hunks
+// (the diff view already renders a binary state) rather than crashing.
+func TestService_FileHunks_BinaryHasNoHunks(t *testing.T) {
+	requireGit(t)
+	dir := initRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, "b.bin"), []byte{0, 1, 2, 3}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "b.bin")
+	gitCmd(t, dir, "commit", "-m", "add bin")
+	if err := os.WriteFile(filepath.Join(dir, "b.bin"), []byte{0, 9, 9, 9}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	svc := NewService()
+
+	fh, err := svc.FileHunks(ctx(), dir, "b.bin", false)
+	if err != nil {
+		t.Fatalf("FileHunks(binary) error = %v", err)
+	}
+	if len(fh.Hunks) != 0 {
+		t.Errorf("hunks = %d, want 0 for a binary change", len(fh.Hunks))
+	}
+}
+
+// TestService_FileHunks_NoChangesEmpty: a clean file has no hunks and never
+// returns a nil slice (stable JSON for the bindings).
+func TestService_FileHunks_NoChangesEmpty(t *testing.T) {
+	requireGit(t)
+	dir := initRepo(t)
+	svc := NewService()
+
+	fh, err := svc.FileHunks(ctx(), dir, "README.md", false)
+	if err != nil {
+		t.Fatalf("FileHunks() error = %v", err)
+	}
+	if fh.Hunks == nil || len(fh.Hunks) != 0 {
+		t.Errorf("Hunks = %#v, want empty non-nil slice", fh.Hunks)
+	}
+}
+
+// TestService_ApplyPatch_RejectsNonPatch guards the bindings boundary: junk
+// never reaches `git apply`.
+func TestService_ApplyPatch_RejectsNonPatch(t *testing.T) {
+	requireGit(t)
+	dir := initRepo(t)
+	svc := NewService()
+
+	if err := svc.ApplyPatch(ctx(), dir, "rm -rf /\n", false); err == nil {
+		t.Error("ApplyPatch() accepted non-patch input, want rejection")
+	}
+}
+
+// TestService_FileHunks_RejectsTraversalPath: path validation matches the rest
+// of the service — no absolute or escaping paths reach a git argv.
+func TestService_FileHunks_RejectsTraversalPath(t *testing.T) {
+	requireGit(t)
+	dir := initRepo(t)
+	svc := NewService()
+
+	if _, err := svc.FileHunks(ctx(), dir, "../escape.txt", false); err == nil {
+		t.Error("FileHunks() accepted traversal path, want rejection")
+	}
+}
+
+func findFile(files []FileChange, path string) *FileChange {
+	for i := range files {
+		if files[i].Path == path {
+			return &files[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #163. Follow-up to #162 (M7 git integration), deferred to keep M7 narrow.

Adds per-hunk stage/unstage inside the diff preview, backed by a real `git apply --cached` of a synthesized single-hunk patch (`--reverse` to unstage). TDD throughout.

## Backend (`internal/git/hunks.go`)
- `parseFileHunks` splits a real `git diff` unified patch into a file header plus hunks; each hunk keeps a standalone, applyable `Patch` and its new-side start/line count.
- `Service.FileHunks(dir, path, staged)` — `git diff [--cached] --no-color --no-ext-diff -- <path>` via a direct git invocation (not the rtk-proxied compact-diff path), then parses.
- `Service.ApplyPatch(dir, patch, reverse)` pipes the patch to `git apply --cached [--reverse]`; `looksLikePatch` guards the bindings boundary.

## Bindings
- `GitFileHunks` and `GitApplyHunk` on `App`; wails bindings regenerated (`git.Hunk` / `git.FileHunks` models).

## Frontend
- `gitStore`: `DiffSession.hunks` fetched in `openDiff` for tracked, textual, in-size diffs; `applyHunk(patch, reverse)` reuses the stage/unstage `runOp` (single-flight + auto-refresh repaints the reduced hunk set). Hunks are suppressed while the working-tree pane shows an unsaved editor buffer git hasn't diffed, so gutter anchors never drift.
- `hunkStagingGutter`: a CodeMirror gutter on the right pane with a `+`/`−` button at each hunk's new-side start line. An unstaged diff stages; a staged diff unstages. Click logic (`hunkStagingAction`, `createHunkButton`) is extracted so it's unit-tested without a live editor.

## Correctness
Relies on the git invariant that `git diff`'s preimage is the index, so `git apply --cached` of a single hunk applies without fuzz (the mechanism `git add -p` uses); unstage is the reverse against index-vs-HEAD. Verified end-to-end, including staging one of two separate hunks (index reflects only the picked hunk), deletion-only hunks, and unstage round-trips.

## Tests
- Backend: 8 new integration tests against real git in temp repos (stage/unstage round-trip, one-of-two selection, deletion hunk, binary, no-op, patch/path validation).
- Bindings: end-to-end App test.
- Frontend: store hunk-fetch + `applyHunk` + dirty-buffer suppression; pure gutter logic; GitDiffView gutter wiring. Full suite green (Go 605, jest 1326), go vet + golangci-lint + eslint + prettier clean.