### PR TITLE
fix(terminal): unwedge xterm after command output completes

### DIFF
--- a/frontend/src/components/Terminal/Terminal.tsx
+++ b/frontend/src/components/Terminal/Terminal.tsx
@@ -24,6 +24,7 @@ import { Terminal as XTerm } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
 import { createShellIntegration } from './shellIntegration';
+import { XTERM_OPTIONS } from './xtermConfig';
 import {
   CreateTerminal,
   WriteTerminal,
@@ -41,32 +42,6 @@ const TERMINAL_TABS: Array<{
   { id: 'problems', icon: AlertCircleIcon, label: 'Problems' },
   { id: 'terminal', icon: TerminalIcon, label: 'Terminal' },
 ];
-
-const TERMINAL_ACCENT = '#38BDF8'; // Glacier blue — brand anchor
-
-const XTERM_THEME = {
-  background: '#040406', // Near-black void (glacier glow)
-  foreground: '#E2E8F0', // slate-200
-  cursor: TERMINAL_ACCENT,
-  cursorAccent: '#040406',
-  selectionBackground: `${TERMINAL_ACCENT}33`,
-  black: '#030712', // gray-950
-  red: '#FCA5A5', // red-300
-  green: '#86EFAC', // green-300
-  yellow: '#FDE68A', // amber-200
-  blue: '#7DD3FC', // sky-300
-  magenta: '#D8B4FE', // purple-300
-  cyan: '#67E8F9', // cyan-300
-  white: '#E2E8F0', // slate-200
-  brightBlack: '#64748B', // slate-500
-  brightRed: '#FDA4AF', // rose-300
-  brightGreen: '#A7F3D0', // emerald-200
-  brightYellow: '#FEF3C7', // amber-100
-  brightBlue: '#BAE6FD', // sky-200
-  brightMagenta: '#E9D5FF', // purple-200
-  brightCyan: '#A5F3FC', // cyan-200
-  brightWhite: '#F8FAFC', // slate-50
-};
 
 // Gutter marker / separator colors for shell-integration decorations.
 const SHELL_INTEGRATION_COLORS = {
@@ -566,14 +541,7 @@ function TerminalContent({ sessionId, isVisible }: TerminalContentProps) {
   useEffect(() => {
     if (!containerDiv.current) return;
 
-    const term = new XTerm({
-      theme: XTERM_THEME,
-      fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
-      fontSize: 13.5,
-      fontWeight: 500,
-      lineHeight: 1.3,
-      letterSpacing: 0,
-    });
+    const term = new XTerm(XTERM_OPTIONS);
 
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);

--- a/frontend/src/components/Terminal/shellIntegration.test.ts
+++ b/frontend/src/components/Terminal/shellIntegration.test.ts
@@ -181,16 +181,42 @@ describe('createShellIntegration', () => {
     f.term.registerDecoration = () => {
       throw new Error('You must set the allowProposedApi option to true to use proposed API');
     };
-    createShellIntegration(f.term, COLORS);
-    f.fire('A');
-    f.fire('C');
-    expect(() => f.fire('D;0')).not.toThrow();
-    // The parser must keep working for subsequent commands.
-    expect(() => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      createShellIntegration(f.term, COLORS);
       f.fire('A');
       f.fire('C');
-      f.fire('D;1');
-    }).not.toThrow();
+      // Still reports the sequence as handled, so xterm never prints it raw.
+      expect(f.fire('D;0')).toBe(true);
+      // The parser must keep working for subsequent commands.
+      expect(() => {
+        f.fire('A');
+        f.fire('C');
+        f.fire('D;1');
+      }).not.toThrow();
+      // Warns once, not per command.
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('contains a marker-registration failure too (whole handler is guarded)', () => {
+    const f = makeFakeTerm();
+    f.term.registerMarker = () => {
+      throw new Error('marker registration failed');
+    };
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      createShellIntegration(f.term, COLORS);
+      expect(f.fire('A')).toBe(true);
+      expect(() => {
+        f.fire('C');
+        f.fire('D;0');
+      }).not.toThrow();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('dispose() tears down handler, markers and decorations', () => {

--- a/frontend/src/components/Terminal/shellIntegration.test.ts
+++ b/frontend/src/components/Terminal/shellIntegration.test.ts
@@ -171,6 +171,28 @@ describe('createShellIntegration', () => {
     expect(() => integ?.dispose()).not.toThrow();
   });
 
+  it('never propagates a decoration failure into the OSC parser (wedge regression)', () => {
+    // Real-world failure: registerDecoration is proposed API in @xterm/xterm 6
+    // and throws without allowProposedApi. An exception escaping the OSC 133
+    // handler kills xterm's write loop permanently — the terminal stops
+    // rendering all further output (and looks completely wedged). The handler
+    // must contain any decoration error.
+    const f = makeFakeTerm();
+    f.term.registerDecoration = () => {
+      throw new Error('You must set the allowProposedApi option to true to use proposed API');
+    };
+    createShellIntegration(f.term, COLORS);
+    f.fire('A');
+    f.fire('C');
+    expect(() => f.fire('D;0')).not.toThrow();
+    // The parser must keep working for subsequent commands.
+    expect(() => {
+      f.fire('A');
+      f.fire('C');
+      f.fire('D;1');
+    }).not.toThrow();
+  });
+
   it('dispose() tears down handler, markers and decorations', () => {
     const f = makeFakeTerm();
     const integ = createShellIntegration(f.term, COLORS);

--- a/frontend/src/components/Terminal/shellIntegration.ts
+++ b/frontend/src/components/Terminal/shellIntegration.ts
@@ -63,7 +63,24 @@ export function createShellIntegration(
     return { dispose() {} };
   }
 
+  let warned = false;
+
   const handler = parser.registerOscHandler(133, (data: string): boolean => {
+    // An exception escaping an OSC handler kills xterm's write loop: the
+    // terminal permanently stops rendering output (it looks wedged, while the
+    // shell stays alive). Decorations are cosmetic — contain any failure here.
+    try {
+      handle(data);
+    } catch (err) {
+      if (!warned) {
+        warned = true;
+        console.warn('Shell integration marker failed; continuing without decorations.', err);
+      }
+    }
+    return true; // handled — xterm will not print the sequence
+  });
+
+  function handle(data: string): void {
     const parts = data.split(';');
     switch (parts[0]) {
       case 'A': {
@@ -96,8 +113,7 @@ export function createShellIntegration(
         }
         break;
     }
-    return true; // handled — xterm will not print the sequence
-  });
+  }
 
   function discard(block: PromptBlock): void {
     for (const d of block.decorations) d.dispose();

--- a/frontend/src/components/Terminal/shellIntegration.ts
+++ b/frontend/src/components/Terminal/shellIntegration.ts
@@ -107,9 +107,12 @@ export function createShellIntegration(
         if (current && current.executed && !current.decorated) {
           const exit = Number.parseInt(parts[1] ?? '0', 10);
           const failed = !Number.isNaN(exit) && exit !== 0;
-          decorate(current, failed, decoratedCount > 0);
+          // Mark before decorating: if decorate() throws mid-way, a duplicate
+          // 'D' must not stack a second set of decorations on the same block.
           current.decorated = true;
+          const withSeparator = decoratedCount > 0;
           decoratedCount += 1;
+          decorate(current, failed, withSeparator);
         }
         break;
     }

--- a/frontend/src/components/Terminal/xtermConfig.test.ts
+++ b/frontend/src/components/Terminal/xtermConfig.test.ts
@@ -1,0 +1,12 @@
+import { XTERM_OPTIONS } from './xtermConfig';
+
+describe('XTERM_OPTIONS', () => {
+  it('enables proposed API so shell-integration decorations cannot wedge the terminal', () => {
+    // registerDecoration is proposed API in @xterm/xterm 6: without this flag
+    // it throws inside the OSC 133 handler, which permanently stalls xterm's
+    // write loop after the first command completes. The real parser cannot be
+    // exercised under jsdom (term.parser is undefined even after open()), so
+    // this pins the flag directly.
+    expect(XTERM_OPTIONS.allowProposedApi).toBe(true);
+  });
+});

--- a/frontend/src/components/Terminal/xtermConfig.ts
+++ b/frontend/src/components/Terminal/xtermConfig.ts
@@ -1,0 +1,41 @@
+import type { ITerminalOptions } from '@xterm/xterm';
+
+const TERMINAL_ACCENT = '#38BDF8'; // Glacier blue — brand anchor
+
+const XTERM_THEME = {
+  background: '#040406', // Near-black void (glacier glow)
+  foreground: '#E2E8F0', // slate-200
+  cursor: TERMINAL_ACCENT,
+  cursorAccent: '#040406',
+  selectionBackground: `${TERMINAL_ACCENT}33`,
+  black: '#030712', // gray-950
+  red: '#FCA5A5', // red-300
+  green: '#86EFAC', // green-300
+  yellow: '#FDE68A', // amber-200
+  blue: '#7DD3FC', // sky-300
+  magenta: '#D8B4FE', // purple-300
+  cyan: '#67E8F9', // cyan-300
+  white: '#E2E8F0', // slate-200
+  brightBlack: '#64748B', // slate-500
+  brightRed: '#FDA4AF', // rose-300
+  brightGreen: '#A7F3D0', // emerald-200
+  brightYellow: '#FEF3C7', // amber-100
+  brightBlue: '#BAE6FD', // sky-200
+  brightMagenta: '#E9D5FF', // purple-200
+  brightCyan: '#A5F3FC', // cyan-200
+  brightWhite: '#F8FAFC', // slate-50
+};
+
+export const XTERM_OPTIONS: ITerminalOptions = {
+  // registerDecoration (shell-integration gutter markers) is proposed API in
+  // @xterm/xterm 6. Without this flag the OSC 133 'D' handler throws inside
+  // xterm's parser, which permanently stalls its write loop — the terminal
+  // stops rendering all output after the first command completes.
+  allowProposedApi: true,
+  theme: XTERM_THEME,
+  fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+  fontSize: 13.5,
+  fontWeight: 500,
+  lineHeight: 1.3,
+  letterSpacing: 0,
+};

--- a/frontend/src/components/Terminal/xtermConfig.ts
+++ b/frontend/src/components/Terminal/xtermConfig.ts
@@ -2,7 +2,10 @@ import type { ITerminalOptions } from '@xterm/xterm';
 
 const TERMINAL_ACCENT = '#38BDF8'; // Glacier blue — brand anchor
 
-const XTERM_THEME = {
+// Frozen: one module-level options object is shared by every terminal session,
+// and xterm holds `theme` by reference — a stray mutation would silently
+// restyle all sessions and bypass xterm's theme setter.
+const XTERM_THEME = Object.freeze({
   background: '#040406', // Near-black void (glacier glow)
   foreground: '#E2E8F0', // slate-200
   cursor: TERMINAL_ACCENT,
@@ -24,9 +27,9 @@ const XTERM_THEME = {
   brightMagenta: '#E9D5FF', // purple-200
   brightCyan: '#A5F3FC', // cyan-200
   brightWhite: '#F8FAFC', // slate-50
-};
+});
 
-export const XTERM_OPTIONS: ITerminalOptions = {
+export const XTERM_OPTIONS: ITerminalOptions = Object.freeze({
   // registerDecoration (shell-integration gutter markers) is proposed API in
   // @xterm/xterm 6. Without this flag the OSC 133 'D' handler throws inside
   // xterm's parser, which permanently stalls its write loop — the terminal
@@ -38,4 +41,4 @@ export const XTERM_OPTIONS: ITerminalOptions = {
   fontWeight: 500,
   lineHeight: 1.3,
   letterSpacing: 0,
-};
+});


### PR DESCRIPTION
## Problem

Running any command in an integrated shell wedged the terminal: output printed fully, then no new prompt appeared and no keypress echoed. The app stayed responsive and the shell stayed alive.

## Root cause

Reproduced live and instrumented the running app:

- The shell was healthy, blocked at a zle read() waiting at its (already printed) prompt.
- The backend PTY read loop, EventsEmit, and JS event delivery were all alive: bytes written to the PTY slave arrived at the frontend.
- xterm's WriteBuffer held 17 queued chunks (the prompt, echo, everything after the burst) that were never processed.
- Kicking xterm's _innerWrite manually surfaced the killer: `Error: You must set the allowProposedApi option to true to use proposed API`, thrown by `registerDecoration` from the OSC 133 'D' handler in shellIntegration.ts.

`registerDecoration` is proposed API in @xterm/xterm 6 and the Terminal was constructed without `allowProposedApi`. The zsh/bash integration hooks (#47) emit OSC `133;D` on every command completion, so the first completed command threw inside xterm's parser. An exception escaping `_innerWrite` kills the write loop permanently: later writes only kick the loop when the buffer was empty, so everything after the throw queues forever. The gutter-marker feature has been throwing since it shipped; tests never caught it because they use structural fakes, and jsdom mounts no-op the integration (`term.parser` is undefined even after `open()`).

## Fix

- `xtermConfig.ts`: shared `XTERM_OPTIONS` with `allowProposedApi: true` (plus the existing theme/font options moved from Terminal.tsx). Restores the OSC 133 gutter markers.
- `shellIntegration.ts`: wrap the OSC 133 handler body in try/catch so no decoration failure can ever stall xterm's parser again; warns once and keeps the terminal usable.

## Tests

- New regression test: a `registerDecoration` that throws must not propagate out of the OSC handler, and the handler must keep working for subsequent commands (red before the fix).
- New pin test on `XTERM_OPTIONS.allowProposedApi` (the real parser cannot be exercised under jsdom, documented in the test).
- Full suite: 1346 jest tests pass, eslint and prettier clean; tsc shows only the pre-existing TS5107 deprecation on the clean tree.

## Verification

Live against the dev app with a real PTY: `seq 1 20000` returns a fresh prompt, multiple subsequent commands run, OSC 133 markers register, decoration elements render in the DOM, and xterm's write queue drains to zero.

Generated with [Claude Code](https://claude.com/claude-code)