### PR TITLE
fix(lsp): Phase 2 provisioning polish - override Reset, RetryProvision keying, musllinux wheels

### DIFF
--- a/app.go
+++ b/app.go
@@ -850,13 +850,15 @@ func (a *App) LSPClearInterpreter(workspacePath string) error {
 	return a.persistLSPInterpreter(workspacePath, "") // empty clears it
 }
 
-// LSPRetryProvision re-attempts a managed server install for a family.
+// LSPRetryProvision re-attempts a managed server install for a family, keyed
+// to the project root the failing status reported (empty falls back to the
+// workspace root).
 // This is exposed to the frontend via Wails bindings.
-func (a *App) LSPRetryProvision(family string) error {
+func (a *App) LSPRetryProvision(family, projectRoot string) error {
 	if a.lspManager == nil {
 		return fmt.Errorf("LSP not initialized")
 	}
-	return a.lspManager.RetryProvision(family)
+	return a.lspManager.RetryProvision(family, projectRoot)
 }
 
 // persistLSPInterpreter writes the interpreter override into the workspace's

--- a/frontend/src/__tests__/components/Editor/LSPSetupCard.test.tsx
+++ b/frontend/src/__tests__/components/Editor/LSPSetupCard.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { LSPSetupCard } from '../../../components/Editor/LSPSetupCard';
 import { describeSetup } from '../../../components/Editor/lspSetupNotice';
+import { useIDEStore } from '../../../stores/ideStore';
 import type { LSPServerStatus } from '../../../stores/lspStore';
 
 const mockRetry = jest.fn().mockResolvedValue(undefined);
@@ -22,6 +23,7 @@ function status(overrides: Partial<LSPServerStatus>): LSPServerStatus {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  useIDEStore.setState(useIDEStore.getInitialState());
   mockDoctor.mockResolvedValue({ family: 'python', candidates: ['/cand'] });
 });
 
@@ -115,6 +117,24 @@ describe('LSPSetupCard', () => {
     expect(mockRetry).toHaveBeenCalledWith('python', '/proj');
   });
 
+  it('reports Retry failures', async () => {
+    mockRetry.mockRejectedValueOnce(new Error('network unavailable'));
+    const user = userEvent.setup();
+    render(
+      <LSPSetupCard
+        status={status({ setupState: 'offline', action: 'retry' })}
+        workspacePath="/proj"
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+    await waitFor(() =>
+      expect(useIDEStore.getState().toast).toEqual({
+        message: 'Failed to retry LSP provisioning: network unavailable',
+        type: 'error',
+      })
+    );
+  });
+
   it('provisioning shows progress and no Retry button', () => {
     render(
       <LSPSetupCard
@@ -157,6 +177,24 @@ describe('LSPSetupCard', () => {
     );
     await user.click(screen.getByRole('button', { name: /reset to auto/i }));
     expect(mockClearInterpreter).toHaveBeenCalledWith('/proj');
+  });
+
+  it('reports Reset-to-auto failures', async () => {
+    mockClearInterpreter.mockRejectedValueOnce(new Error('workspace write failed'));
+    const user = userEvent.setup();
+    render(
+      <LSPSetupCard
+        status={status({ setupState: 'ready', configSource: 'override' })}
+        workspacePath="/proj"
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /reset to auto/i }));
+    await waitFor(() =>
+      expect(useIDEStore.getState().toast).toEqual({
+        message: 'Failed to reset the Python interpreter: workspace write failed',
+        type: 'error',
+      })
+    );
   });
 
   it('renders Reset to auto when an interpreter override is active', async () => {

--- a/frontend/src/__tests__/components/Editor/LSPSetupCard.test.tsx
+++ b/frontend/src/__tests__/components/Editor/LSPSetupCard.test.tsx
@@ -51,6 +51,19 @@ describe('describeSetup', () => {
     expect(notice!.hint).toContain('(0%)');
   });
 
+  it('describes an active manual override when ready', () => {
+    const notice = describeSetup(
+      status({ setupState: 'ready', configSource: 'override', interpreterPath: '/manual/python' })
+    );
+    expect(notice).not.toBeNull();
+    expect(notice!.tone).toBe('info');
+    expect(notice!.message).toContain('/manual/python');
+  });
+
+  it('still returns null when ready without an override', () => {
+    expect(describeSetup(status({ setupState: 'ready', configSource: 'detected' }))).toBeNull();
+  });
+
   it('uses ASCII ellipsis in the provisioning message', () => {
     const notice = describeSetup(status({ setupState: 'provisioning' }));
     expect(notice!.message).toContain('...');
@@ -112,6 +125,22 @@ describe('LSPSetupCard', () => {
       '/cand'
     );
     expect(mockSetInterpreter).toHaveBeenCalledWith('/proj', '/cand');
+  });
+
+  it('ready with an active override renders Reset to auto wired to clear', async () => {
+    const user = userEvent.setup();
+    render(
+      <LSPSetupCard
+        status={status({
+          setupState: 'ready',
+          configSource: 'override',
+          interpreterPath: '/manual/python',
+        })}
+        workspacePath="/proj"
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /reset to auto/i }));
+    expect(mockClearInterpreter).toHaveBeenCalledWith('/proj');
   });
 
   it('renders Reset to auto when an interpreter override is active', async () => {

--- a/frontend/src/__tests__/components/Editor/LSPSetupCard.test.tsx
+++ b/frontend/src/__tests__/components/Editor/LSPSetupCard.test.tsx
@@ -87,7 +87,19 @@ describe('LSPSetupCard', () => {
     expect(screen.getByText(/no python interpreter/i)).toBeInTheDocument();
   });
 
-  it('offline status renders Retry wired to LSPRetryProvision', async () => {
+  it('offline status renders Retry wired to LSPRetryProvision with the status project root', async () => {
+    const user = userEvent.setup();
+    render(
+      <LSPSetupCard
+        status={status({ setupState: 'offline', action: 'retry', projectRoot: '/proj/services/api' })}
+        workspacePath="/proj"
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+    expect(mockRetry).toHaveBeenCalledWith('python', '/proj/services/api');
+  });
+
+  it('Retry falls back to the workspace path when the status has no project root', async () => {
     const user = userEvent.setup();
     render(
       <LSPSetupCard
@@ -96,7 +108,7 @@ describe('LSPSetupCard', () => {
       />
     );
     await user.click(screen.getByRole('button', { name: /retry/i }));
-    expect(mockRetry).toHaveBeenCalledWith('python');
+    expect(mockRetry).toHaveBeenCalledWith('python', '/proj');
   });
 
   it('provisioning shows progress and no Retry button', () => {

--- a/frontend/src/__tests__/components/Editor/LSPSetupCard.test.tsx
+++ b/frontend/src/__tests__/components/Editor/LSPSetupCard.test.tsx
@@ -91,7 +91,11 @@ describe('LSPSetupCard', () => {
     const user = userEvent.setup();
     render(
       <LSPSetupCard
-        status={status({ setupState: 'offline', action: 'retry', projectRoot: '/proj/services/api' })}
+        status={status({
+          setupState: 'offline',
+          action: 'retry',
+          projectRoot: '/proj/services/api',
+        })}
         workspacePath="/proj"
       />
     );

--- a/frontend/src/components/Editor/LSPSetupCard.tsx
+++ b/frontend/src/components/Editor/LSPSetupCard.tsx
@@ -48,7 +48,10 @@ export function LSPSetupCard({
       {showActions && (
         <div className={styles.actions}>
           {action === 'retry' && status && (
-            <button type="button" onClick={() => LSPRetryProvision(status.family)}>
+            <button
+              type="button"
+              onClick={() => LSPRetryProvision(status.family, status.projectRoot ?? workspacePath)}
+            >
               Retry
             </button>
           )}

--- a/frontend/src/components/Editor/LSPSetupCard.tsx
+++ b/frontend/src/components/Editor/LSPSetupCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { LSPServerStatus } from '../../stores/lspStore';
+import { useIDEStore } from '../../stores/ideStore';
 import { describeSetup } from './lspSetupNotice';
 import {
   LSPRetryProvision,
@@ -8,6 +9,11 @@ import {
   LSPDoctor,
 } from '../../../wailsjs/go/main/App';
 import styles from './LSPSetupCard.module.css';
+
+function showActionError(action: string, error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  useIDEStore.getState().showToast(`Failed to ${action}: ${message}`, 'error');
+}
 
 export function LSPSetupCard({
   status,
@@ -50,7 +56,11 @@ export function LSPSetupCard({
           {action === 'retry' && status && (
             <button
               type="button"
-              onClick={() => LSPRetryProvision(status.family, status.projectRoot ?? workspacePath)}
+              onClick={() =>
+                LSPRetryProvision(status.family, status.projectRoot ?? workspacePath).catch(
+                  (error) => showActionError('retry LSP provisioning', error)
+                )
+              }
             >
               Retry
             </button>
@@ -74,7 +84,14 @@ export function LSPSetupCard({
             </select>
           )}
           {status?.configSource === 'override' && (
-            <button type="button" onClick={() => LSPClearInterpreter(workspacePath)}>
+            <button
+              type="button"
+              onClick={() =>
+                LSPClearInterpreter(workspacePath).catch((error) =>
+                  showActionError('reset the Python interpreter', error)
+                )
+              }
+            >
               Reset to auto
             </button>
           )}

--- a/frontend/src/components/Editor/lspSetupNotice.ts
+++ b/frontend/src/components/Editor/lspSetupNotice.ts
@@ -9,11 +9,22 @@ export interface LSPSetupNotice {
 /**
  * Maps a server's typed setup status onto a user-facing message + next-step
  * hint. Returns null when there is nothing actionable to show (server ready,
- * or no setup state reported). The interactive affordances (interpreter
- * picker, retry) live in LSPSetupCard.
+ * or no setup state reported) — except ready on a manual override, which keeps
+ * a lightweight notice so Reset-to-auto stays reachable. The interactive
+ * affordances (interpreter picker, retry, reset) live in LSPSetupCard.
  */
 export function describeSetup(status: LSPServerStatus | undefined): LSPSetupNotice | null {
-  if (!status?.setupState || status.setupState === 'ready') return null;
+  if (!status?.setupState) return null;
+  if (status.setupState === 'ready') {
+    if (status.configSource === 'override') {
+      return {
+        message: `Using a manually selected interpreter${status.interpreterPath ? ` (${status.interpreterPath})` : ''}.`,
+        hint: 'Reset to auto to re-detect the project environment.',
+        tone: 'info',
+      };
+    }
+    return null;
+  }
 
   switch (status.setupState) {
     case 'missing_server':

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -88,7 +88,7 @@ export function LSPHover(arg1:string,arg2:number,arg3:number):Promise<lsp.Hover>
 
 export function LSPResolveCompletionItem(arg1:string,arg2:lsp.CompletionItem):Promise<lsp.CompletionItem>;
 
-export function LSPRetryProvision(arg1:string):Promise<void>;
+export function LSPRetryProvision(arg1:string,arg2:string):Promise<void>;
 
 export function LSPSetInterpreter(arg1:string,arg2:string):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -162,8 +162,8 @@ export function LSPResolveCompletionItem(arg1, arg2) {
   return window['go']['main']['App']['LSPResolveCompletionItem'](arg1, arg2);
 }
 
-export function LSPRetryProvision(arg1) {
-  return window['go']['main']['App']['LSPRetryProvision'](arg1);
+export function LSPRetryProvision(arg1, arg2) {
+  return window['go']['main']['App']['LSPRetryProvision'](arg1, arg2);
 }
 
 export function LSPSetInterpreter(arg1, arg2) {

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -614,13 +614,18 @@ func (m *Manager) beginProvision(family, projectRoot string) {
 	}()
 }
 
-// RetryProvision re-attempts a managed install (frontend Retry action). It uses
-// the manager's current workspace root as the project root.
-func (m *Manager) RetryProvision(family string) error {
+// RetryProvision re-attempts a managed install (frontend Retry action) keyed
+// to the same project root the failed auto-provision used, so a nested
+// monorepo sub-project retries the right scope. An empty projectRoot falls
+// back to the workspace root (older callers and root-level workspaces).
+func (m *Manager) RetryProvision(family, projectRoot string) error {
 	if _, ok := m.provisioners[family]; !ok {
 		return fmt.Errorf("no managed provisioner for %q", family)
 	}
-	m.beginProvision(family, m.WorkspaceRoot())
+	if projectRoot == "" {
+		projectRoot = m.WorkspaceRoot()
+	}
+	m.beginProvision(family, projectRoot)
 	return nil
 }
 

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -1294,9 +1294,12 @@ func (m *Manager) enrichPythonSetup(status *ServerStatus) {
 		status.InterpreterPath = env.InterpreterPath
 		status.ExtraPaths = env.ExtraPaths
 		status.PythonVersion = env.PythonVersion
-		if env.InterpreterPath == "" {
+		switch {
+		case env.InterpreterPath == "":
 			status.ConfigSource = "none"
-		} else {
+		case env.Source == "override":
+			status.ConfigSource = "override"
+		default:
 			status.ConfigSource = "detected"
 		}
 		switch {

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -1956,6 +1956,35 @@ func TestGetStatus_PythonReadyEnriched(t *testing.T) {
 	}
 }
 
+func TestEmitStatus_PythonOverrideEmitsOverrideConfigSource(t *testing.T) {
+	var got ServerStatus
+	m := NewManager(func(event string, data ...any) {
+		if event == "lsp:status" && len(data) > 0 {
+			got, _ = data[0].(ServerStatus)
+		}
+	})
+	m.configProvider = &envConfigProvider{
+		detectPython: func(string, pythonenv.Deps) pythonenv.Env {
+			t.Fatal("detect must not run when an override is active")
+			return pythonenv.Env{}
+		},
+		pythonDeps:  pythonenv.Deps{},
+		overrideFor: func(string) string { return "/manual/bin/python" },
+	}
+
+	m.emitStatus("python", "/proj", "ready", "", "pyright-langserver")
+
+	if got.SetupState != "ready" {
+		t.Fatalf("SetupState = %q, want ready", got.SetupState)
+	}
+	if got.ConfigSource != "override" {
+		t.Errorf("ConfigSource = %q, want override", got.ConfigSource)
+	}
+	if got.InterpreterPath != "/manual/bin/python" {
+		t.Errorf("InterpreterPath = %q, want /manual/bin/python", got.InterpreterPath)
+	}
+}
+
 // --- Managed provisioning orchestration (#112) ---
 
 // scriptedProv is a test Provisioner whose Resolve flips to StateAvailable only

--- a/internal/lsp/manager_test.go
+++ b/internal/lsp/manager_test.go
@@ -2193,6 +2193,49 @@ func TestManager_provisionChecksumFailed(t *testing.T) {
 	}
 }
 
+func TestRetryProvision_usesProvidedProjectRoot(t *testing.T) {
+	prov := &scriptedProv{
+		family:     "python",
+		installRes: provision.Resolution{State: provision.StateOffline, Err: errors.New("network down")},
+	}
+	mgr, collector, workspace := newProvisionManager(t, prov)
+	nested := filepath.Join(workspace, "services", "api")
+
+	if err := mgr.RetryProvision("python", nested); err != nil {
+		t.Fatalf("RetryProvision: %v", err)
+	}
+
+	waitFor(t, 2*time.Second, "offline status for nested root", func() bool {
+		s, ok := latestPythonStatus(collector)
+		return ok && s.SetupState == "offline"
+	})
+	s, _ := latestPythonStatus(collector)
+	if s.ProjectRoot != nested {
+		t.Errorf("ProjectRoot = %q, want nested root %q", s.ProjectRoot, nested)
+	}
+}
+
+func TestRetryProvision_emptyRootFallsBackToWorkspaceRoot(t *testing.T) {
+	prov := &scriptedProv{
+		family:     "python",
+		installRes: provision.Resolution{State: provision.StateOffline, Err: errors.New("network down")},
+	}
+	mgr, collector, workspace := newProvisionManager(t, prov)
+
+	if err := mgr.RetryProvision("python", ""); err != nil {
+		t.Fatalf("RetryProvision: %v", err)
+	}
+
+	waitFor(t, 2*time.Second, "offline status for workspace root", func() bool {
+		s, ok := latestPythonStatus(collector)
+		return ok && s.SetupState == "offline"
+	})
+	s, _ := latestPythonStatus(collector)
+	if s.ProjectRoot != workspace {
+		t.Errorf("ProjectRoot = %q, want workspace root %q", s.ProjectRoot, workspace)
+	}
+}
+
 func TestSetInterpreterOverride_rejectsMissingPath(t *testing.T) {
 	m := NewManager(nil)
 	err := m.SetInterpreterOverride(t.TempDir(), filepath.Join(t.TempDir(), "nope", "python"))

--- a/internal/lsp/provision/catalog.go
+++ b/internal/lsp/provision/catalog.go
@@ -1,5 +1,7 @@
 package provision
 
+import "path/filepath"
+
 // ArtifactType describes how a family's server is packaged.
 type ArtifactType string
 
@@ -23,6 +25,7 @@ type Artifact struct {
 	SHA256  string // hex digest; mismatch is a hard stop
 	GOOS    string // "" = any platform (universal wheel/tarball)
 	GOARCH  string
+	Libc    string // linux only: "gnu" (manylinux) | "musl" (musllinux); "" = any libc
 }
 
 // CatalogEntry pins one family's managed install.
@@ -31,6 +34,22 @@ type CatalogEntry struct {
 	Version      string
 	ArtifactType ArtifactType
 	Artifacts    []Artifact
+}
+
+// hostLinuxLibc reports the libc flavor of the host ("gnu" or "musl") for
+// libc-tagged linux artifacts. Package var so tests can pin either flavor.
+var hostLinuxLibc = detectLinuxLibc
+
+// detectLinuxLibc detects musl by the presence of its dynamic loader
+// (/lib/ld-musl-<arch>.so.1, the stable, documented location on Alpine and
+// other musl distros); everything else is treated as glibc. On non-linux
+// hosts artifacts carry no Libc tag for the running GOOS, so the "gnu"
+// default is never consulted.
+func detectLinuxLibc() string {
+	if matches, err := filepath.Glob("/lib/ld-musl-*.so*"); err == nil && len(matches) > 0 {
+		return "musl"
+	}
+	return "gnu"
 }
 
 var catalog = map[string]CatalogEntry{
@@ -49,7 +68,7 @@ func PlatformArtifacts(family, goos, goarch string) (CatalogEntry, []Artifact, b
 	}
 	var out []Artifact
 	for _, a := range entry.Artifacts {
-		if (a.GOOS == "" && a.GOARCH == "") || (a.GOOS == goos && a.GOARCH == goarch) {
+		if (a.GOOS == "" && a.GOARCH == "") || (a.GOOS == goos && a.GOARCH == goarch && (a.Libc == "" || a.Libc == hostLinuxLibc())) {
 			out = append(out, a)
 		}
 	}

--- a/internal/lsp/provision/catalog_node.go
+++ b/internal/lsp/provision/catalog_node.go
@@ -4,9 +4,8 @@ package provision
 // OS/arch. Both the Python (basedpyright) and TypeScript
 // (typescript-language-server) managed installs run on this bundled Node, so
 // the pinned wheels live here and are shared by both catalog entries. Linux
-// uses the glibc (manylinux) wheels; musl/Alpine falls through to a family fast
-// path or a guidance card.
-// ponytail: glibc-only linux node wheels; add musllinux entries if Alpine demand appears.
+// carries both glibc (manylinux) and musl (musllinux) wheels; PlatformArtifacts
+// picks the one matching the host libc.
 var nodeWheelArtifacts = []Artifact{
 	{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "darwin", GOARCH: "arm64",
 		URL:    "https://files.pythonhosted.org/packages/24/6d/333e5458422f12318e3c3e6e7f194353aa68b0d633217c7e89833427ca01/nodejs_wheel_binaries-22.20.0-py2.py3-none-macosx_11_0_arm64.whl",
@@ -14,12 +13,18 @@ var nodeWheelArtifacts = []Artifact{
 	{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "darwin", GOARCH: "amd64",
 		URL:    "https://files.pythonhosted.org/packages/56/30/dcd6879d286a35b3c4c8f9e5e0e1bcf4f9e25fe35310fc77ecf97f915a23/nodejs_wheel_binaries-22.20.0-py2.py3-none-macosx_11_0_x86_64.whl",
 		SHA256: "5d8c12f97eea7028b34a84446eb5ca81829d0c428dfb4e647e09ac617f4e21fa"},
-	{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "linux", GOARCH: "arm64",
+	{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "linux", GOARCH: "arm64", Libc: "gnu",
 		URL:    "https://files.pythonhosted.org/packages/58/be/c7b2e7aa3bb281d380a1c531f84d0ccfe225832dfc3bed1ca171753b9630/nodejs_wheel_binaries-22.20.0-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
 		SHA256: "7a2b0989194148f66e9295d8f11bc463bde02cbe276517f4d20a310fb84780ae"},
-	{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "linux", GOARCH: "amd64",
+	{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "linux", GOARCH: "amd64", Libc: "gnu",
 		URL:    "https://files.pythonhosted.org/packages/3e/c5/8befacf4190e03babbae54cb0809fb1a76e1600ec3967ab8ee9f8fc85b65/nodejs_wheel_binaries-22.20.0-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
 		SHA256: "b5c500aa4dc046333ecb0a80f183e069e5c30ce637f1c1a37166b2c0b642dc21"},
+	{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "linux", GOARCH: "arm64", Libc: "musl",
+		URL:    "https://files.pythonhosted.org/packages/c0/bd/cfffd1e334277afa0714962c6ec432b5fe339340a6bca2e5fa8e678e7590/nodejs_wheel_binaries-22.20.0-py2.py3-none-musllinux_1_2_aarch64.whl",
+		SHA256: "3279eb1b99521f0d20a850bbfc0159a658e0e85b843b3cf31b090d7da9f10dfc"},
+	{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "linux", GOARCH: "amd64", Libc: "musl",
+		URL:    "https://files.pythonhosted.org/packages/08/14/10b83a9c02faac985b3e9f5e65d63a34fc0f46b48d8a2c3e4caa3e1e7318/nodejs_wheel_binaries-22.20.0-py2.py3-none-musllinux_1_2_x86_64.whl",
+		SHA256: "d29705797b33bade62d79d8f106c2453c8a26442a9b2a5576610c0f7e7c351ed"},
 	{Kind: "node-wheel", Package: "nodejs-wheel-binaries", Version: "22.20.0", GOOS: "windows", GOARCH: "amd64",
 		URL:    "https://files.pythonhosted.org/packages/b4/a9/c6a480259aa0d6b270aac2c6ba73a97444b9267adde983a5b7e34f17e45a/nodejs_wheel_binaries-22.20.0-py2.py3-none-win_amd64.whl",
 		SHA256: "4bd658962f24958503541963e5a6f2cc512a8cb301e48a69dc03c879f40a28ae"},

--- a/internal/lsp/provision/catalog_python.go
+++ b/internal/lsp/provision/catalog_python.go
@@ -1,8 +1,8 @@
 package provision
 
 // pythonCatalogEntry pins basedpyright (universal py3-none-any wheel) plus the
-// shared nodejs-wheel-binaries runtime (see nodeWheelArtifacts). musl/Alpine
-// falls through to the uv fast-path or a guidance card.
+// shared nodejs-wheel-binaries runtime (see nodeWheelArtifacts), with
+// glibc and musl linux wheels selected by host libc.
 var pythonCatalogEntry = CatalogEntry{
 	Family:       "python",
 	Version:      "1.39.9",

--- a/internal/lsp/provision/catalog_test.go
+++ b/internal/lsp/provision/catalog_test.go
@@ -1,6 +1,9 @@
 package provision
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestPlatformArtifacts_Python_supported(t *testing.T) {
 	entry, arts, ok := PlatformArtifacts("python", "darwin", "arm64")
@@ -24,6 +27,46 @@ func TestPlatformArtifacts_Python_supported(t *testing.T) {
 	}
 	if server != 1 || node != 1 {
 		t.Errorf("got server=%d node=%d, want 1/1", server, node)
+	}
+}
+
+func TestPlatformArtifacts_LinuxNodeWheelMatchesHostLibc(t *testing.T) {
+	orig := hostLinuxLibc
+	t.Cleanup(func() { hostLinuxLibc = orig })
+
+	for _, tc := range []struct{ libc, wantTag string }{
+		{"gnu", "manylinux"},
+		{"musl", "musllinux"},
+	} {
+		hostLinuxLibc = func() string { return tc.libc }
+		for _, arch := range []string{"amd64", "arm64"} {
+			_, arts, ok := PlatformArtifacts("python", "linux", arch)
+			if !ok {
+				t.Fatalf("python/linux/%s libc=%s expected supported", arch, tc.libc)
+			}
+			var nodes []Artifact
+			for _, a := range arts {
+				if a.Kind == "node-wheel" {
+					nodes = append(nodes, a)
+				}
+			}
+			if len(nodes) != 1 {
+				t.Fatalf("python/linux/%s libc=%s: got %d node wheels, want exactly 1", arch, tc.libc, len(nodes))
+			}
+			if !strings.Contains(nodes[0].URL, tc.wantTag) {
+				t.Errorf("python/linux/%s libc=%s: node wheel URL %q missing %q", arch, tc.libc, nodes[0].URL, tc.wantTag)
+			}
+			if nodes[0].SHA256 == "" || nodes[0].Version == "" {
+				t.Errorf("python/linux/%s libc=%s: node wheel missing pinned field: %+v", arch, tc.libc, nodes[0])
+			}
+		}
+	}
+}
+
+func TestDetectLinuxLibc_returnsGnuOrMusl(t *testing.T) {
+	got := detectLinuxLibc()
+	if got != "gnu" && got != "musl" {
+		t.Errorf("detectLinuxLibc() = %q, want gnu or musl", got)
 	}
 }
 


### PR DESCRIPTION
Closes #152. Three small follow-ups from the #150 review.

## 1. Reset-to-auto is now reachable

A manual per-workspace interpreter override resolves with Source "override" in the config provider, but enrichPythonSetup only ever emitted ConfigSource none/detected, and ready-state hid the setup card entirely - so the Reset button (gated on configSource === "override") never rendered.

- enrichPythonSetup emits ConfigSource "override" when the resolved env came from an override.
- describeSetup renders a lightweight info notice for ready-with-override ("Using a manually selected interpreter (path)"), keeping the existing Reset button reachable. Reset calls LSPClearInterpreter, which clears workspace.State.LSP.InterpreterOverride, persists, and restarts the server to re-detect.

## 2. RetryProvision keyed to the project root

Manager.RetryProvision used m.WorkspaceRoot(); the auto-provision path uses the file's resolved project root, so a retry in a nested monorepo sub-project could restart the server at the wrong scope. RetryProvision(family, projectRoot) now threads the root from the failing status through the LSPRetryProvision binding (wailsjs regenerated); empty root falls back to the workspace root. LSPSetupCard passes status.projectRoot with a workspacePath fallback.

## 3. musllinux node wheels

The shared nodejs-wheel-binaries catalog pinned glibc/manylinux wheels only, so Alpine/musl hosts fell through to a guidance card unless uv was present. Artifact gains a Libc tag ("gnu"/"musl"/"" = any), PlatformArtifacts filters linux wheels by host libc (musl detected via the /lib/ld-musl-* dynamic loader), and musllinux_1_2 wheels for linux amd64/arm64 are pinned alongside the manylinux ones. Both URLs and sha256 digests verified against actual PyPI downloads.

## Testing

TDD throughout (red-green per fix). Gates: go test ./... 645 passed, go vet clean, golangci-lint clean, jest 1342 passed, npm run build clean, wails bindings regenerated for the LSPRetryProvision signature change.

Generated with [Claude Code](https://claude.com/claude-code)