### PR TITLE
fix: harden hunk staging patches

### DIFF
--- a/frontend/src/stores/gitStore.test.ts
+++ b/frontend/src/stores/gitStore.test.ts
@@ -411,6 +411,8 @@ describe('gitStore diff sessions', () => {
       label: 'HEAD',
       content: 'old text',
     });
+    expect(mockFileHunks).not.toHaveBeenCalled();
+    expect(useGitStore.getState().diffSession?.hunks).toEqual([]);
   });
 
   it('unstaged context diffs the index against the working tree', async () => {

--- a/frontend/src/stores/gitStore.ts
+++ b/frontend/src/stores/gitStore.ts
@@ -411,10 +411,10 @@ export const useGitStore = create<GitStore>()(
           }
 
           // Per-hunk staging data for tracked, textual, in-size diffs.
-          // Untracked/binary/too-large diffs stage whole-file only, so skip the
-          // extra git call and leave hunks empty (the UI shows no gutter button).
+          // Untracked/rename/binary/too-large diffs stage whole-file only, so
+          // skip the extra git call and leave hunks empty (no gutter button).
           let hunks: git.Hunk[] = [];
-          if (!untracked && !binary && !truncated && !dirtyBufferWorktree) {
+          if (!untracked && !change.origPath && !binary && !truncated && !dirtyBufferWorktree) {
             const fh = await GitFileHunks(repoRoot, change.path, context === 'staged');
             hunks = fh.hunks ?? [];
           }

--- a/internal/git/hunks.go
+++ b/internal/git/hunks.go
@@ -38,7 +38,15 @@ func (s *Service) FileHunks(ctx context.Context, dir, path string, staged bool) 
 	if err := validateRepoRelPaths([]string{path}); err != nil {
 		return FileHunks{}, err
 	}
-	args := []string{"diff", "--no-color", "--no-ext-diff"}
+	args := []string{
+		"diff",
+		"--no-color",
+		"--no-ext-diff",
+		"--no-textconv",
+		"--unified=3",
+		"--src-prefix=a/",
+		"--dst-prefix=b/",
+	}
 	if staged {
 		args = append(args, "--cached")
 	}

--- a/internal/git/hunks_test.go
+++ b/internal/git/hunks_test.go
@@ -205,6 +205,37 @@ func TestService_FileHunks_NoChangesEmpty(t *testing.T) {
 	}
 }
 
+func TestService_FileHunks_PinsApplyableDiffOutput(t *testing.T) {
+	requireGit(t)
+	dir := initRepo(t)
+	svc := NewService()
+	writeFile(t, dir, "README.md", "1\n2\n3\n4\n5\n")
+	if err := svc.Stage(ctx(), dir, []string{"README.md"}); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "commit", "-m", "expand readme")
+	gitCmd(t, dir, "config", "diff.context", "0")
+	gitCmd(t, dir, "config", "diff.noprefix", "true")
+	writeFile(t, dir, "README.md", "1\n2\nTHREE\n4\n5\n")
+
+	fh, err := svc.FileHunks(ctx(), dir, "README.md", false)
+	if err != nil {
+		t.Fatalf("FileHunks() error = %v", err)
+	}
+	if len(fh.Hunks) != 1 {
+		t.Fatalf("hunks = %d, want 1 (%+v)", len(fh.Hunks), fh.Hunks)
+	}
+	if !strings.Contains(fh.Hunks[0].Patch, "diff --git a/README.md b/README.md") {
+		t.Fatalf("patch did not keep default prefixes:\n%s", fh.Hunks[0].Patch)
+	}
+	if !strings.Contains(fh.Hunks[0].Patch, "@@ -1,5 +1,5 @@") {
+		t.Fatalf("patch did not override zero-context config:\n%s", fh.Hunks[0].Patch)
+	}
+	if err := svc.ApplyPatch(ctx(), dir, fh.Hunks[0].Patch, false); err != nil {
+		t.Fatalf("ApplyPatch() error = %v", err)
+	}
+}
+
 // TestService_ApplyPatch_RejectsNonPatch guards the bindings boundary: junk
 // never reaches `git apply`.
 func TestService_ApplyPatch_RejectsNonPatch(t *testing.T) {


### PR DESCRIPTION
Follow-up to merged PR #173. Commits the review fixes that were left local: pin hunk diff output so generated patches remain applyable under user git config, and suppress hunk controls for staged renames until rename-aware patch handling exists. Validation: go test ./..., go vet ./..., frontend build, focused Jest hunk/diff tests, and pre-push full frontend/go/golangci-lint checks.