### PR TITLE
fix: allow hunks for renamed file edits

### DIFF
--- a/frontend/src/stores/gitStore.test.ts
+++ b/frontend/src/stores/gitStore.test.ts
@@ -415,6 +415,23 @@ describe('gitStore diff sessions', () => {
     expect(useGitStore.getState().diffSession?.hunks).toEqual([]);
   });
 
+  it('fetches hunks for unstaged edits on a staged rename', async () => {
+    mockFileAtRev.mockResolvedValueOnce(rev('index text'));
+    mockFileHunks.mockResolvedValueOnce(hunks({ patch: 'PATCH', newStart: 1, newLines: 1 }));
+
+    await useGitStore
+      .getState()
+      .openDiff(
+        { path: 'src/new.ts', origPath: 'src/old.ts', index: 'R', worktree: 'M' },
+        'unstaged'
+      );
+
+    expect(mockFileHunks).toHaveBeenCalledWith('/repo', 'src/new.ts', false);
+    expect(useGitStore.getState().diffSession?.hunks).toEqual([
+      { patch: 'PATCH', newStart: 1, newLines: 1 },
+    ]);
+  });
+
   it('unstaged context diffs the index against the working tree', async () => {
     mockFileAtRev.mockResolvedValueOnce(rev('index text'));
 

--- a/frontend/src/stores/gitStore.ts
+++ b/frontend/src/stores/gitStore.ts
@@ -411,10 +411,11 @@ export const useGitStore = create<GitStore>()(
           }
 
           // Per-hunk staging data for tracked, textual, in-size diffs.
-          // Untracked/rename/binary/too-large diffs stage whole-file only, so
-          // skip the extra git call and leave hunks empty (no gutter button).
+          // Untracked/staged-rename/binary/too-large diffs stage whole-file only,
+          // so skip the extra git call and leave hunks empty (no gutter button).
           let hunks: git.Hunk[] = [];
-          if (!untracked && !change.origPath && !binary && !truncated && !dirtyBufferWorktree) {
+          const stagedRename = context === 'staged' && change.origPath;
+          if (!untracked && !stagedRename && !binary && !truncated && !dirtyBufferWorktree) {
             const fh = await GitFileHunks(repoRoot, change.path, context === 'staged');
             hunks = fh.hunks ?? [];
           }


### PR DESCRIPTION
Follow-up to merged PR #174. Addresses the new review comment on the staged-rename guard: staged rename diffs still suppress hunk controls, but unstaged edits after a rename (porcelain RM) now fetch normal modification hunks for hunk staging. Validation: npm test -- --runInBand gitStore.test.ts, npm run build, and pre-push full frontend/go/golangci-lint checks.