### PR TITLE
feat: intent-to-add (git add -N) affordance for untracked files

### DIFF
--- a/app_git.go
+++ b/app_git.go
@@ -42,6 +42,16 @@ func (a *App) GitStage(root string, paths []string) error {
 	return a.gitService.Stage(ctx, root, paths)
 }
 
+// GitIntentToAdd marks untracked repo-root-relative paths intent-to-add
+// (git add -N): tracked as empty index blobs, content left unstaged so the
+// file diffs normally and can be staged hunk-by-hunk.
+// This is exposed to the frontend via Wails bindings.
+func (a *App) GitIntentToAdd(root string, paths []string) error {
+	ctx, cancel := a.gitCtx(gitLocalTimeout)
+	defer cancel()
+	return a.gitService.IntentToAdd(ctx, root, paths)
+}
+
 // GitUnstage removes repo-root-relative paths from the index.
 // This is exposed to the frontend via Wails bindings.
 func (a *App) GitUnstage(root string, paths []string) error {

--- a/frontend/src/__tests__/components/GitPanel/GitPanel.test.tsx
+++ b/frontend/src/__tests__/components/GitPanel/GitPanel.test.tsx
@@ -202,6 +202,45 @@ describe('GitPanel sections', () => {
     expect(GitStage).not.toHaveBeenCalled();
   });
 
+  it('labels the track affordance with the repo-relative path, not the bare name', () => {
+    seed([file('docs/new.md', '?', '?'), file('other/new.md', '?', '?')]);
+
+    render(<GitPanel />);
+
+    // Same filename in two directories must yield distinct accessible names.
+    expect(screen.getByRole('button', { name: 'Track docs/new.md without staging' })).toBeVisible();
+    expect(
+      screen.getByRole('button', { name: 'Track other/new.md without staging' })
+    ).toBeVisible();
+  });
+
+  it('an intent-to-add (.A) row offers untrack, which unstages the path', async () => {
+    (GitUnstage as jest.Mock).mockResolvedValue(undefined);
+    seed([file('docs/new.md', '.', 'A'), file('changed.ts', '.', 'M')]);
+
+    render(<GitPanel />);
+
+    // Only intent-to-add rows carry the affordance.
+    expect(screen.queryByRole('button', { name: /untrack changed\.ts/i })).toBeNull();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Untrack docs/new.md' }));
+    });
+
+    expect(GitUnstage).toHaveBeenCalledWith('/repo', ['docs/new.md']);
+  });
+
+  it('disables track and untrack while another git op is in flight', () => {
+    seed([file('new.md', '?', '?'), file('ita.md', '.', 'A')]);
+    act(() => {
+      useGitStore.setState({ opInFlight: 'pull' });
+    });
+
+    render(<GitPanel />);
+
+    expect(screen.getByRole('button', { name: 'Track new.md without staging' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Untrack ita.md' })).toBeDisabled();
+  });
+
   it('conflict rows have no include checkbox until resolved', () => {
     seed([file('clash.go', 'U', 'U', true)]);
 

--- a/frontend/src/__tests__/components/GitPanel/GitPanel.test.tsx
+++ b/frontend/src/__tests__/components/GitPanel/GitPanel.test.tsx
@@ -2,6 +2,7 @@ jest.mock('../../../../wailsjs/go/main/App', () => ({
   GitStatus: jest.fn(),
   GitStage: jest.fn(),
   GitUnstage: jest.fn(),
+  GitIntentToAdd: jest.fn(),
   GitCommit: jest.fn(),
   GitPull: jest.fn(),
   GitPush: jest.fn(),
@@ -23,6 +24,7 @@ import {
   GitStatus,
   GitStage,
   GitUnstage,
+  GitIntentToAdd,
   GitCommit,
   GitPull,
   GitPush,
@@ -182,6 +184,22 @@ describe('GitPanel sections', () => {
     await act(async () => {});
 
     expect(GitUnstage).toHaveBeenCalledWith('/repo', ['staged.ts']);
+  });
+
+  it('untracked rows offer a track-without-staging (git add -N) affordance', async () => {
+    (GitIntentToAdd as jest.Mock).mockResolvedValue(undefined);
+    seed([file('new.md', '?', '?'), file('changed.ts', '.', 'M')]);
+
+    render(<GitPanel />);
+
+    // Only untracked rows carry the affordance.
+    expect(screen.queryByRole('button', { name: /track changed\.ts/i })).toBeNull();
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Track new.md without staging' }));
+    });
+
+    expect(GitIntentToAdd).toHaveBeenCalledWith('/repo', ['new.md']);
+    expect(GitStage).not.toHaveBeenCalled();
   });
 
   it('conflict rows have no include checkbox until resolved', () => {

--- a/frontend/src/components/GitPanel/GitPanel.module.css
+++ b/frontend/src/components/GitPanel/GitPanel.module.css
@@ -491,6 +491,30 @@
   font-weight: 700;
 }
 
+/* Untracked-only "Track" (git add -N) affordance: revealed on row hover like
+ * a secondary action, but kept focusable at all times for keyboard users. */
+.rowTrackBtn {
+  padding: 0 6px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 16px;
+  cursor: pointer;
+  opacity: 0;
+}
+
+.row:hover .rowTrackBtn,
+.rowTrackBtn:focus-visible {
+  opacity: 1;
+}
+
+.rowTrackBtn:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
 /* Both the filename and its status badge take the state color, so a file's
  * git state is readable from the name alone: modified (amber), added (green),
  * untracked (slate), deleted (red, struck through), conflict (bright red). */

--- a/frontend/src/components/GitPanel/GitPanel.module.css
+++ b/frontend/src/components/GitPanel/GitPanel.module.css
@@ -491,8 +491,10 @@
   font-weight: 700;
 }
 
-/* Untracked-only "Track" (git add -N) affordance: revealed on row hover like
- * a secondary action, but kept focusable at all times for keyboard users. */
+/* Track (git add -N) / Untrack affordance: revealed on row hover like a
+ * secondary action. Hidden via opacity + pointer-events rather than
+ * visibility so the button stays keyboard-focusable (tab reveals it via
+ * :focus-visible); pointer-events blocks stray clicks while invisible. */
 .rowTrackBtn {
   padding: 0 6px;
   border: 1px solid var(--border);
@@ -503,16 +505,27 @@
   line-height: 16px;
   cursor: pointer;
   opacity: 0;
+  pointer-events: none;
 }
 
 .row:hover .rowTrackBtn,
 .rowTrackBtn:focus-visible {
   opacity: 1;
+  pointer-events: auto;
 }
 
-.rowTrackBtn:hover {
+.rowTrackBtn:hover:not(:disabled) {
   background: var(--surface-hover);
   color: var(--text-primary);
+}
+
+.rowTrackBtn:disabled {
+  cursor: default;
+  opacity: 0;
+}
+
+.row:hover .rowTrackBtn:disabled {
+  opacity: 0.45;
 }
 
 /* Both the filename and its status badge take the state color, so a file's

--- a/frontend/src/components/GitPanel/GitPanel.tsx
+++ b/frontend/src/components/GitPanel/GitPanel.tsx
@@ -542,6 +542,7 @@ function ChangeRow({
   rowAction: 'stage' | 'unstage' | null;
 }) {
   const name = fileName(file.change.path);
+  const busy = useGitStore((s) => s.opInFlight !== null);
   const git = useGitStore.getState();
 
   // Staged rows diff HEAD↔index, unstaged/untracked rows diff index↔worktree;
@@ -595,10 +596,23 @@ function ChangeRow({
             type="button"
             className={styles.rowTrackBtn}
             onClick={() => void git.intentToAdd([file.change.path])}
-            aria-label={`Track ${name} without staging`}
+            disabled={busy}
+            aria-label={`Track ${file.change.path} without staging`}
             title="Track without staging (git add -N): the file shows in diffs and can be staged hunk-by-hunk"
           >
             Track
+          </button>
+        )}
+        {classifyChange(file.change).intentToAdd && (
+          <button
+            type="button"
+            className={styles.rowTrackBtn}
+            onClick={() => void git.unstage([file.change.path])}
+            disabled={busy}
+            aria-label={`Untrack ${file.change.path}`}
+            title="Stop tracking (git restore --staged): back to untracked, file kept on disk"
+          >
+            Untrack
           </button>
         )}
         <span className={styles.rowBadge} aria-hidden="true">

--- a/frontend/src/components/GitPanel/GitPanel.tsx
+++ b/frontend/src/components/GitPanel/GitPanel.tsx
@@ -590,6 +590,17 @@ function ChangeRow({
         )}
       </button>
       <span className={styles.rowActions}>
+        {file.rowStatus === 'untracked' && (
+          <button
+            type="button"
+            className={styles.rowTrackBtn}
+            onClick={() => void git.intentToAdd([file.change.path])}
+            aria-label={`Track ${name} without staging`}
+            title="Track without staging (git add -N): the file shows in diffs and can be staged hunk-by-hunk"
+          >
+            Track
+          </button>
+        )}
         <span className={styles.rowBadge} aria-hidden="true">
           {statusLetter[file.rowStatus]}
         </span>

--- a/frontend/src/stores/gitStore.test.ts
+++ b/frontend/src/stores/gitStore.test.ts
@@ -581,6 +581,23 @@ describe('gitStore diff sessions', () => {
     expect(useGitStore.getState().diffSession).toBe(first);
   });
 
+  it('rebuilds an open untracked diff after intent-to-add enables hunks', async () => {
+    const untracked = { path: 'fresh.ts', index: '?', worktree: '?' };
+    const intentToAdd = { path: 'fresh.ts', index: '.', worktree: 'A' };
+    mockReadFile.mockResolvedValue({ content: 'x' } as Awaited<ReturnType<typeof ReadFile>>);
+    await useGitStore.getState().openDiff(untracked, 'unstaged');
+    const first = useGitStore.getState().diffSession;
+
+    mockGitStatus.mockResolvedValue(repoStatus({ files: [intentToAdd] }));
+    mockFileAtRev.mockResolvedValueOnce(rev(''));
+    mockFileHunks.mockResolvedValueOnce(hunks({ patch: 'PATCH', newStart: 1, newLines: 1 }));
+    await useGitStore.getState().refresh();
+
+    const session = useGitStore.getState().diffSession;
+    expect(session).not.toBe(first);
+    expect(session?.hunks).toEqual([{ patch: 'PATCH', newStart: 1, newLines: 1 }]);
+  });
+
   it('keeps the diff unfocused across a refresh when the user is on a file tab', async () => {
     const added = { path: 'fresh.ts', index: 'A', worktree: 'M' };
     mockFileAtRev.mockResolvedValue(rev('x'));

--- a/frontend/src/stores/gitStore.test.ts
+++ b/frontend/src/stores/gitStore.test.ts
@@ -2,6 +2,7 @@ jest.mock('../../wailsjs/go/main/App', () => ({
   GitStatus: jest.fn(),
   GitStage: jest.fn(),
   GitUnstage: jest.fn(),
+  GitIntentToAdd: jest.fn(),
   GitCommit: jest.fn(),
   GitPull: jest.fn(),
   GitPush: jest.fn(),
@@ -18,6 +19,7 @@ jest.mock('../../wailsjs/go/main/App', () => ({
 import {
   GitStatus,
   GitStage,
+  GitIntentToAdd,
   GitCommit,
   GitPull,
   GitBranches,
@@ -34,6 +36,7 @@ import { useIDEStore } from './ideStore';
 
 const mockGitStatus = GitStatus as jest.MockedFunction<typeof GitStatus>;
 const mockGitStage = GitStage as jest.MockedFunction<typeof GitStage>;
+const mockGitIntentToAdd = GitIntentToAdd as jest.MockedFunction<typeof GitIntentToAdd>;
 const mockGitCommit = GitCommit as jest.MockedFunction<typeof GitCommit>;
 const mockGitPull = GitPull as jest.MockedFunction<typeof GitPull>;
 const mockGitBranches = GitBranches as jest.MockedFunction<typeof GitBranches>;
@@ -144,6 +147,24 @@ describe('gitStore operations', () => {
 
     expect(mockGitStage).toHaveBeenCalledWith('/repo', ['a.ts']);
     expect(mockGitStatus).toHaveBeenCalled();
+  });
+
+  it('intentToAdd calls the binding with the workspace root and refreshes', async () => {
+    mockGitIntentToAdd.mockResolvedValue(undefined);
+
+    await useGitStore.getState().intentToAdd(['new.md']);
+
+    expect(mockGitIntentToAdd).toHaveBeenCalledWith('/repo', ['new.md']);
+    expect(mockGitStatus).toHaveBeenCalled();
+  });
+
+  it('intentToAdd failure lands in lastError and toasts', async () => {
+    mockGitIntentToAdd.mockRejectedValue(new Error('pathspec did not match'));
+
+    await useGitStore.getState().intentToAdd(['gone.md']);
+
+    expect(useGitStore.getState().lastError).toContain('pathspec');
+    expect(useIDEStore.getState().toast?.type).toBe('error');
   });
 
   it('commit clears the message on success', async () => {

--- a/frontend/src/stores/gitStore.ts
+++ b/frontend/src/stores/gitStore.ts
@@ -80,7 +80,18 @@ function sameSession(a: DiffSession | null, b: DiffSession): boolean {
     a.left.label === b.left.label &&
     a.left.content === b.left.content &&
     a.right.label === b.right.label &&
-    a.right.content === b.right.content
+    a.right.content === b.right.content &&
+    sameHunks(a.hunks, b.hunks)
+  );
+}
+
+function sameHunks(a: git.Hunk[], b: git.Hunk[]): boolean {
+  return (
+    a.length === b.length &&
+    a.every(
+      (h, i) =>
+        h.patch === b[i].patch && h.newStart === b[i].newStart && h.newLines === b[i].newLines
+    )
   );
 }
 

--- a/frontend/src/stores/gitStore.ts
+++ b/frontend/src/stores/gitStore.ts
@@ -5,6 +5,7 @@ import {
   GitStatus,
   GitStage,
   GitUnstage,
+  GitIntentToAdd,
   GitCommit,
   GitPull,
   GitPush,
@@ -94,7 +95,15 @@ function parseCommitSummary(output: string): Pick<CommitReceipt, 'branch' | 'has
  * (branch switches, installs) into one `git status` run. */
 export const GIT_REFRESH_DEBOUNCE_MS = 300;
 
-export type GitOp = 'stage' | 'unstage' | 'commit' | 'pull' | 'push' | 'checkout' | 'generate';
+export type GitOp =
+  | 'stage'
+  | 'unstage'
+  | 'intent-to-add'
+  | 'commit'
+  | 'pull'
+  | 'push'
+  | 'checkout'
+  | 'generate';
 
 interface GitState {
   /** Workspace root git commands run from; null = no workspace. */
@@ -136,6 +145,10 @@ interface GitActions {
   scheduleRefresh: () => void;
   stage: (paths: string[]) => Promise<void>;
   unstage: (paths: string[]) => Promise<void>;
+  /** Track untracked paths without staging content (git add -N): the files
+   * gain an empty index blob so they diff normally and can be staged
+   * hunk-by-hunk. */
+  intentToAdd: (paths: string[]) => Promise<void>;
   /** Stage (reverse=false) or unstage (reverse=true) a single diff hunk by
    * applying its patch to the index. Refreshes status + the open diff after. */
   applyHunk: (patch: string, reverse: boolean) => Promise<void>;
@@ -264,6 +277,13 @@ export const useGitStore = create<GitStore>()(
       unstage: async (paths) => {
         await runOp('unstage', get, set, async (root) => {
           await GitUnstage(root, paths);
+          return null;
+        });
+      },
+
+      intentToAdd: async (paths) => {
+        await runOp('intent-to-add', get, set, async (root) => {
+          await GitIntentToAdd(root, paths);
           return null;
         });
       },

--- a/frontend/src/types/git.test.ts
+++ b/frontend/src/types/git.test.ts
@@ -49,6 +49,20 @@ describe('classifyChange', () => {
     expect(classifyChange(fc('R', '.', { origPath: 'src/old.ts' })).rowStatus).toBe('renamed');
   });
 
+  it('flags an intent-to-add entry (.A) so the UI can offer untrack', () => {
+    const c = classifyChange(fc('.', 'A'));
+    expect(c.intentToAdd).toBe(true);
+    expect(c.unstaged).toBe(true);
+    expect(c.staged).toBe(false);
+    expect(c.rowStatus).toBe('added');
+  });
+
+  it('does not flag plain untracked or staged additions as intent-to-add', () => {
+    expect(classifyChange(fc('?', '?')).intentToAdd).toBe(false);
+    expect(classifyChange(fc('A', '.')).intentToAdd).toBe(false);
+    expect(classifyChange(fc('A', 'M')).intentToAdd).toBe(false);
+  });
+
   it('conflict wins over everything', () => {
     const c = classifyChange(fc('U', 'U', { unmerged: true }));
     expect(c.conflicted).toBe(true);

--- a/frontend/src/types/git.ts
+++ b/frontend/src/types/git.ts
@@ -28,6 +28,9 @@ export interface ChangeClassification {
   unstaged: boolean;
   untracked: boolean;
   conflicted: boolean;
+  /** Intent-to-add entry (porcelain ".A", from git add -N): tracked as an
+   * empty index blob, content unstaged. The UI offers untrack on these. */
+  intentToAdd: boolean;
   rowStatus: GitRowStatus;
 }
 
@@ -52,6 +55,7 @@ export function classifyChange(change: GitFileChange): ChangeClassification {
       unstaged: false,
       untracked: false,
       conflicted: true,
+      intentToAdd: false,
       rowStatus: 'conflicted',
     };
   }
@@ -61,15 +65,18 @@ export function classifyChange(change: GitFileChange): ChangeClassification {
       unstaged: false,
       untracked: true,
       conflicted: false,
+      intentToAdd: false,
       rowStatus: 'untracked',
     };
   }
   const staged = change.index !== '.';
   const unstaged = change.worktree !== '.';
+  // ".A" only arises from git add -N: an unstaged addition of a tracked path.
+  const intentToAdd = change.index === '.' && change.worktree === 'A';
   // Worktree letter wins for the row look: it is what the user sees on disk.
   const rowStatus =
     (unstaged ? letterStatus[change.worktree] : letterStatus[change.index]) ?? 'modified';
-  return { staged, unstaged, untracked: false, conflicted: false, rowStatus };
+  return { staged, unstaged, untracked: false, conflicted: false, intentToAdd, rowStatus };
 }
 
 /**

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -52,6 +52,8 @@ export function GitFileHunks(arg1:string,arg2:string,arg3:boolean):Promise<git.F
 
 export function GitGenerateCommitMessage(arg1:string):Promise<string>;
 
+export function GitIntentToAdd(arg1:string,arg2:Array<string>):Promise<void>;
+
 export function GitPull(arg1:string):Promise<string>;
 
 export function GitPush(arg1:string):Promise<string>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -90,6 +90,10 @@ export function GitGenerateCommitMessage(arg1) {
   return window['go']['main']['App']['GitGenerateCommitMessage'](arg1);
 }
 
+export function GitIntentToAdd(arg1, arg2) {
+  return window['go']['main']['App']['GitIntentToAdd'](arg1, arg2);
+}
+
 export function GitPull(arg1) {
   return window['go']['main']['App']['GitPull'](arg1);
 }

--- a/internal/git/service.go
+++ b/internal/git/service.go
@@ -79,6 +79,17 @@ func (s *Service) Stage(ctx context.Context, dir string, paths []string) error {
 	return err
 }
 
+// IntentToAdd records untracked paths in the index as empty blobs
+// (git add --intent-to-add): the files become tracked and diffable while
+// their content stays unstaged, enabling later hunk-by-hunk staging.
+func (s *Service) IntentToAdd(ctx context.Context, dir string, paths []string) error {
+	if err := validateRepoRelPaths(paths); err != nil {
+		return err
+	}
+	_, err := s.runAtRoot(ctx, dir, append([]string{"add", "--intent-to-add", "--"}, paths...)...)
+	return err
+}
+
 // Unstage removes paths from the index. On an unborn HEAD (no commits yet)
 // `restore --staged` cannot resolve HEAD, so fall back to rm --cached.
 func (s *Service) Unstage(ctx context.Context, dir string, paths []string) error {

--- a/internal/git/service_test.go
+++ b/internal/git/service_test.go
@@ -201,6 +201,36 @@ func TestService_StageAndUnstage(t *testing.T) {
 	}
 }
 
+func TestService_IntentToAdd(t *testing.T) {
+	requireGit(t)
+	dir := initRepo(t)
+	writeFile(t, dir, "new.txt", "content\n")
+	svc := NewService()
+
+	if err := svc.IntentToAdd(ctx(), dir, []string{"new.txt"}); err != nil {
+		t.Fatalf("IntentToAdd() error = %v", err)
+	}
+
+	// Intent-to-add records the path in the index as an empty blob: the file
+	// is tracked (no longer "?") but its content stays unstaged (".A").
+	st, _ := svc.Status(ctx(), dir)
+	if len(st.Files) != 1 {
+		t.Fatalf("Files = %+v, want single entry", st.Files)
+	}
+	if st.Files[0].Index != "." || st.Files[0].Worktree != "A" {
+		t.Errorf("XY = %s%s, want .A (intent-to-add)", st.Files[0].Index, st.Files[0].Worktree)
+	}
+}
+
+func TestService_IntentToAdd_RejectsTraversal(t *testing.T) {
+	requireGit(t)
+	svc := NewService()
+
+	if err := svc.IntentToAdd(ctx(), t.TempDir(), []string{"../evil.txt"}); err == nil {
+		t.Error("IntentToAdd() with traversal path = nil error, want error")
+	}
+}
+
 func TestService_Unstage_BeforeFirstCommit(t *testing.T) {
 	requireGit(t)
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

Implements #167: untracked files can now be tracked without staging their content, completing the hunk-staging story from #163 (which deliberately skips untracked files).

- `Service.IntentToAdd` in `internal/git/service.go`: validated repo-root-relative paths, `git add --intent-to-add --` run at the repo root, following the Stage/Unstage pattern.
- `GitIntentToAdd` Wails binding with the standard local timeout; wailsjs modules regenerated.
- `gitStore.intentToAdd` action through the shared `runOp` wrapper (single-flight, error toast, automatic status refresh).
- Git panel: untracked rows get a hover-revealed (keyboard-focusable) Track button. After tracking, the file reports porcelain `.A` — `classifyChange` buckets it as an unstaged add (new `intentToAdd` flag), it diffs against the empty index blob, and per-hunk staging works unchanged.
- Intent-to-add rows get a matching Untrack button (reuses `unstage`; `git restore --staged` returns the path to untracked), closing the loop.
- Review hardening: Track/Untrack disable during in-flight git ops, aria-labels use repo-relative paths (distinct accessible names for same-named files), hidden buttons carry `pointer-events: none` so invisible affordances cannot be clicked, and `sameSession` compares hunks so an open untracked diff rebuilds once -N enables hunk controls.

## Test plan

- `go test ./...` — 608 passed (new: `TestService_IntentToAdd`, `TestService_IntentToAdd_RejectsTraversal`)
- `frontend: npx jest` — 1336 passed (store: binding call, error surfacing, diff rebuild after -N; panel: track/untrack affordances, busy-disable, path-based labels; types: intentToAdd classification)
- `frontend: npm run build` — tsc + vite clean

Closes #167

Generated with Claude Code