### PR TITLE
LSP Phase 3: managed provisioning for gopls, rust-analyzer, and typescript-language-server

### DIFF
--- a/app.go
+++ b/app.go
@@ -99,8 +99,7 @@ func (a *App) startup(ctx context.Context) {
 }
 
 // wireLSPProvisioners builds and registers the managed-server provisioners on
-// the LSP manager. Currently only the Python (basedpyright) provisioner is
-// managed. When the home directory is unavailable the provisioner is skipped
+// the LSP manager. When the home directory is unavailable, provisioners are skipped
 // gracefully — managed installs simply won't be offered, while interpreter/env
 // wiring still works.
 func (a *App) wireLSPProvisioners() {

--- a/app.go
+++ b/app.go
@@ -121,7 +121,26 @@ func (a *App) wireLSPProvisioners() {
 		},
 		// Fetch nil -> defaultFetch (real download+verify+unzip).
 	})
-	a.lspManager.SetProvisioners(map[string]provision.Provisioner{"python": pyProv})
+	goProv := provision.NewGoProvisioner(cacheRoot, stdruntime.GOOS, stdruntime.GOARCH, provision.GoDeps{
+		LookPath: exec.LookPath,
+		RunGo: func(ctx context.Context, goBin string, args, env []string) error {
+			cmd := exec.CommandContext(ctx, goBin, args...)
+			cmd.Env = env
+			return cmd.Run()
+		},
+	})
+	rustProv := provision.NewRustProvisioner(cacheRoot, stdruntime.GOOS, stdruntime.GOARCH, provision.RustDeps{
+		// Fetch nil -> defaultRustFetch (real download+verify+gunzip/unzip).
+	})
+	tsProv := provision.NewTypeScriptProvisioner(cacheRoot, stdruntime.GOOS, stdruntime.GOARCH, provision.TypeScriptDeps{
+		// Fetch nil -> defaultTypeScriptFetch (real download+verify+untar/unzip).
+	})
+	a.lspManager.SetProvisioners(map[string]provision.Provisioner{
+		"python":     pyProv,
+		"go":         goProv,
+		"rust":       rustProv,
+		"typescript": tsProv,
+	})
 }
 
 // beforeClose is called by Wails before the application window closes.

--- a/frontend/src/__tests__/components/Editor/lspSetupNotice.test.ts
+++ b/frontend/src/__tests__/components/Editor/lspSetupNotice.test.ts
@@ -26,4 +26,13 @@ describe('describeSetup phase 2 states', () => {
     const n = describeSetup(status({ setupState: 'provision_failed', action: 'retry' }));
     expect(n?.tone).toBe('error');
   });
+  it('provision_failed for python keeps the basedpyright/pyright suggestion', () => {
+    const n = describeSetup(status({ family: 'python', setupState: 'provision_failed' }));
+    expect(n?.hint.toLowerCase()).toContain('basedpyright');
+  });
+  it('provision_failed for a non-python family is family-aware, not python copy', () => {
+    const n = describeSetup(status({ family: 'rust', setupState: 'provision_failed' }));
+    expect(n?.hint.toLowerCase()).not.toContain('basedpyright');
+    expect(n?.hint.toLowerCase()).toContain('rust');
+  });
 });

--- a/frontend/src/components/Editor/lspSetupNotice.ts
+++ b/frontend/src/components/Editor/lspSetupNotice.ts
@@ -61,12 +61,19 @@ export function describeSetup(status: LSPServerStatus | undefined): LSPSetupNoti
         hint: 'Check your connection, then Retry.',
         tone: 'error',
       };
-    case 'provision_failed':
+    case 'provision_failed': {
+      // Python has a well-known package name worth naming; other families get a
+      // generic manual-install suggestion so the copy is never Python-specific.
+      const manual =
+        status.family === 'python'
+          ? 'install basedpyright/pyright manually'
+          : `install the ${status.family} language server manually`;
       return {
         message: 'Language server setup failed.',
-        hint: 'Retry, or install basedpyright/pyright manually.',
+        hint: `Retry, or ${manual}.`,
         tone: 'error',
       };
+    }
     default:
       return null;
   }

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -1171,6 +1171,8 @@ func defaultServerCommand(family string) string {
 		return "gopls"
 	case "python":
 		return "pyright-langserver"
+	case "rust":
+		return "rust-analyzer"
 	default:
 		return ""
 	}

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -1139,6 +1139,8 @@ func projectRootMarkers(family string) []string {
 		return []string{"go.mod"}
 	case "python":
 		return []string{"pyproject.toml", "requirements.txt", "setup.py"}
+	case "rust":
+		return []string{"Cargo.toml"}
 	}
 	return nil
 }

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -110,7 +110,8 @@ func TestRegistry_LanguageIDMapping(t *testing.T) {
 		{".py", "python", "python"},
 		{".pyw", "python", "python"},
 		{".pyi", "python", "python"},
-		{".rs", "", ""},
+		{".rs", "rust", "rust"},
+		{".txt", "", ""},
 	}
 
 	for _, tt := range tests {
@@ -348,7 +349,7 @@ func TestManager_DidOpenUnsupported(t *testing.T) {
 	mgr.SetWorkspaceRoot("/tmp/test")
 
 	ctx := context.Background()
-	err := mgr.DidOpen(ctx, "/tmp/test/main.rs", "", 1, "fn main() {}")
+	err := mgr.DidOpen(ctx, "/tmp/test/notes.txt", "", 1, "just some notes")
 	if err != nil {
 		t.Errorf("DidOpen unsupported file should be no-op, got: %v", err)
 	}
@@ -358,9 +359,9 @@ func TestManager_DocumentSymbolNoServer(t *testing.T) {
 	mgr, _ := newTestManager(t)
 	mgr.SetWorkspaceRoot("/tmp/test")
 
-	// No language server covers .rs in the test registry, so DocumentSymbol
+	// No language server covers .txt in the test registry, so DocumentSymbol
 	// must return (nil, nil) rather than erroring.
-	symbols, err := mgr.DocumentSymbol(context.Background(), "/tmp/test/main.rs")
+	symbols, err := mgr.DocumentSymbol(context.Background(), "/tmp/test/notes.txt")
 	if err != nil {
 		t.Errorf("DocumentSymbol on unsupported file should not error, got: %v", err)
 	}

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -1325,6 +1325,25 @@ func TestManager_ProjectRootForPath_GoUsesNearestGoMod(t *testing.T) {
 	}
 }
 
+func TestManager_ProjectRootForPath_RustUsesNearestCargoToml(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	ws := t.TempDir()
+	touch(t, filepath.Join(ws, "Cargo.toml"))
+	touch(t, filepath.Join(ws, "crates", "tool", "Cargo.toml"))
+	file := filepath.Join(ws, "crates", "tool", "src", "main.rs")
+	touch(t, file)
+	mgr.SetWorkspaceRoot(ws)
+
+	root, err := mgr.projectRootForPath("rust", file)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(ws, "crates", "tool")
+	if root != want {
+		t.Errorf("Rust project root = %q, want nearest Cargo.toml root %q", root, want)
+	}
+}
+
 func TestManager_ProjectRootForPath_PythonUsesNearestProjectMarker(t *testing.T) {
 	for _, marker := range []string{"pyproject.toml", "requirements.txt", "setup.py"} {
 		t.Run(marker, func(t *testing.T) {

--- a/internal/lsp/provision/archive.go
+++ b/internal/lsp/provision/archive.go
@@ -1,7 +1,9 @@
 package provision
 
 import (
+	"archive/tar"
 	"archive/zip"
+	"compress/gzip"
 	"fmt"
 	"io"
 	"os"
@@ -42,6 +44,108 @@ func UnzipWheel(src, destDir string) error {
 		}
 	}
 	return nil
+}
+
+// GunzipFile decompresses a single-member gzip stream (e.g. a rust-analyzer
+// release binary) to dest and marks it executable. dest's parent must exist.
+func GunzipFile(src, dest string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	gr, err := gzip.NewReader(in)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = gr.Close() }()
+
+	out, err := os.OpenFile(dest, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, gr); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+// UntarGz extracts a gzipped tarball into destDir, dropping the first strip
+// leading path components from each entry (npm tarballs nest everything under
+// "package/", so strip=1 flattens that). It rejects entries that would escape
+// destDir (zip-slip) and preserves the executable bit.
+func UntarGz(src, destDir string, strip int) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	gr, err := gzip.NewReader(in)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = gr.Close() }()
+
+	cleanDest := filepath.Clean(destDir)
+	tr := tar.NewReader(gr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		name := stripComponents(hdr.Name, strip)
+		if name == "" {
+			continue // the stripped prefix itself (e.g. the bare "package/" dir)
+		}
+		target := filepath.Join(cleanDest, name)
+		if target != cleanDest && !strings.HasPrefix(target, cleanDest+string(os.PathSeparator)) {
+			return fmt.Errorf("unsafe path in archive: %q", hdr.Name)
+		}
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			if err := writeTarFile(tr, target, hdr.FileInfo().Mode()); err != nil {
+				return err
+			}
+			// ponytail: symlinks/hardlinks skipped — trusted pinned npm tarballs carry none.
+		}
+	}
+}
+
+// stripComponents removes the first n path components from a slash-separated
+// archive path, returning "" when the path has n or fewer components.
+func stripComponents(name string, n int) string {
+	name = strings.TrimPrefix(filepath.ToSlash(name), "./")
+	parts := strings.Split(name, "/")
+	if len(parts) <= n {
+		return ""
+	}
+	return filepath.Join(parts[n:]...)
+}
+
+func writeTarFile(tr *tar.Reader, target string, mode os.FileMode) error {
+	if mode == 0 {
+		mode = 0o644
+	}
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode.Perm())
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, tr); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
 }
 
 func extractZipFile(f *zip.File, target string) error {

--- a/internal/lsp/provision/archive_gztar_test.go
+++ b/internal/lsp/provision/archive_gztar_test.go
@@ -1,0 +1,103 @@
+package provision
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func makeGz(t *testing.T, body []byte) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "bin.gz")
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	zw := gzip.NewWriter(f)
+	if _, err := zw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestGunzipFile_ok(t *testing.T) {
+	body := []byte("#!/bin/sh\n# rust-analyzer binary")
+	src := makeGz(t, body)
+	dest := filepath.Join(t.TempDir(), "rust-analyzer")
+	if err := GunzipFile(src, dest); err != nil {
+		t.Fatalf("GunzipFile: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil || !bytes.Equal(got, body) {
+		t.Fatalf("contents = %q err=%v", got, err)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("gunzipped binary not executable: mode = %v", info.Mode())
+	}
+}
+
+// makeTarGz builds a gzipped tar with an npm-style "package/" prefix so the
+// strip-components behaviour can be exercised.
+func makeTarGz(t *testing.T, files map[string]string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "pkg.tgz")
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+	for name, body := range files {
+		hdr := &tar.Header{Name: name, Mode: 0o644, Size: int64(len(body)), Typeflag: tar.TypeReg}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestUntarGz_stripsLeadingComponent(t *testing.T) {
+	src := makeTarGz(t, map[string]string{
+		"package/lib/cli.mjs":  "console.log('tls')",
+		"package/package.json": `{"name":"typescript-language-server"}`,
+	})
+	dest := t.TempDir()
+	if err := UntarGz(src, dest, 1); err != nil {
+		t.Fatalf("UntarGz: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "lib", "cli.mjs"))
+	if err != nil || string(got) != "console.log('tls')" {
+		t.Fatalf("stripped extract wrong: %q err=%v", got, err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "package", "lib", "cli.mjs")); err == nil {
+		t.Error("expected leading 'package/' component stripped")
+	}
+}
+
+func TestUntarGz_zipSlipRejected(t *testing.T) {
+	src := makeTarGz(t, map[string]string{"package/../escape.txt": "evil"})
+	if err := UntarGz(src, t.TempDir(), 1); err == nil {
+		t.Fatal("expected zip-slip rejection")
+	}
+}

--- a/internal/lsp/provision/catalog.go
+++ b/internal/lsp/provision/catalog.go
@@ -6,17 +6,22 @@ type ArtifactType string
 const (
 	// ArtifactWheelNode: a py3-none-any server wheel + a platform nodejs-wheel-binaries wheel.
 	ArtifactWheelNode ArtifactType = "wheel-node"
+	// ArtifactNpmNode: universal npm server + typescript tarballs + a platform node wheel.
+	ArtifactNpmNode ArtifactType = "npm-node"
+	// ArtifactArchiveBinary: one native server binary per platform, shipped as a
+	// gzipped binary (.gz) or a zip, with no separate runtime.
+	ArtifactArchiveBinary ArtifactType = "archive-binary"
 )
 
 // Artifact is one pinned downloadable. Pinned URL/SHA256/Version are
 // configuration constants, not placeholder data.
 type Artifact struct {
-	Kind    string // "server-wheel" | "node-wheel"
-	Package string // e.g. "basedpyright" / "nodejs-wheel-binaries"
+	Kind    string // "server-wheel" | "node-wheel" | "npm-server" | "npm-typescript" | "archive-binary"
+	Package string // e.g. "basedpyright" / "nodejs-wheel-binaries" / "rust-analyzer"
 	Version string // exact, no floating ranges
-	URL     string // HTTPS files.pythonhosted.org URL
+	URL     string // HTTPS download URL (pythonhosted / npm registry / github release)
 	SHA256  string // hex digest; mismatch is a hard stop
-	GOOS    string // "" = any platform (universal wheel)
+	GOOS    string // "" = any platform (universal wheel/tarball)
 	GOARCH  string
 }
 
@@ -29,31 +34,46 @@ type CatalogEntry struct {
 }
 
 var catalog = map[string]CatalogEntry{
-	"python": pythonCatalogEntry,
+	"python":     pythonCatalogEntry,
+	"rust":       rustCatalogEntry,
+	"typescript": typescriptCatalogEntry,
 }
 
 // PlatformArtifacts returns the catalog entry and the exact artifact set to
 // fetch for family on goos/goarch. ok is false when the family or platform is
-// unsupported (no universal server wheel + matching platform node wheel).
+// unsupported for managed download (missing a required artifact for the shape).
 func PlatformArtifacts(family, goos, goarch string) (CatalogEntry, []Artifact, bool) {
 	entry, found := catalog[family]
 	if !found {
 		return CatalogEntry{}, nil, false
 	}
 	var out []Artifact
-	var haveServer, haveNode bool
 	for _, a := range entry.Artifacts {
-		switch {
-		case a.GOOS == "" && a.GOARCH == "": // universal
+		if (a.GOOS == "" && a.GOARCH == "") || (a.GOOS == goos && a.GOARCH == goarch) {
 			out = append(out, a)
-			haveServer = haveServer || a.Kind == "server-wheel"
-		case a.GOOS == goos && a.GOARCH == goarch:
-			out = append(out, a)
-			haveNode = haveNode || a.Kind == "node-wheel"
 		}
 	}
-	if !haveServer || !haveNode {
+	if !platformComplete(entry.ArtifactType, out) {
 		return entry, nil, false
 	}
 	return entry, out, true
+}
+
+// platformComplete reports whether the collected artifact set contains every
+// piece the artifact type needs to launch on the target platform.
+func platformComplete(t ArtifactType, arts []Artifact) bool {
+	have := map[string]bool{}
+	for _, a := range arts {
+		have[a.Kind] = true
+	}
+	switch t {
+	case ArtifactWheelNode:
+		return have["server-wheel"] && have["node-wheel"]
+	case ArtifactNpmNode:
+		return have["npm-server"] && have["npm-typescript"] && have["node-wheel"]
+	case ArtifactArchiveBinary:
+		return have["archive-binary"]
+	default:
+		return false
+	}
 }

--- a/internal/lsp/provision/catalog_families_test.go
+++ b/internal/lsp/provision/catalog_families_test.go
@@ -1,0 +1,70 @@
+package provision
+
+import "testing"
+
+func TestPlatformArtifacts_Rust_supported(t *testing.T) {
+	for _, plat := range [][2]string{{"darwin", "arm64"}, {"darwin", "amd64"}, {"linux", "amd64"}, {"linux", "arm64"}, {"windows", "amd64"}, {"windows", "arm64"}} {
+		entry, arts, ok := PlatformArtifacts("rust", plat[0], plat[1])
+		if !ok {
+			t.Fatalf("rust/%s/%s expected supported", plat[0], plat[1])
+		}
+		if entry.ArtifactType != ArtifactArchiveBinary {
+			t.Errorf("rust artifact type = %q", entry.ArtifactType)
+		}
+		var bins int
+		for _, a := range arts {
+			if a.Kind == "archive-binary" {
+				bins++
+			}
+			if a.URL == "" || a.SHA256 == "" || a.Version == "" {
+				t.Errorf("rust artifact missing pinned field: %+v", a)
+			}
+			if a.GOOS != plat[0] || a.GOARCH != plat[1] {
+				t.Errorf("rust artifact platform = %s/%s, want %s/%s", a.GOOS, a.GOARCH, plat[0], plat[1])
+			}
+		}
+		if bins != 1 {
+			t.Errorf("rust/%s/%s: got %d archive-binary artifacts, want 1", plat[0], plat[1], bins)
+		}
+	}
+}
+
+func TestPlatformArtifacts_Rust_unsupportedPlatform(t *testing.T) {
+	if _, _, ok := PlatformArtifacts("rust", "plan9", "mips"); ok {
+		t.Error("expected rust/plan9/mips unsupported")
+	}
+}
+
+func TestPlatformArtifacts_TypeScript_supported(t *testing.T) {
+	entry, arts, ok := PlatformArtifacts("typescript", "darwin", "arm64")
+	if !ok {
+		t.Fatal("typescript/darwin/arm64 expected supported")
+	}
+	if entry.ArtifactType != ArtifactNpmNode {
+		t.Errorf("typescript artifact type = %q", entry.ArtifactType)
+	}
+	var server, tsc, node int
+	for _, a := range arts {
+		switch a.Kind {
+		case "npm-server":
+			server++
+		case "npm-typescript":
+			tsc++
+		case "node-wheel":
+			node++
+		}
+		if a.URL == "" || a.SHA256 == "" || a.Version == "" || a.Package == "" {
+			t.Errorf("typescript artifact missing pinned field: %+v", a)
+		}
+	}
+	if server != 1 || tsc != 1 || node != 1 {
+		t.Errorf("got server=%d typescript=%d node=%d, want 1/1/1", server, tsc, node)
+	}
+}
+
+func TestPlatformArtifacts_TypeScript_unsupportedPlatform(t *testing.T) {
+	// No node wheel for plan9/mips -> incomplete -> unsupported.
+	if _, _, ok := PlatformArtifacts("typescript", "plan9", "mips"); ok {
+		t.Error("expected typescript/plan9/mips unsupported")
+	}
+}

--- a/internal/lsp/provision/catalog_node.go
+++ b/internal/lsp/provision/catalog_node.go
@@ -1,0 +1,29 @@
+package provision
+
+// nodeWheelArtifacts pins the nodejs-wheel-binaries runtime per supported
+// OS/arch. Both the Python (basedpyright) and TypeScript
+// (typescript-language-server) managed installs run on this bundled Node, so
+// the pinned wheels live here and are shared by both catalog entries. Linux
+// uses the glibc (manylinux) wheels; musl/Alpine falls through to a family fast
+// path or a guidance card.
+// ponytail: glibc-only linux node wheels; add musllinux entries if Alpine demand appears.
+var nodeWheelArtifacts = []Artifact{
+	{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "darwin", GOARCH: "arm64",
+		URL:    "https://files.pythonhosted.org/packages/24/6d/333e5458422f12318e3c3e6e7f194353aa68b0d633217c7e89833427ca01/nodejs_wheel_binaries-22.20.0-py2.py3-none-macosx_11_0_arm64.whl",
+		SHA256: "455add5ac4f01c9c830ab6771dbfad0fdf373f9b040d3aabe8cca9b6c56654fb"},
+	{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "darwin", GOARCH: "amd64",
+		URL:    "https://files.pythonhosted.org/packages/56/30/dcd6879d286a35b3c4c8f9e5e0e1bcf4f9e25fe35310fc77ecf97f915a23/nodejs_wheel_binaries-22.20.0-py2.py3-none-macosx_11_0_x86_64.whl",
+		SHA256: "5d8c12f97eea7028b34a84446eb5ca81829d0c428dfb4e647e09ac617f4e21fa"},
+	{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "linux", GOARCH: "arm64",
+		URL:    "https://files.pythonhosted.org/packages/58/be/c7b2e7aa3bb281d380a1c531f84d0ccfe225832dfc3bed1ca171753b9630/nodejs_wheel_binaries-22.20.0-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+		SHA256: "7a2b0989194148f66e9295d8f11bc463bde02cbe276517f4d20a310fb84780ae"},
+	{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "linux", GOARCH: "amd64",
+		URL:    "https://files.pythonhosted.org/packages/3e/c5/8befacf4190e03babbae54cb0809fb1a76e1600ec3967ab8ee9f8fc85b65/nodejs_wheel_binaries-22.20.0-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+		SHA256: "b5c500aa4dc046333ecb0a80f183e069e5c30ce637f1c1a37166b2c0b642dc21"},
+	{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "windows", GOARCH: "amd64",
+		URL:    "https://files.pythonhosted.org/packages/b4/a9/c6a480259aa0d6b270aac2c6ba73a97444b9267adde983a5b7e34f17e45a/nodejs_wheel_binaries-22.20.0-py2.py3-none-win_amd64.whl",
+		SHA256: "4bd658962f24958503541963e5a6f2cc512a8cb301e48a69dc03c879f40a28ae"},
+	{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "windows", GOARCH: "arm64",
+		URL:    "https://files.pythonhosted.org/packages/42/b1/6a4eb2c6e9efa028074b0001b61008c9d202b6b46caee9e5d1b18c088216/nodejs_wheel_binaries-22.20.0-py2.py3-none-win_arm64.whl",
+		SHA256: "1fccac931faa210d22b6962bcdbc99269d16221d831b9a118bbb80fe434a60b8"},
+}

--- a/internal/lsp/provision/catalog_python.go
+++ b/internal/lsp/provision/catalog_python.go
@@ -1,15 +1,13 @@
 package provision
 
 // pythonCatalogEntry pins basedpyright (universal py3-none-any wheel) plus the
-// nodejs-wheel-binaries platform wheel per supported OS/arch. Linux uses the
-// glibc (manylinux) wheels; musl/Alpine falls through to the uv fast-path or a
-// guidance card.
-// ponytail: glibc-only linux node wheels; add musllinux entries if Alpine demand appears.
+// shared nodejs-wheel-binaries runtime (see nodeWheelArtifacts). musl/Alpine
+// falls through to the uv fast-path or a guidance card.
 var pythonCatalogEntry = CatalogEntry{
 	Family:       "python",
 	Version:      "1.39.9",
 	ArtifactType: ArtifactWheelNode,
-	Artifacts: []Artifact{
+	Artifacts: append([]Artifact{
 		{
 			Kind:    "server-wheel",
 			Package: "basedpyright",
@@ -17,23 +15,5 @@ var pythonCatalogEntry = CatalogEntry{
 			URL:     "https://files.pythonhosted.org/packages/2a/d4/e1fa108710d0498a18c77b1e13897f31eab47c69aa8cfe2d2a4df746541e/basedpyright-1.39.9-py3-none-any.whl",
 			SHA256:  "6b0837b9eba972c71895167ab9b127e6afdbc17abc92312e3f8d15ca82a5611c",
 		},
-		{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "darwin", GOARCH: "arm64",
-			URL:    "https://files.pythonhosted.org/packages/24/6d/333e5458422f12318e3c3e6e7f194353aa68b0d633217c7e89833427ca01/nodejs_wheel_binaries-22.20.0-py2.py3-none-macosx_11_0_arm64.whl",
-			SHA256: "455add5ac4f01c9c830ab6771dbfad0fdf373f9b040d3aabe8cca9b6c56654fb"},
-		{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "darwin", GOARCH: "amd64",
-			URL:    "https://files.pythonhosted.org/packages/56/30/dcd6879d286a35b3c4c8f9e5e0e1bcf4f9e25fe35310fc77ecf97f915a23/nodejs_wheel_binaries-22.20.0-py2.py3-none-macosx_11_0_x86_64.whl",
-			SHA256: "5d8c12f97eea7028b34a84446eb5ca81829d0c428dfb4e647e09ac617f4e21fa"},
-		{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "linux", GOARCH: "arm64",
-			URL:    "https://files.pythonhosted.org/packages/58/be/c7b2e7aa3bb281d380a1c531f84d0ccfe225832dfc3bed1ca171753b9630/nodejs_wheel_binaries-22.20.0-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-			SHA256: "7a2b0989194148f66e9295d8f11bc463bde02cbe276517f4d20a310fb84780ae"},
-		{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "linux", GOARCH: "amd64",
-			URL:    "https://files.pythonhosted.org/packages/3e/c5/8befacf4190e03babbae54cb0809fb1a76e1600ec3967ab8ee9f8fc85b65/nodejs_wheel_binaries-22.20.0-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-			SHA256: "b5c500aa4dc046333ecb0a80f183e069e5c30ce637f1c1a37166b2c0b642dc21"},
-		{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "windows", GOARCH: "amd64",
-			URL:    "https://files.pythonhosted.org/packages/b4/a9/c6a480259aa0d6b270aac2c6ba73a97444b9267adde983a5b7e34f17e45a/nodejs_wheel_binaries-22.20.0-py2.py3-none-win_amd64.whl",
-			SHA256: "4bd658962f24958503541963e5a6f2cc512a8cb301e48a69dc03c879f40a28ae"},
-		{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "windows", GOARCH: "arm64",
-			URL:    "https://files.pythonhosted.org/packages/42/b1/6a4eb2c6e9efa028074b0001b61008c9d202b6b46caee9e5d1b18c088216/nodejs_wheel_binaries-22.20.0-py2.py3-none-win_arm64.whl",
-			SHA256: "1fccac931faa210d22b6962bcdbc99269d16221d831b9a118bbb80fe434a60b8"},
-	},
+	}, nodeWheelArtifacts...),
 }

--- a/internal/lsp/provision/catalog_rust.go
+++ b/internal/lsp/provision/catalog_rust.go
@@ -1,0 +1,33 @@
+package provision
+
+// rustCatalogEntry pins rust-analyzer's native release binaries per OS/arch.
+// rust-analyzer publishes a self-contained executable per target — a gzipped
+// binary (.gz) on macOS/Linux and a zip on Windows — so no separate runtime is
+// bundled. The pinned tag is a dated rust-analyzer release (the project ships
+// rolling releases; there is no semver line to track).
+// ponytail: glibc-only linux binaries; add the -musl target if Alpine demand appears.
+var rustCatalogEntry = CatalogEntry{
+	Family:       "rust",
+	Version:      "2026-07-06",
+	ArtifactType: ArtifactArchiveBinary,
+	Artifacts: []Artifact{
+		{Kind: "archive-binary", Package: "rust-analyzer", Version: "2026-07-06", GOOS: "darwin", GOARCH: "arm64",
+			URL:    "https://github.com/rust-lang/rust-analyzer/releases/download/2026-07-06/rust-analyzer-aarch64-apple-darwin.gz",
+			SHA256: "0fb2229496105666460d22d062a55e154c862bb8004c464a38c6ffaff6fd68fe"},
+		{Kind: "archive-binary", Package: "rust-analyzer", Version: "2026-07-06", GOOS: "darwin", GOARCH: "amd64",
+			URL:    "https://github.com/rust-lang/rust-analyzer/releases/download/2026-07-06/rust-analyzer-x86_64-apple-darwin.gz",
+			SHA256: "3a6bc5b42c27d3f8d308dacb25fdbe9bba0577be2970500cdb936e53c21c3496"},
+		{Kind: "archive-binary", Package: "rust-analyzer", Version: "2026-07-06", GOOS: "linux", GOARCH: "arm64",
+			URL:    "https://github.com/rust-lang/rust-analyzer/releases/download/2026-07-06/rust-analyzer-aarch64-unknown-linux-gnu.gz",
+			SHA256: "7e2627d96c6f1614115d212b61fd5f8dc9279853054b800f2b023c883e3ae056"},
+		{Kind: "archive-binary", Package: "rust-analyzer", Version: "2026-07-06", GOOS: "linux", GOARCH: "amd64",
+			URL:    "https://github.com/rust-lang/rust-analyzer/releases/download/2026-07-06/rust-analyzer-x86_64-unknown-linux-gnu.gz",
+			SHA256: "2fb596e12676e512de5dbf1c322dd591127ee089a1cca47995605593f2fc8850"},
+		{Kind: "archive-binary", Package: "rust-analyzer", Version: "2026-07-06", GOOS: "windows", GOARCH: "arm64",
+			URL:    "https://github.com/rust-lang/rust-analyzer/releases/download/2026-07-06/rust-analyzer-aarch64-pc-windows-msvc.zip",
+			SHA256: "9429a8d2c6309b78bc8a944fdd3ac036fd3ec022266a92836cab02de56d69b65"},
+		{Kind: "archive-binary", Package: "rust-analyzer", Version: "2026-07-06", GOOS: "windows", GOARCH: "amd64",
+			URL:    "https://github.com/rust-lang/rust-analyzer/releases/download/2026-07-06/rust-analyzer-x86_64-pc-windows-msvc.zip",
+			SHA256: "b046120af10d0cb7c735bbd377a53007d97048666fe967e95ea88a9fc177fa09"},
+	},
+}

--- a/internal/lsp/provision/catalog_typescript.go
+++ b/internal/lsp/provision/catalog_typescript.go
@@ -1,0 +1,21 @@
+package provision
+
+// typescriptCatalogEntry pins typescript-language-server plus the TypeScript
+// package it drives, both as universal npm tarballs, on the shared Node runtime
+// (see nodeWheelArtifacts). typescript-language-server has no runtime npm
+// dependencies of its own (it is a bundled single package), so the two tarballs
+// laid out as node_modules/{typescript-language-server,typescript} are enough
+// to launch it without running a package manager.
+var typescriptCatalogEntry = CatalogEntry{
+	Family:       "typescript",
+	Version:      "5.3.0",
+	ArtifactType: ArtifactNpmNode,
+	Artifacts: append([]Artifact{
+		{Kind: "npm-server", Package: "typescript-language-server", Version: "5.3.0",
+			URL:    "https://registry.npmjs.org/typescript-language-server/-/typescript-language-server-5.3.0.tgz",
+			SHA256: "398cacc17fff2108652e7b4050e3182008d17063246b3fea7dcf5fae2ce1560e"},
+		{Kind: "npm-typescript", Package: "typescript", Version: "5.9.3",
+			URL:    "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			SHA256: "10e108c9cf7d5f2879053dff18515fb405abf2ccef63eaaf017d9c571687a1d3"},
+	}, nodeWheelArtifacts...),
+}

--- a/internal/lsp/provision/go.go
+++ b/internal/lsp/provision/go.go
@@ -123,7 +123,8 @@ func (p *GoProvisioner) lookGo() (string, error) {
 // goBinDir extracts the GOBIN value from a go-install env slice (shared by impl
 // + test so they agree on the variable name).
 func goBinDir(env []string) string {
-	for _, kv := range env {
+	for i := len(env) - 1; i >= 0; i-- {
+		kv := env[i]
 		if v, ok := strings.CutPrefix(kv, "GOBIN="); ok {
 			return v
 		}

--- a/internal/lsp/provision/go.go
+++ b/internal/lsp/provision/go.go
@@ -1,0 +1,132 @@
+package provision
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// goplsModule/goplsVersion pin the managed gopls install. gopls publishes no
+// prebuilt binaries, so the only official distribution is `go install`; the
+// version is a fixed tag, never a floating @latest.
+const (
+	goplsModule  = "golang.org/x/tools/gopls"
+	goplsVersion = "v0.22.0"
+)
+
+// GoDeps are the injected, side-effecting operations GoProvisioner needs.
+type GoDeps struct {
+	// LookPath resolves the "go" toolchain. Mirrors exec.LookPath.
+	LookPath func(string) (string, error)
+	// RunGo runs the go binary (e.g. `go install`). nil disables managed install.
+	RunGo func(ctx context.Context, goBin string, args, env []string) error
+}
+
+// GoProvisioner provisions gopls into <cacheRoot>/go/<version>/ via `go install`.
+type GoProvisioner struct {
+	cacheRoot string
+	goos      string
+	goarch    string
+	deps      GoDeps
+	mu        sync.Mutex // single-flight: one install at a time for this family
+}
+
+func NewGoProvisioner(cacheRoot, goos, goarch string, deps GoDeps) *GoProvisioner {
+	return &GoProvisioner{cacheRoot: cacheRoot, goos: goos, goarch: goarch, deps: deps}
+}
+
+func (p *GoProvisioner) Family() string { return "go" }
+
+func (p *GoProvisioner) versionDir() string {
+	return filepath.Join(p.cacheRoot, "go", goplsVersion)
+}
+
+// Resolve reads the committed launch.json (cache-only, no network).
+func (p *GoProvisioner) Resolve() Resolution {
+	return resolveCached(p.versionDir())
+}
+
+// Install runs `go install golang.org/x/tools/gopls@<version>` with GOBIN
+// pointed at a staging dir, then atomically renames staging -> versionDir. When
+// no Go toolchain is present the family is unsupported (gopls ships no binary).
+func (p *GoProvisioner) Install(ctx context.Context, progress func(Progress)) Resolution {
+	if progress == nil {
+		progress = func(Progress) {}
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if r := p.Resolve(); r.State == StateAvailable { // a concurrent installer may have finished
+		return r
+	}
+
+	goBin, err := p.lookGo()
+	if err != nil {
+		return Resolution{State: StateUnsupported, Err: errors.New("go toolchain not found: gopls has no prebuilt binary and requires `go install`")}
+	}
+
+	progress(Progress{Phase: "download", Pct: 0})
+	parent := filepath.Dir(p.versionDir())
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+	staging, err := os.MkdirTemp(parent, ".staging-*")
+	if err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+	defer func() { _ = os.RemoveAll(staging) }() // no-op after successful rename
+
+	binDir := filepath.Join(staging, "bin")
+	// gopls is a self-contained, relocatable Go binary, so a shared module cache
+	// (default GOPATH) is fine; only GOBIN is redirected into the managed dir.
+	env := append(os.Environ(), "GOBIN="+binDir, "GOFLAGS=-mod=mod")
+	args := []string{"install", goplsModule + "@" + goplsVersion}
+	if err := p.deps.RunGo(ctx, goBin, args, env); err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+
+	gopls := filepath.Join(binDir, "gopls")
+	if p.goos == "windows" {
+		gopls += ".exe"
+	}
+	if _, err := os.Stat(gopls); err != nil {
+		return Resolution{State: StateOffline, Err: errors.New("go install produced no gopls binary")}
+	}
+	rel, relErr := filepath.Rel(staging, gopls)
+	if relErr != nil {
+		return Resolution{State: StateOffline, Err: relErr}
+	}
+	// gopls serves LSP over stdio by default, so it needs no launch args.
+	spec := launchSpec{Path: rel, Args: nil, Version: goplsVersion, Abs: false}
+	if err := writeLaunchSpec(staging, spec); err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+
+	_ = os.RemoveAll(p.versionDir()) // clear any partial prior dir
+	if err := os.Rename(staging, p.versionDir()); err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+	progress(Progress{Phase: "done", Pct: 100})
+	return p.Resolve()
+}
+
+func (p *GoProvisioner) lookGo() (string, error) {
+	if p.deps.LookPath == nil || p.deps.RunGo == nil {
+		return "", errors.New("go install path disabled")
+	}
+	return p.deps.LookPath("go")
+}
+
+// goBinDir extracts the GOBIN value from a go-install env slice (shared by impl
+// + test so they agree on the variable name).
+func goBinDir(env []string) string {
+	for _, kv := range env {
+		if v, ok := strings.CutPrefix(kv, "GOBIN="); ok {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/lsp/provision/go_test.go
+++ b/internal/lsp/provision/go_test.go
@@ -1,0 +1,78 @@
+package provision
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGo_Resolve_missingThenAvailable(t *testing.T) {
+	cache := t.TempDir()
+	p := NewGoProvisioner(cache, "darwin", "arm64", GoDeps{
+		LookPath: func(name string) (string, error) {
+			if name == "go" {
+				return "/usr/local/go/bin/go", nil
+			}
+			return "", os.ErrNotExist
+		},
+		RunGo: func(_ context.Context, _ string, args, env []string) error {
+			binDir := goBinDir(env)
+			if binDir == "" {
+				t.Fatalf("no GOBIN in env: %v", env)
+			}
+			// Simulate `go install` producing the gopls binary in GOBIN.
+			return writeFile(filepath.Join(binDir, "gopls"), "#!/bin/sh\n# gopls")
+		},
+	})
+
+	if r := p.Resolve(); r.State != StateMissing {
+		t.Fatalf("pre-install Resolve = %v, want missing", r.State)
+	}
+	r := p.Install(context.Background(), func(Progress) {})
+	if r.State != StateAvailable {
+		t.Fatalf("Install = %v (%v), want available", r.State, r.Err)
+	}
+	if filepath.Base(r.Path) != "gopls" {
+		t.Errorf("launch path = %q, want gopls binary", r.Path)
+	}
+	if len(r.Args) != 0 {
+		t.Errorf("args = %v, want none (gopls serves stdio by default)", r.Args)
+	}
+	if got := p.Resolve(); got.State != StateAvailable {
+		t.Fatalf("post-install Resolve = %v", got.State)
+	}
+	if _, err := os.Stat(r.Path); err != nil {
+		t.Errorf("gopls launch path %q not on disk: %v", r.Path, err)
+	}
+}
+
+func TestGo_Install_noToolchain(t *testing.T) {
+	p := NewGoProvisioner(t.TempDir(), "darwin", "arm64", GoDeps{
+		LookPath: func(string) (string, error) { return "", os.ErrNotExist },
+	})
+	if r := p.Install(context.Background(), func(Progress) {}); r.State != StateUnsupported {
+		t.Fatalf("Install without go toolchain = %v, want unsupported", r.State)
+	}
+}
+
+func TestGo_Install_goInstallFails(t *testing.T) {
+	p := NewGoProvisioner(t.TempDir(), "darwin", "arm64", GoDeps{
+		LookPath: func(string) (string, error) { return "/usr/local/go/bin/go", nil },
+		RunGo:    func(context.Context, string, []string, []string) error { return errors.New("go install: network unreachable") },
+	})
+	if r := p.Install(context.Background(), func(Progress) {}); r.State != StateOffline {
+		t.Fatalf("Install with failing go install = %v, want offline", r.State)
+	}
+}
+
+func TestGo_Install_producesNoBinary(t *testing.T) {
+	p := NewGoProvisioner(t.TempDir(), "darwin", "arm64", GoDeps{
+		LookPath: func(string) (string, error) { return "/usr/local/go/bin/go", nil },
+		RunGo:    func(context.Context, string, []string, []string) error { return nil }, // succeeds but writes nothing
+	})
+	if r := p.Install(context.Background(), func(Progress) {}); r.State == StateAvailable {
+		t.Fatalf("Install = available despite no binary produced")
+	}
+}

--- a/internal/lsp/provision/go_test.go
+++ b/internal/lsp/provision/go_test.go
@@ -48,6 +48,12 @@ func TestGo_Resolve_missingThenAvailable(t *testing.T) {
 	}
 }
 
+func TestGoBinDirUsesLastDuplicate(t *testing.T) {
+	if got := goBinDir([]string{"GOBIN=/old", "PATH=/bin", "GOBIN=/staging"}); got != "/staging" {
+		t.Fatalf("goBinDir = %q, want last GOBIN", got)
+	}
+}
+
 func TestGo_Install_noToolchain(t *testing.T) {
 	p := NewGoProvisioner(t.TempDir(), "darwin", "arm64", GoDeps{
 		LookPath: func(string) (string, error) { return "", os.ErrNotExist },
@@ -60,7 +66,9 @@ func TestGo_Install_noToolchain(t *testing.T) {
 func TestGo_Install_goInstallFails(t *testing.T) {
 	p := NewGoProvisioner(t.TempDir(), "darwin", "arm64", GoDeps{
 		LookPath: func(string) (string, error) { return "/usr/local/go/bin/go", nil },
-		RunGo:    func(context.Context, string, []string, []string) error { return errors.New("go install: network unreachable") },
+		RunGo: func(context.Context, string, []string, []string) error {
+			return errors.New("go install: network unreachable")
+		},
 	})
 	if r := p.Install(context.Background(), func(Progress) {}); r.State != StateOffline {
 		t.Fatalf("Install with failing go install = %v, want offline", r.State)

--- a/internal/lsp/provision/provisioner_common.go
+++ b/internal/lsp/provision/provisioner_common.go
@@ -1,0 +1,38 @@
+package provision
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// resolveCached reads the committed launch.json under versionDir and reports the
+// managed server as available only when its launch target still exists on disk.
+// It is the cache-only Resolve path shared by every family provisioner (never
+// touches the network). A relative launchSpec.Path is joined to versionDir; an
+// absolute one (uv/go-install shims that bake in absolute paths) is used as-is.
+func resolveCached(versionDir string) Resolution {
+	spec, err := readLaunchSpec(versionDir)
+	if err != nil {
+		return Resolution{State: StateMissing}
+	}
+	launchPath := spec.Path
+	if !spec.Abs {
+		launchPath = filepath.Join(versionDir, spec.Path)
+	}
+	if _, err := os.Stat(launchPath); err != nil {
+		return Resolution{State: StateMissing}
+	}
+	args := spec.Args
+	// A node-based launch stores its entry script in ScriptRel so it can be
+	// resolved to an absolute path here and prepended to Args. The server runs
+	// with cwd=projectRoot (not the version dir), so a relative script arg would
+	// fail with "cannot find module".
+	if spec.ScriptRel != "" {
+		script := spec.ScriptRel
+		if !spec.Abs {
+			script = filepath.Join(versionDir, spec.ScriptRel)
+		}
+		args = append([]string{script}, spec.Args...)
+	}
+	return Resolution{State: StateAvailable, Path: launchPath, Args: args, Version: spec.Version}
+}

--- a/internal/lsp/provision/python.go
+++ b/internal/lsp/provision/python.go
@@ -21,10 +21,16 @@ type PythonDeps struct {
 
 // launchSpec is persisted as launch.json and is the install's commit marker.
 type launchSpec struct {
-	Path    string   `json:"path"`
-	Args    []string `json:"args"`
-	Version string   `json:"version"`
-	Abs     bool     `json:"abs"` // true: Path absolute; false: Path relative to the version dir
+	Path string `json:"path"`
+	// ScriptRel is an optional entry script (e.g. a node server's cli.mjs) that,
+	// like Path, is stored relative to the version dir and resolved to an absolute
+	// path at launch, then prepended to Args. It exists because the server runs
+	// with cwd=projectRoot, not the version dir, so a relative script arg would
+	// not be found. Empty for single-binary launches (gopls, rust-analyzer, uv shim).
+	ScriptRel string   `json:"scriptRel,omitempty"`
+	Args      []string `json:"args"`
+	Version   string   `json:"version"`
+	Abs       bool     `json:"abs"` // true: Path/ScriptRel absolute; false: relative to the version dir
 }
 
 // PythonProvisioner provisions basedpyright into <cacheRoot>/python/<version>/.
@@ -48,18 +54,7 @@ func (p *PythonProvisioner) versionDir() string {
 
 // Resolve reads the committed launch.json (cache-only, no network).
 func (p *PythonProvisioner) Resolve() Resolution {
-	spec, err := readLaunchSpec(p.versionDir())
-	if err != nil {
-		return Resolution{State: StateMissing}
-	}
-	launchPath := spec.Path
-	if !spec.Abs {
-		launchPath = filepath.Join(p.versionDir(), spec.Path)
-	}
-	if _, err := os.Stat(launchPath); err != nil {
-		return Resolution{State: StateMissing}
-	}
-	return Resolution{State: StateAvailable, Path: launchPath, Args: spec.Args, Version: spec.Version}
+	return resolveCached(p.versionDir())
 }
 
 func (p *PythonProvisioner) Install(ctx context.Context, progress func(Progress)) Resolution {
@@ -180,7 +175,7 @@ func (p *PythonProvisioner) installManual(ctx context.Context, artifacts []Artif
 	if err != nil {
 		return Resolution{State: StateOffline, Err: err}
 	}
-	spec := launchSpec{Path: nodeRel, Args: []string{jsRel, "--stdio"}, Version: pythonCatalogEntry.Version, Abs: false}
+	spec := launchSpec{Path: nodeRel, ScriptRel: jsRel, Args: []string{"--stdio"}, Version: pythonCatalogEntry.Version, Abs: false}
 	if err := writeLaunchSpec(staging, spec); err != nil {
 		return Resolution{State: StateOffline, Err: err}
 	}

--- a/internal/lsp/provision/python_test.go
+++ b/internal/lsp/provision/python_test.go
@@ -44,6 +44,14 @@ func TestPython_Resolve_missingThenAvailable(t *testing.T) {
 	if len(got.Args) == 0 || got.Args[len(got.Args)-1] != "--stdio" {
 		t.Errorf("args = %v, want trailing --stdio", got.Args)
 	}
+	// The manual (non-uv) path launches `node <langserver.index.js> --stdio` with
+	// cwd=projectRoot, so the script arg must be absolute and on disk.
+	if !filepath.IsAbs(got.Args[0]) {
+		t.Errorf("langserver script arg must be absolute, got %q", got.Args[0])
+	}
+	if _, err := os.Stat(got.Args[0]); err != nil {
+		t.Errorf("langserver script arg %q not resolvable on disk: %v", got.Args[0], err)
+	}
 	if _, err := os.Stat(filepath.Join(cache, "python", "1.39.9", "launch.json")); err != nil {
 		t.Errorf("launch.json missing: %v", err)
 	}

--- a/internal/lsp/provision/rust.go
+++ b/internal/lsp/provision/rust.go
@@ -1,0 +1,138 @@
+package provision
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RustDeps are the injected, side-effecting operations RustProvisioner needs.
+type RustDeps struct {
+	// Fetch downloads+verifies+extracts one archive-binary artifact into destDir,
+	// leaving the runnable rust-analyzer binary there. nil => defaultRustFetch.
+	Fetch func(ctx context.Context, a Artifact, destDir string) error
+}
+
+// RustProvisioner provisions rust-analyzer into <cacheRoot>/rust/<version>/.
+// rust-analyzer ships one self-contained native binary per platform (a gzipped
+// binary on macOS/Linux, a zip on Windows), so there is no separate runtime.
+type RustProvisioner struct {
+	cacheRoot string
+	goos      string
+	goarch    string
+	deps      RustDeps
+	mu        sync.Mutex // single-flight: one install at a time for this family
+}
+
+func NewRustProvisioner(cacheRoot, goos, goarch string, deps RustDeps) *RustProvisioner {
+	return &RustProvisioner{cacheRoot: cacheRoot, goos: goos, goarch: goarch, deps: deps}
+}
+
+func (p *RustProvisioner) Family() string { return "rust" }
+
+func (p *RustProvisioner) versionDir() string {
+	return filepath.Join(p.cacheRoot, "rust", rustCatalogEntry.Version)
+}
+
+// Resolve reads the committed launch.json (cache-only, no network).
+func (p *RustProvisioner) Resolve() Resolution {
+	return resolveCached(p.versionDir())
+}
+
+// Install downloads+verifies+extracts the platform binary into a staging dir,
+// writes launch.json (relative path), then atomically renames staging ->
+// versionDir.
+func (p *RustProvisioner) Install(ctx context.Context, progress func(Progress)) Resolution {
+	if progress == nil {
+		progress = func(Progress) {}
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if r := p.Resolve(); r.State == StateAvailable { // a concurrent installer may have finished
+		return r
+	}
+
+	_, artifacts, ok := PlatformArtifacts("rust", p.goos, p.goarch)
+	if !ok {
+		return Resolution{State: StateUnsupported, Err: errors.New("no managed rust-analyzer binary for platform")}
+	}
+
+	progress(Progress{Phase: "download", Pct: 0})
+	parent := filepath.Dir(p.versionDir())
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+	staging, err := os.MkdirTemp(parent, ".staging-*")
+	if err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+	defer func() { _ = os.RemoveAll(staging) }() // no-op after successful rename
+
+	for i, a := range artifacts {
+		if err := p.fetch(ctx, a, staging); err != nil {
+			var ce *ChecksumError
+			if errors.As(err, &ce) {
+				return Resolution{State: StateChecksumFailed, Err: err}
+			}
+			return Resolution{State: StateOffline, Err: err}
+		}
+		progress(Progress{Phase: "extract", Pct: (i + 1) * 100 / len(artifacts)})
+	}
+
+	binName := "rust-analyzer"
+	if p.goos == "windows" {
+		binName += ".exe"
+	}
+	found, ferr := findFile(staging, binName)
+	if ferr != nil || found == "" {
+		return Resolution{State: StateOffline, Err: errors.New("rust-analyzer binary not found after extract")}
+	}
+	if err := os.Chmod(found, 0o755); err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+	rel, relErr := filepath.Rel(staging, found)
+	if relErr != nil {
+		return Resolution{State: StateOffline, Err: relErr}
+	}
+	// rust-analyzer serves LSP over stdio by default, so it needs no launch args.
+	spec := launchSpec{Path: rel, Args: nil, Version: rustCatalogEntry.Version, Abs: false}
+	if err := writeLaunchSpec(staging, spec); err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+
+	_ = os.RemoveAll(p.versionDir()) // clear any partial prior dir
+	if err := os.Rename(staging, p.versionDir()); err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+	progress(Progress{Phase: "done", Pct: 100})
+	return p.Resolve()
+}
+
+func (p *RustProvisioner) fetch(ctx context.Context, a Artifact, destDir string) error {
+	if p.deps.Fetch != nil {
+		return p.deps.Fetch(ctx, a, destDir)
+	}
+	return defaultRustFetch(ctx, a, destDir)
+}
+
+// defaultRustFetch downloads+verifies one archive-binary artifact and extracts
+// the rust-analyzer executable into destDir. macOS/Linux artifacts are a bare
+// gzipped binary (.gz); Windows artifacts are a zip containing rust-analyzer.exe.
+func defaultRustFetch(ctx context.Context, a Artifact, destDir string) error {
+	client := &http.Client{Timeout: 5 * time.Minute}
+	tmp := filepath.Join(destDir, ".dl-"+a.SHA256[:12])
+	if err := DownloadAndVerify(ctx, client, a.URL, a.SHA256, tmp); err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(tmp) }()
+	if strings.HasSuffix(a.URL, ".gz") {
+		return GunzipFile(tmp, filepath.Join(destDir, "rust-analyzer"))
+	}
+	return UnzipWheel(tmp, destDir) // .zip (Windows) -> rust-analyzer.exe
+}

--- a/internal/lsp/provision/rust_test.go
+++ b/internal/lsp/provision/rust_test.go
@@ -1,0 +1,92 @@
+package provision
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRust_Resolve_missingThenAvailable(t *testing.T) {
+	cache := t.TempDir()
+	p := NewRustProvisioner(cache, "darwin", "arm64", RustDeps{
+		Fetch: func(_ context.Context, a Artifact, destDir string) error {
+			if a.Kind != "archive-binary" {
+				t.Fatalf("unexpected artifact kind %q", a.Kind)
+			}
+			return writeFile(filepath.Join(destDir, "rust-analyzer"), "#!/bin/sh\n# rust-analyzer")
+		},
+	})
+
+	if r := p.Resolve(); r.State != StateMissing {
+		t.Fatalf("pre-install Resolve = %v, want missing", r.State)
+	}
+	r := p.Install(context.Background(), func(Progress) {})
+	if r.State != StateAvailable {
+		t.Fatalf("Install = %v (%v), want available", r.State, r.Err)
+	}
+	if filepath.Base(r.Path) != "rust-analyzer" {
+		t.Errorf("launch path = %q, want rust-analyzer", r.Path)
+	}
+	if len(r.Args) != 0 {
+		t.Errorf("args = %v, want none (rust-analyzer serves stdio by default)", r.Args)
+	}
+	if _, err := os.Stat(r.Path); err != nil {
+		t.Errorf("rust-analyzer launch path %q not on disk: %v", r.Path, err)
+	}
+	if got := p.Resolve(); got.State != StateAvailable {
+		t.Fatalf("post-install Resolve = %v", got.State)
+	}
+}
+
+func TestRust_Install_unsupportedPlatform(t *testing.T) {
+	p := NewRustProvisioner(t.TempDir(), "plan9", "mips", RustDeps{})
+	if r := p.Install(context.Background(), func(Progress) {}); r.State != StateUnsupported {
+		t.Fatalf("Install = %v, want unsupported", r.State)
+	}
+}
+
+func TestRust_Install_offline(t *testing.T) {
+	p := NewRustProvisioner(t.TempDir(), "darwin", "arm64", RustDeps{
+		Fetch: func(context.Context, Artifact, string) error { return errors.New("dial tcp: offline") },
+	})
+	if r := p.Install(context.Background(), func(Progress) {}); r.State != StateOffline {
+		t.Fatalf("Install = %v, want offline", r.State)
+	}
+}
+
+func TestRust_Install_checksumFailMapsToChecksumState(t *testing.T) {
+	p := NewRustProvisioner(t.TempDir(), "darwin", "arm64", RustDeps{
+		Fetch: func(context.Context, Artifact, string) error { return &ChecksumError{URL: "u", Got: "a", Want: "b"} },
+	})
+	if r := p.Install(context.Background(), func(Progress) {}); r.State != StateChecksumFailed {
+		t.Fatalf("Install = %v, want checksum-failed", r.State)
+	}
+}
+
+// TestRust_defaultFetch_gunzips exercises the real download+verify+gunzip path
+// (no injected Fetch) against a local server serving a gzipped fake binary.
+func TestRust_defaultFetch_gunzips(t *testing.T) {
+	body := []byte("#!/bin/sh\n# fake rust-analyzer")
+	var gzbuf bytes.Buffer
+	zw := gzip.NewWriter(&gzbuf)
+	_, _ = zw.Write(body)
+	_ = zw.Close()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(gzbuf.Bytes()) }))
+	defer srv.Close()
+
+	dest := t.TempDir()
+	a := Artifact{Kind: "archive-binary", URL: srv.URL + "/rust-analyzer.gz", SHA256: sha256Hex(gzbuf.Bytes())}
+	if err := defaultRustFetch(context.Background(), a, dest); err != nil {
+		t.Fatalf("defaultRustFetch: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "rust-analyzer"))
+	if err != nil || !bytes.Equal(got, body) {
+		t.Fatalf("gunzipped binary = %q err=%v", got, err)
+	}
+}

--- a/internal/lsp/provision/typescript.go
+++ b/internal/lsp/provision/typescript.go
@@ -1,0 +1,162 @@
+package provision
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// TypeScriptDeps are the injected, side-effecting operations the provisioner needs.
+type TypeScriptDeps struct {
+	// Fetch downloads+verifies+extracts one artifact into destDir, laying it out
+	// at its final location (node runtime, node_modules/typescript-language-server,
+	// node_modules/typescript). nil => defaultTypeScriptFetch.
+	Fetch func(ctx context.Context, a Artifact, destDir string) error
+}
+
+// TypeScriptProvisioner provisions typescript-language-server into
+// <cacheRoot>/typescript/<version>/. It bundles the Node runtime plus the
+// server and the TypeScript package it drives, all as pinned artifacts, and
+// launches `node <cli.mjs> --stdio`.
+type TypeScriptProvisioner struct {
+	cacheRoot string
+	goos      string
+	goarch    string
+	deps      TypeScriptDeps
+	mu        sync.Mutex // single-flight: one install at a time for this family
+}
+
+func NewTypeScriptProvisioner(cacheRoot, goos, goarch string, deps TypeScriptDeps) *TypeScriptProvisioner {
+	return &TypeScriptProvisioner{cacheRoot: cacheRoot, goos: goos, goarch: goarch, deps: deps}
+}
+
+func (p *TypeScriptProvisioner) Family() string { return "typescript" }
+
+func (p *TypeScriptProvisioner) versionDir() string {
+	return filepath.Join(p.cacheRoot, "typescript", typescriptCatalogEntry.Version)
+}
+
+// Resolve reads the committed launch.json (cache-only, no network).
+func (p *TypeScriptProvisioner) Resolve() Resolution {
+	return resolveCached(p.versionDir())
+}
+
+// Install downloads+verifies+extracts the node runtime and the two npm
+// packages into a staging dir, writes launch.json (relative paths), then
+// atomically renames staging -> versionDir.
+func (p *TypeScriptProvisioner) Install(ctx context.Context, progress func(Progress)) Resolution {
+	if progress == nil {
+		progress = func(Progress) {}
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if r := p.Resolve(); r.State == StateAvailable { // a concurrent installer may have finished
+		return r
+	}
+
+	_, artifacts, ok := PlatformArtifacts("typescript", p.goos, p.goarch)
+	if !ok {
+		return Resolution{State: StateUnsupported, Err: errors.New("no managed node runtime for platform")}
+	}
+
+	progress(Progress{Phase: "download", Pct: 0})
+	parent := filepath.Dir(p.versionDir())
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+	staging, err := os.MkdirTemp(parent, ".staging-*")
+	if err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+	defer func() { _ = os.RemoveAll(staging) }() // no-op after successful rename
+
+	for i, a := range artifacts {
+		if err := p.fetch(ctx, a, staging); err != nil {
+			var ce *ChecksumError
+			if errors.As(err, &ce) {
+				return Resolution{State: StateChecksumFailed, Err: err}
+			}
+			return Resolution{State: StateOffline, Err: err}
+		}
+		progress(Progress{Phase: "extract", Pct: (i + 1) * 100 / len(artifacts)})
+	}
+
+	nodeRel, cliRel, err := typescriptLaunchTargets(staging, p.goos)
+	if err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+	spec := launchSpec{Path: nodeRel, ScriptRel: cliRel, Args: []string{"--stdio"}, Version: typescriptCatalogEntry.Version, Abs: false}
+	if err := writeLaunchSpec(staging, spec); err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+
+	_ = os.RemoveAll(p.versionDir()) // clear any partial prior dir
+	if err := os.Rename(staging, p.versionDir()); err != nil {
+		return Resolution{State: StateOffline, Err: err}
+	}
+	progress(Progress{Phase: "done", Pct: 100})
+	return p.Resolve()
+}
+
+func (p *TypeScriptProvisioner) fetch(ctx context.Context, a Artifact, destDir string) error {
+	if p.deps.Fetch != nil {
+		return p.deps.Fetch(ctx, a, destDir)
+	}
+	return defaultTypeScriptFetch(ctx, a, destDir)
+}
+
+// typescriptLaunchTargets locates the node binary and the language-server entry
+// inside an extracted staging dir, returning their paths RELATIVE to staging.
+// It also verifies the TypeScript package is present, since the server resolves
+// it at runtime and would otherwise start but produce no diagnostics.
+func typescriptLaunchTargets(staging, goos string) (nodeRel, cliRel string, err error) {
+	cliRel = filepath.Join("node_modules", "typescript-language-server", "lib", "cli.mjs")
+	if _, statErr := os.Stat(filepath.Join(staging, cliRel)); statErr != nil {
+		return "", "", errors.New("typescript-language-server entry (cli.mjs) not found after extract")
+	}
+	if _, statErr := os.Stat(filepath.Join(staging, "node_modules", "typescript")); statErr != nil {
+		return "", "", errors.New("typescript package not found after extract")
+	}
+	nodeName := "node"
+	if goos == "windows" {
+		nodeName = "node.exe"
+	}
+	found, ferr := findFile(staging, nodeName)
+	if ferr != nil || found == "" {
+		return "", "", errors.New("node binary not found after extract")
+	}
+	rel, relErr := filepath.Rel(staging, found)
+	if relErr != nil {
+		return "", "", relErr
+	}
+	return rel, cliRel, nil
+}
+
+// defaultTypeScriptFetch downloads+verifies one artifact and extracts it to its
+// final layout: the node runtime wheel unzips into destDir; the npm tarballs
+// untar (dropping their "package/" prefix) into
+// node_modules/{typescript-language-server,typescript}.
+func defaultTypeScriptFetch(ctx context.Context, a Artifact, destDir string) error {
+	client := &http.Client{Timeout: 5 * time.Minute}
+	tmp := filepath.Join(destDir, ".dl-"+a.SHA256[:12])
+	if err := DownloadAndVerify(ctx, client, a.URL, a.SHA256, tmp); err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(tmp) }()
+
+	switch a.Kind {
+	case "node-wheel":
+		return UnzipWheel(tmp, destDir)
+	case "npm-server":
+		return UntarGz(tmp, filepath.Join(destDir, "node_modules", "typescript-language-server"), 1)
+	case "npm-typescript":
+		return UntarGz(tmp, filepath.Join(destDir, "node_modules", "typescript"), 1)
+	default:
+		return errors.New("unknown typescript artifact kind: " + a.Kind)
+	}
+}

--- a/internal/lsp/provision/typescript_test.go
+++ b/internal/lsp/provision/typescript_test.go
@@ -1,0 +1,129 @@
+package provision
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// tsFakeFetch lays out the same on-disk shape the real defaultTypeScriptFetch
+// produces, so the launch-target locator can find node + cli.mjs + typescript.
+func tsFakeFetch(_ context.Context, a Artifact, destDir string) error {
+	switch a.Kind {
+	case "node-wheel":
+		return writeFile(filepath.Join(destDir, "nodejs_wheel", "node"), "#!node")
+	case "npm-server":
+		return writeFile(filepath.Join(destDir, "node_modules", "typescript-language-server", "lib", "cli.mjs"), "// tls")
+	case "npm-typescript":
+		return writeFile(filepath.Join(destDir, "node_modules", "typescript", "lib", "tsserver.js"), "// tsc")
+	default:
+		return errors.New("unexpected kind " + a.Kind)
+	}
+}
+
+func TestTypeScript_Resolve_missingThenAvailable(t *testing.T) {
+	cache := t.TempDir()
+	p := NewTypeScriptProvisioner(cache, "darwin", "arm64", TypeScriptDeps{Fetch: tsFakeFetch})
+
+	if r := p.Resolve(); r.State != StateMissing {
+		t.Fatalf("pre-install Resolve = %v, want missing", r.State)
+	}
+	r := p.Install(context.Background(), func(Progress) {})
+	if r.State != StateAvailable {
+		t.Fatalf("Install = %v (%v), want available", r.State, r.Err)
+	}
+	if filepath.Base(r.Path) != "node" {
+		t.Errorf("launch path = %q, want node runtime", r.Path)
+	}
+	if len(r.Args) < 2 || r.Args[len(r.Args)-1] != "--stdio" {
+		t.Errorf("args = %v, want [<cli.mjs> --stdio]", r.Args)
+	}
+	if filepath.Base(r.Args[0]) != "cli.mjs" {
+		t.Errorf("first arg = %q, want cli.mjs", r.Args[0])
+	}
+	// The script arg must be absolute and on disk: the server is launched with
+	// cwd=projectRoot (not the version dir), so a relative script path would make
+	// node fail with "Cannot find module".
+	if !filepath.IsAbs(r.Args[0]) {
+		t.Errorf("cli.mjs arg must be absolute, got %q", r.Args[0])
+	}
+	if _, err := os.Stat(r.Args[0]); err != nil {
+		t.Errorf("cli.mjs arg %q not resolvable on disk: %v", r.Args[0], err)
+	}
+	if _, err := os.Stat(r.Path); err != nil {
+		t.Errorf("node launch path %q not on disk: %v", r.Path, err)
+	}
+	if got := p.Resolve(); got.State != StateAvailable {
+		t.Fatalf("post-install Resolve = %v", got.State)
+	}
+}
+
+func TestTypeScript_Install_missingTypeScriptFailsInstall(t *testing.T) {
+	// node + tls present but no typescript package -> the server can't run.
+	p := NewTypeScriptProvisioner(t.TempDir(), "darwin", "arm64", TypeScriptDeps{
+		Fetch: func(_ context.Context, a Artifact, destDir string) error {
+			if a.Kind == "npm-typescript" {
+				return nil // skip laying down typescript
+			}
+			return tsFakeFetch(context.Background(), a, destDir)
+		},
+	})
+	if r := p.Install(context.Background(), func(Progress) {}); r.State == StateAvailable {
+		t.Fatalf("Install = available despite missing typescript package")
+	}
+}
+
+func TestTypeScript_Install_unsupportedPlatform(t *testing.T) {
+	p := NewTypeScriptProvisioner(t.TempDir(), "plan9", "mips", TypeScriptDeps{})
+	if r := p.Install(context.Background(), func(Progress) {}); r.State != StateUnsupported {
+		t.Fatalf("Install = %v, want unsupported", r.State)
+	}
+}
+
+func TestTypeScript_Install_offline(t *testing.T) {
+	p := NewTypeScriptProvisioner(t.TempDir(), "darwin", "arm64", TypeScriptDeps{
+		Fetch: func(context.Context, Artifact, string) error { return errors.New("dial tcp: offline") },
+	})
+	if r := p.Install(context.Background(), func(Progress) {}); r.State != StateOffline {
+		t.Fatalf("Install = %v, want offline", r.State)
+	}
+}
+
+func TestTypeScript_Install_checksumFailMapsToChecksumState(t *testing.T) {
+	p := NewTypeScriptProvisioner(t.TempDir(), "darwin", "arm64", TypeScriptDeps{
+		Fetch: func(context.Context, Artifact, string) error { return &ChecksumError{URL: "u", Got: "a", Want: "b"} },
+	})
+	if r := p.Install(context.Background(), func(Progress) {}); r.State != StateChecksumFailed {
+		t.Fatalf("Install = %v, want checksum-failed", r.State)
+	}
+}
+
+// TestTypeScript_defaultFetch_npmServer exercises the real download+verify+untar
+// path for an npm tarball, confirming the "package/" prefix is stripped into
+// node_modules/typescript-language-server.
+func TestTypeScript_defaultFetch_npmServer(t *testing.T) {
+	tgz := makeTarGz(t, map[string]string{
+		"package/lib/cli.mjs":  "// tls entry",
+		"package/package.json": `{"name":"typescript-language-server"}`,
+	})
+	raw, err := os.ReadFile(tgz)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(raw) }))
+	defer srv.Close()
+
+	dest := t.TempDir()
+	a := Artifact{Kind: "npm-server", URL: srv.URL + "/tls.tgz", SHA256: sha256Hex(raw)}
+	if err := defaultTypeScriptFetch(context.Background(), a, dest); err != nil {
+		t.Fatalf("defaultTypeScriptFetch: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "node_modules", "typescript-language-server", "lib", "cli.mjs"))
+	if err != nil || string(got) != "// tls entry" {
+		t.Fatalf("extracted cli.mjs = %q err=%v", got, err)
+	}
+}

--- a/internal/lsp/registry.go
+++ b/internal/lsp/registry.go
@@ -93,6 +93,7 @@ var extensionMap = map[string]langInfo{
 	".py":  {"python", "python"},
 	".pyw": {"python", "python"},
 	".pyi": {"python", "python"},
+	".rs":  {"rust", "rust"},
 }
 
 // LanguageIDForExtension returns the LSP languageId for the given file extension.
@@ -131,6 +132,8 @@ func (r *Registry) ServerConfigFor(family, projectRoot string) (*ServerConfig, e
 		return r.resolveGoServer(projectRoot)
 	case "python":
 		return r.resolvePythonServer(projectRoot)
+	case "rust":
+		return r.resolveRustServer(projectRoot)
 	default:
 		return nil, fmt.Errorf("no language server configured for %q", family)
 	}
@@ -168,9 +171,10 @@ func (r *Registry) resolveTypeScriptServer(projectRoot string) (*ServerConfig, e
 	// 2. Fall back to system PATH
 	path, err := exec.LookPath(binary)
 	if err != nil {
-		return nil, &ServerMissError{Family: "typescript", Provisionable: false, Hint: "typescript-language-server not found: install it with " +
-			"\"npm install -g typescript-language-server typescript\" " +
-			"or add it as a project dependency"}
+		// 3. No system server: offer a managed install when one is available,
+		// otherwise return an actionable manual-install hint.
+		return r.managedOrMiss("typescript", projectRoot, "typescript-language-server not found. Firn can install it automatically, "+
+			"or add it with \"npm install -g typescript-language-server typescript\" or as a project dependency.")
 	}
 
 	args := []string{"--stdio"}
@@ -209,9 +213,10 @@ func (r *Registry) resolveGoServer(projectRoot string) (*ServerConfig, error) {
 	if err != nil {
 		path = findGoBinary("gopls")
 		if path == "" {
-			return nil, &ServerMissError{Family: "go", Provisionable: false, Hint: "gopls not found: install it with " +
-				"\"go install golang.org/x/tools/gopls@latest\" " +
-				"or add it to PATH"}
+			// No system gopls: offer a managed install (via `go install`) when one
+			// is available, otherwise return an actionable manual-install hint.
+			return r.managedOrMiss("go", projectRoot, "gopls not found. Firn can install it automatically (requires the Go toolchain), "+
+				"or install it with \"go install golang.org/x/tools/gopls@latest\" and add it to PATH.")
 		}
 	}
 
@@ -220,6 +225,47 @@ func (r *Registry) resolveGoServer(projectRoot string) (*ServerConfig, error) {
 		Command:        path,
 		Dir:            projectRoot,
 	}, nil
+}
+
+// resolveRustServer finds and configures rust-analyzer. Lookup order:
+//  1. System PATH.
+//  2. ~/.cargo/bin (rustup installs land here but are absent from the PATH a
+//     Finder/Dock-launched app inherits, mirroring the gopls fallback).
+//  3. A managed install when a rust provisioner is registered, otherwise an
+//     actionable manual-install hint.
+func (r *Registry) resolveRustServer(projectRoot string) (*ServerConfig, error) {
+	path, err := exec.LookPath("rust-analyzer")
+	if err != nil {
+		path = findCargoBinary("rust-analyzer")
+		if path == "" {
+			return r.managedOrMiss("rust", projectRoot, "rust-analyzer not found. Firn can install it automatically, "+
+				"or install it with \"rustup component add rust-analyzer\" and add it to PATH.")
+		}
+	}
+
+	return &ServerConfig{
+		LanguageFamily: "rust",
+		Command:        path,
+		Dir:            projectRoot,
+	}, nil
+}
+
+// findCargoBinary looks for a Rust binary under ~/.cargo/bin, covering the
+// Finder/Dock launch case where the shell PATH (with ~/.cargo/bin) is absent.
+func findCargoBinary(name string) string {
+	binName := name
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	candidate := filepath.Join(home, ".cargo", "bin", binName)
+	if isExecutableFile(candidate) {
+		return candidate
+	}
+	return ""
 }
 
 // goBinarySearchDirs returns the directories findGoBinary scans. It is a

--- a/internal/lsp/registry_phase3_test.go
+++ b/internal/lsp/registry_phase3_test.go
@@ -1,0 +1,165 @@
+package lsp
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"firn/internal/lsp/provision"
+)
+
+func TestExtensionMap_Rust(t *testing.T) {
+	r := NewRegistry()
+	if got := r.FamilyForExtension(".rs"); got != "rust" {
+		t.Errorf("FamilyForExtension(.rs) = %q, want rust", got)
+	}
+	if got := r.LanguageIDForExtension(".rs"); got != "rust" {
+		t.Errorf("LanguageIDForExtension(.rs) = %q, want rust", got)
+	}
+}
+
+// With no rust-analyzer on PATH and no managed provisioner, the miss is
+// unprovisionable and carries an actionable hint.
+func TestResolveRustServer_NotFoundUnprovisionable(t *testing.T) {
+	t.Setenv("PATH", "")
+	t.Setenv("HOME", t.TempDir())
+	r := NewRegistry()
+	_, err := r.ServerConfigFor("rust", t.TempDir())
+	var miss *ServerMissError
+	if !errors.As(err, &miss) {
+		t.Fatalf("err = %v, want *ServerMissError", err)
+	}
+	if miss.Provisionable {
+		t.Error("no rust provisioner registered; expected Provisionable=false")
+	}
+	if !contains(miss.Hint, "rust-analyzer") {
+		t.Errorf("hint should mention rust-analyzer, got: %s", miss.Hint)
+	}
+}
+
+// Once a rust provisioner is registered (cache empty), the miss flips to
+// Provisionable so the manager can kick off a managed install.
+func TestResolveRustServer_ManagedWhenMissing(t *testing.T) {
+	t.Setenv("PATH", "")
+	t.Setenv("HOME", t.TempDir())
+	r := NewRegistry()
+	r.SetProvisioners(map[string]provision.Provisioner{
+		"rust": fakeProv{res: provision.Resolution{State: provision.StateMissing}},
+	})
+	_, err := r.ServerConfigFor("rust", t.TempDir())
+	var miss *ServerMissError
+	if !errors.As(err, &miss) {
+		t.Fatalf("err = %v, want *ServerMissError", err)
+	}
+	if !miss.Provisionable {
+		t.Error("expected Provisionable=true when a rust provisioner exists")
+	}
+}
+
+// A managed rust-analyzer in the cache is launched directly.
+func TestResolveRustServer_ManagedAvailable(t *testing.T) {
+	t.Setenv("PATH", "")
+	t.Setenv("HOME", t.TempDir())
+	r := NewRegistry()
+	r.SetProvisioners(map[string]provision.Provisioner{
+		"rust": fakeProv{res: provision.Resolution{State: provision.StateAvailable, Path: "/cache/rust-analyzer"}},
+	})
+	cfg, err := r.ServerConfigFor("rust", "/proj")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if cfg.Command != "/cache/rust-analyzer" || cfg.Dir != "/proj" {
+		t.Errorf("cfg = %+v", cfg)
+	}
+}
+
+// gopls not on PATH and not in the Go bin dirs: with a provisioner registered
+// the miss becomes Provisionable (previously always Provisionable=false).
+func TestResolveGoServer_ManagedWhenMissing(t *testing.T) {
+	orig := goBinarySearchDirs
+	goBinarySearchDirs = func() []string { return nil }
+	t.Cleanup(func() { goBinarySearchDirs = orig })
+	t.Setenv("PATH", "")
+
+	r := NewRegistry()
+	r.SetProvisioners(map[string]provision.Provisioner{
+		"go": fakeProv{res: provision.Resolution{State: provision.StateMissing}},
+	})
+	_, err := r.ServerConfigFor("go", t.TempDir())
+	var miss *ServerMissError
+	if !errors.As(err, &miss) {
+		t.Fatalf("err = %v, want *ServerMissError", err)
+	}
+	if !miss.Provisionable {
+		t.Error("expected Provisionable=true when a go provisioner exists")
+	}
+}
+
+// A managed gopls in the cache is launched directly, in preference to the miss.
+func TestResolveGoServer_ManagedAvailable(t *testing.T) {
+	orig := goBinarySearchDirs
+	goBinarySearchDirs = func() []string { return nil }
+	t.Cleanup(func() { goBinarySearchDirs = orig })
+	t.Setenv("PATH", "")
+
+	r := NewRegistry()
+	r.SetProvisioners(map[string]provision.Provisioner{
+		"go": fakeProv{res: provision.Resolution{State: provision.StateAvailable, Path: "/cache/gopls"}},
+	})
+	cfg, err := r.ServerConfigFor("go", "/proj")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if cfg.Command != "/cache/gopls" || cfg.Dir != "/proj" {
+		t.Errorf("cfg = %+v", cfg)
+	}
+}
+
+// typescript-language-server not on PATH: with a provisioner registered the
+// miss becomes Provisionable.
+func TestResolveTypeScriptServer_ManagedWhenMissing(t *testing.T) {
+	t.Setenv("PATH", "")
+	r := NewRegistry()
+	r.SetProvisioners(map[string]provision.Provisioner{
+		"typescript": fakeProv{res: provision.Resolution{State: provision.StateMissing}},
+	})
+	_, err := r.ServerConfigFor("typescript", t.TempDir())
+	var miss *ServerMissError
+	if !errors.As(err, &miss) {
+		t.Fatalf("err = %v, want *ServerMissError", err)
+	}
+	if !miss.Provisionable {
+		t.Error("expected Provisionable=true when a typescript provisioner exists")
+	}
+}
+
+// A managed rust-analyzer at ~/.cargo/bin is preferred over a managed download
+// so a rustup user's own install wins even when the app is Finder-launched.
+func TestResolveRustServer_PrefersCargoBin(t *testing.T) {
+	home := t.TempDir()
+	cargoBin := filepath.Join(home, ".cargo", "bin")
+	if err := os.MkdirAll(cargoBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	name := "rust-analyzer"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	bin := filepath.Join(cargoBin, name)
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "")
+
+	r := NewRegistry()
+	cfg, err := r.ServerConfigFor("rust", "/proj")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if cfg.Command != bin {
+		t.Errorf("cfg.Command = %q, want cargo-bin rust-analyzer %q", cfg.Command, bin)
+	}
+}


### PR DESCRIPTION
Closes #151.

Extends the managed-server provisioning framework shipped for Python (basedpyright) in #150 to the three remaining families, so Go/Rust/TypeScript LSP works with no manual server install. When a file opens and no user-installed server is found, the manager triggers a background managed install into `~/.firn/servers/<family>/<version>/` (the existing, family-generic provision flow), never mutating the user's PATH or global env.

## Each family has a different real fetch shape

The task note warned that basedpyright ships no standalone binary; the three new families each differ again. All flow through the same download -> verify (SHA256) -> extract -> atomic-rename pipeline:

- **gopls** (`go install golang.org/x/tools/gopls@v0.22.0`): gopls publishes no prebuilt binary, so `go install` into a managed `GOBIN` is the only official distribution. Mirrors Python's uv fast-path (a toolchain runner). No Go toolchain -> `StateUnsupported`.
- **rust-analyzer** (archive-binary): pinned GitHub release per OS/arch - a gzipped single binary (`.gz`) on macOS/Linux, a zip on Windows.
- **typescript-language-server** (npm tarballs + node): pinned `typescript-language-server` and `typescript` tarballs laid out as `node_modules` siblings on the shared, pinned Node runtime, launched as `node cli.mjs --stdio`. tls 5.3.0 has no other runtime deps, so the two tarballs alone suffice (no package manager needed).

## Shared infrastructure

- Catalog generalized with `ArtifactArchiveBinary` + `ArtifactNpmNode` types and a per-type completeness check; the Node runtime wheels are now shared between the Python and TypeScript entries.
- Archive helpers `GunzipFile` and `UntarGz` (strip-components, zip-slip safe) alongside the existing `UnzipWheel`.
- `Resolve()` extracted into a shared `resolveCached`.

## Wiring

- Registry gains the `.rs -> rust` mapping and `resolveRustServer` (PATH -> `~/.cargo/bin` -> managed), and flips `resolveGoServer`/`resolveTypeScriptServer` from `Provisionable=false` to `managedOrMiss`, so a miss becomes a managed install only when a provisioner is registered. A user's own installed server always wins.
- `app.go` registers all three provisioners.
- The `provision_failed` frontend hint is now family-aware instead of always naming basedpyright/pyright.

## Review-found fix included

An adversarial review caught a real bug: the managed TypeScript server's `cli.mjs` arg was stored relative to the version dir, but servers launch with `cwd=projectRoot`, so node would fail with "cannot find module" despite a green install. Fixed at the shared root cause by adding `launchSpec.ScriptRel`, which `resolveCached` resolves to an absolute path - this also fixes the same latent defect in Python's manual (non-uv) path.

## Testing

Strict TDD. All URLs and SHA256 digests are pinned constants verified against the live artifacts. The real `go install gopls@v0.22.0` command and the rust-analyzer Windows zip layout were verified end-to-end.

Gate (all green): `go test ./...` (636), `go vet ./...`, `golangci-lint run` (v2.11.4), frontend `npx jest` (1329), `npm run build`. No Go bindings changed, so no `wails generate`.

Generated with Claude Code.